### PR TITLE
Ip viscosity pep8

### DIFF
--- a/cofs/options.py
+++ b/cofs/options.py
@@ -29,6 +29,10 @@ class ModelOptions(AttrDict):
         """bool: Apply log layer bottom stress"""
         self.use_parabolic_viscosity = False
         """bool: Compute parabolic eddy viscosity"""
+        self.use_tensor_form_viscosity = True
+        """bool: Use tensor form instead of symmetric partial stress form"""
+        self.use_grad_depth_term_viscosity_2d = True
+        """bool: Include grad(H)-term in the depth averated viscosity"""
         self.use_ale_moving_mesh = True
         """bool: 3D mesh tracks free surface"""
         self.use_mode_split = True

--- a/cofs/shallowwater_eq.py
+++ b/cofs/shallowwater_eq.py
@@ -379,9 +379,9 @@ class ShallowWaterEquations(Equation):
                 funcs = self.bnd_functions.get(bnd_marker)
                 ds_bnd = self.ds(int(bnd_marker))
                 if funcs is not None:
-                    h = self.bathymetry
+                    depth = self.bathymetry
                     l = self.boundary_len[bnd_marker]
-                    eta_ext, uv_ext = self.get_bnd_functions(None, uv, funcs, h, l)
+                    eta_ext, uv_ext = self.get_bnd_functions(None, uv, funcs, depth, l)
                     if uv_ext is uv:
                         continue
                     elif self.use_tensor_form_viscosity:

--- a/cofs/shallowwater_eq.py
+++ b/cofs/shallowwater_eq.py
@@ -359,7 +359,7 @@ class ShallowWaterEquations(Equation):
 
         f = inner(grad(self.U_test), stress)*dx
 
-        if self.u_is_DG:
+        if self.u_is_dg:
             # projection to DG0 is only necessary because of a bug that's now fixed on master firedrake:
             h = project(CellSize(self.mesh), FunctionSpace(self.mesh, "DG", 0))
             # from Epshteyn et al. 2007 (http://dx.doi.org/10.1016/j.cam.2006.08.029)
@@ -381,7 +381,7 @@ class ShallowWaterEquations(Equation):
                 if funcs is not None:
                     h = self.bathymetry
                     l = self.boundary_len[bnd_marker]
-                    eta_ext, uv_ext = self.get_bnd_functions(head, uv, funcs, h, l)
+                    eta_ext, uv_ext = self.get_bnd_functions(None, uv, funcs, h, l)
                     if uv_ext is uv:
                         continue
                     elif self.use_tensor_form_viscosity:
@@ -399,7 +399,7 @@ class ShallowWaterEquations(Equation):
                     )
 
         if self.use_grad_depth_term_viscosity_2d:
-            f += -dot(self.u_test, dot(grad(total_h)/total_h, stress))*self.dx
+            f += -dot(self.U_test, dot(grad(total_h)/total_h, stress))*self.dx
 
         return f
 
@@ -453,7 +453,7 @@ class ShallowWaterEquations(Equation):
 
         # viscosity
         if viscosity_h is not None:
-            f += self.horizontalViscosity(uv, viscosity_h, total_h)
+            f += self.horizontal_viscosity(uv, viscosity_h, total_h)
 
         return -f - g
 

--- a/cofs/shallowwater_eq.py
+++ b/cofs/shallowwater_eq.py
@@ -389,11 +389,8 @@ class ShallowWaterEquations(Equation):
                     else:
                         stress_jump = nu*2.*sym(outer(uv-uv_ext, n))
 
-                    # we simplify inner(outer(U_test, n), stress_jump) = inner(U_test,n)*stress_jump_n
-                    stress_jump_n = nu*inner(uv-uv_ext, n)
-
                     f += (
-                        2.0*alpha/h*dot(self.U_test, n)*stress_jump_n*ds_bnd
+                        2.0*alpha/h*inner(outer(self.U_test, n), stress_jump)*ds_bnd
                         - inner(grad(self.U_test), stress_jump)*ds_bnd
                         - inner(outer(self.U_test, n), stress)*ds_bnd
                     )

--- a/cofs/shallowwater_eq.py
+++ b/cofs/shallowwater_eq.py
@@ -33,7 +33,9 @@ class ShallowWaterEquations(Equation):
                  mu_manning=None, lin_drag=None, baroc_head=None,
                  coriolis=None, wind_stress=None, uv_lax_friedrichs=None,
                  uv_source=None, elev_source=None,
-                 nonlin=True):
+                 nonlin=True,
+                 use_tensor_form_viscosity=True,
+                 use_grad_depth_term_viscosity_2d=True):
         self.space = solution.function_space()
         self.mesh = self.space.mesh()
         self.U_space, self.eta_space = self.space.split()
@@ -41,6 +43,8 @@ class ShallowWaterEquations(Equation):
         self.U, self.eta = split(self.solution)
         self.bathymetry = bathymetry
         self.nonlin = nonlin
+        self.use_tensor_form_viscosity = use_tensor_form_viscosity
+        self.use_grad_depth_term_viscosity_2d = use_grad_depth_term_viscosity_2d
         # this dict holds all time dep. args to the equation
         self.kwargs = {'uv_old': split(self.solution)[0],
                        'uv_bottom': uv_bottom,
@@ -342,6 +346,64 @@ class ShallowWaterEquations(Equation):
 
         return -f - g
 
+    def horizontal_viscosity(self, uv, nu, total_h):
+
+        n = FacetNormal(self.mesh)
+
+        if self.use_tensor_form_viscosity:
+            stress = nu*grad(uv)
+            stress_jump = nu*tensor_jump(uv, n)
+        else:
+            stress = nu*2.*sym(grad(uv))
+            stress_jump = nu*2.*sym(tensor_jump(uv, n))
+
+        f = inner(grad(self.U_test), stress)*dx
+
+        if self.u_is_DG:
+            # projection to DG0 is only necessary because of a bug that's now fixed on master firedrake:
+            h = project(CellSize(self.mesh), FunctionSpace(self.mesh, "DG", 0))
+            # from Epshteyn et al. 2007 (http://dx.doi.org/10.1016/j.cam.2006.08.029)
+            # the scheme is stable for alpha > 3*X*p*(p+1)*cot(theta), where X is the
+            # maximum ratio of viscosity within a triangle, p the degree, and theta
+            # with X=2, theta=6: cot(theta)~10, 3*X*cot(theta)~60
+            p = self.U_space.ufl_element().degree()
+            alpha = 60.*p*(p+1)
+            f += (
+                + alpha/avg(h)*inner(tensor_jump(self.U_test, n), stress_jump)*self.dS
+                - inner(avg(grad(self.U_test)), stress_jump)*self.dS
+                - inner(tensor_jump(self.U_test, n), avg(stress))*self.dS
+            )
+
+            # Dirichlet bcs only for DG
+            for bnd_marker in self.boundary_markers:
+                funcs = self.bnd_functions.get(bnd_marker)
+                ds_bnd = self.ds(int(bnd_marker))
+                if funcs is not None:
+                    h = self.bathymetry
+                    l = self.boundary_len[bnd_marker]
+                    eta_ext, uv_ext = self.get_bnd_functions(head, uv, funcs, h, l)
+                    if uv_ext is uv:
+                        continue
+                    elif self.use_tensor_form_viscosity:
+                        stress_jump = nu*outer(uv-uv_ext, n)
+                    else:
+                        stress_jump = nu*2.*sym(outer(uv-uv_ext, n))
+
+                    # we simplify inner(outer(U_test, n), stress_jump) = inner(U_test,n)*stress_jump_n
+                    stress_jump_n = nu*inner(uv-uv_ext, n)
+
+                    f += (
+                        2.0*alpha/h*dot(self.U_test, n)*stress_jump_n*ds_bnd
+                        -inner(grad(self.U_test), stress_jump)*ds_bnd
+                        -inner(outer(self.U_test, n), stress)*ds_bnd
+                    )
+
+        if self.use_grad_depth_term_viscosity_2d:
+            f += -dot(self.u_test, dot(grad(total_h)/total_h, stress))*self.dx
+
+        return f
+
+
     def rhs(self, solution, uv_old=None, uv_bottom=None, bottom_drag=None,
             viscosity_h=None, mu_manning=None, lin_drag=None,
             coriolis=None, wind_stress=None,
@@ -391,16 +453,8 @@ class ShallowWaterEquations(Equation):
             f += bot_friction
 
         # viscosity
-        # A double dot product of the stress tensor and grad(w).
         if viscosity_h is not None:
-            f_visc = viscosity_h * (Dx(uv[0], 0) * Dx(self.U_test[0], 0) +
-                                    Dx(uv[0], 1) * Dx(self.U_test[0], 1) +
-                                    Dx(uv[1], 0) * Dx(self.U_test[1], 0) +
-                                    Dx(uv[1], 1) * Dx(self.U_test[1], 1))
-            f_visc += -viscosity_h/total_h*inner(
-                dot(grad(total_h), grad(uv)),
-                self.U_test)
-            f += f_visc * self.dx
+            f += self.horizontalViscosity(uv, viscosity_h, total_h)
 
         return -f - g
 

--- a/cofs/shallowwater_eq.py
+++ b/cofs/shallowwater_eq.py
@@ -394,15 +394,14 @@ class ShallowWaterEquations(Equation):
 
                     f += (
                         2.0*alpha/h*dot(self.U_test, n)*stress_jump_n*ds_bnd
-                        -inner(grad(self.U_test), stress_jump)*ds_bnd
-                        -inner(outer(self.U_test, n), stress)*ds_bnd
+                        - inner(grad(self.U_test), stress_jump)*ds_bnd
+                        - inner(outer(self.U_test, n), stress)*ds_bnd
                     )
 
         if self.use_grad_depth_term_viscosity_2d:
             f += -dot(self.u_test, dot(grad(total_h)/total_h, stress))*self.dx
 
         return f
-
 
     def rhs(self, solution, uv_old=None, uv_bottom=None, bottom_drag=None,
             viscosity_h=None, mu_manning=None, lin_drag=None,

--- a/cofs/solver2d.py
+++ b/cofs/solver2d.py
@@ -95,7 +95,7 @@ class FlowSolver2d(FrozenClass):
             self.fields.solution_2d,
             self.fields.bathymetry_2d,
             lin_drag=self.options.lin_drag,
-            viscosity_h=self.fields.get('h_viscosity'),
+            viscosity_h=self.options.h_viscosity,
             uv_lax_friedrichs=self.options.uv_lax_friedrichs,
             coriolis=self.options.coriolis,
             wind_stress=self.options.wind_stress,

--- a/cofs/solver2d.py
+++ b/cofs/solver2d.py
@@ -101,7 +101,9 @@ class FlowSolver2d(FrozenClass):
             wind_stress=self.options.wind_stress,
             uv_source=self.options.uv_source_2d,
             elev_source=self.options.elev_source_2d,
-            nonlin=self.options.nonlin)
+            nonlin=self.options.nonlin,
+            use_tensor_form_viscosity=self.options.use_tensor_form_viscosity,
+            use_grad_depth_term_viscosity_2d=self.options.use_grad_depth_term_viscosity_2d)
 
         self.eq_sw.bnd_functions = self.bnd_functions['shallow_water']
 

--- a/cofs/utility.py
+++ b/cofs/utility.py
@@ -988,10 +988,10 @@ class EquationOfState(object):
         rho = pn/pd - rho0
         return rho
 
+
 def tensor_jump(v, n):
-"""Jump term for vector functions based on the tensor product.
+    """Jump term for vector functions based on the tensor product.
 
-This is the discrete equivalent of grad(u) as opposed to the normal vectorial 
-jump which represents div(u)."""
+    This is the discrete equivalent of grad(u) as opposed to the normal vectorial
+    jump which represents div(u)."""
     return outer(v('+'), n('+'))+outer(v('-'), n('-'))
-

--- a/cofs/utility.py
+++ b/cofs/utility.py
@@ -987,3 +987,11 @@ class EquationOfState(object):
               p*p*th*th*th*b[11] + p*p*p*th*b[12])
         rho = pn/pd - rho0
         return rho
+
+def tensor_jump(v, n):
+"""Jump term for vector functions based on the tensor product.
+
+This is the discrete equivalent of grad(u) as opposed to the normal vectorial 
+jump which represents div(u)."""
+    return outer(v('+'), n('+'))+outer(v('-'), n('-'))
+

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -370,7 +370,7 @@ def setup9(lx, ly, depth, f0, g, mimetic=True):
             + 4.0*nu0*pi/lx/lx*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx)
             + 9.0*nu0*(1.0 + x[0]/lx)*(pi/lx)*(pi/lx)*sin(pi*(-2.0*x[0] + 1.0*x[1])/lx)
             + 0.5*nu0*(1.0 + x[0]/lx)*(-3.0*pi/lx)*(pi/lx)*sin(pi*(-3.0*x[0] + 1.0*x[1])/lx)''' +
-            '''-({nu})*(pi*(-4.0*({dHdx}) + 1.0*({dHdy}))/lx*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx) 
+            '''-({nu})*(pi*(-4.0*({dHdx}) + 1.0*({dHdy}))/lx*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx)
             - 1.5*pi*({dHdy})/lx*cos(pi*(-3.0*x[0] + 1.0*x[1])/lx))/({H})'''.format(
                 nu=visc_str, dHdx=grad_h_x, dHdy=grad_h_y, H=bath_str+'+'+elev_str
             ),
@@ -419,7 +419,7 @@ def run(setup, refinement, order, export=True):
     ny = 5*refinement
     mesh2d = RectangleMesh(nx, ny, lx, ly)
     dt = 4.0/refinement
-    if sdict['options'].get('timestepper_type')=='cranknicolson':
+    if sdict['options'].get('timestepper_type') == 'cranknicolson':
         dt *= 10.
 
     # outputs
@@ -466,12 +466,12 @@ def run(setup, refinement, order, export=True):
     solver_obj.options.elev_source_2d = source_elev
     solver_obj.options.coriolis = coriolis_func
     if 'visc_expr' in sdict:
-      viscosity_space = FunctionSpace(solver_obj.mesh2d, "CG", order)
-      viscosity_func = Function(viscosity_space, name='viscosity')
-      viscosity_func.project(sdict['visc_expr'])
-      solver_obj.options.h_viscosity = viscosity_func
-      solver_obj.options.use_tensor_form_viscosity = False
-      solver_obj.options.use_grad_depth_term_viscosity_2d = True
+        viscosity_space = FunctionSpace(solver_obj.mesh2d, "CG", order)
+        viscosity_func = Function(viscosity_space, name='viscosity')
+        viscosity_func.project(sdict['visc_expr'])
+        solver_obj.options.h_viscosity = viscosity_func
+        solver_obj.options.use_tensor_form_viscosity = False
+        solver_obj.options.use_grad_depth_term_viscosity_2d = True
 
     # functions for boundary conditions
     # analytical elevation

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -339,6 +339,56 @@ def setup8dg(lx, ly, depth, f0, g):
     return setup8(lx, ly, depth, f0, g, mimetic=False)
 
 
+def setup9(lx, ly, depth, f0, g, mimetic=True):
+    """
+    No Coriolis, non-trivial bath, viscosity, elev, u and v
+    """
+    out = {}
+    out['bath_expr'] = Expression(
+        '4.0 + h0*sqrt(0.3*x[0]*x[0] + 0.2*x[1]*x[1])/lx',
+        lx=lx, h0=depth, f0=f0, g=g)
+    out['cori_expr'] = Expression(
+        '0',
+        lx=lx, h0=depth, f0=f0, g=g)
+    out['visc_expr'] = Expression(
+        '1.0 + x[0]/lx',
+        lx=lx, h0=depth, f0=f0, g=g)
+    out['elev_expr'] = Expression(
+        'cos(pi*(3.0*x[0] + 1.0*x[1])/lx)',
+        lx=lx, h0=depth, f0=f0, g=g)
+    out['uv_expr'] = Expression(
+        (
+            'sin(pi*(-2.0*x[0] + 1.0*x[1])/lx)',
+            '0.5*sin(pi*(-3.0*x[0] + 1.0*x[1])/lx)',
+        ), lx=lx, h0=depth, f0=f0, g=g)
+    out['res_elev_expr'] = Expression(
+        '(0.3*h0*x[0]/(lx*sqrt(0.3*x[0]*x[0] + 0.2*x[1]*x[1])) - 3.0*pi*sin(pi*(3.0*x[0] + 1.0*x[1])/lx)/lx)*sin(pi*(-2.0*x[0] + 1.0*x[1])/lx) + 0.5*(0.2*h0*x[1]/(lx*sqrt(0.3*x[0]*x[0] + 0.2*x[1]*x[1])) - 1.0*pi*sin(pi*(3.0*x[0] + 1.0*x[1])/lx)/lx)*sin(pi*(-3.0*x[0] + 1.0*x[1])/lx) + 0.5*pi*(cos(pi*(3.0*x[0] + 1.0*x[1])/lx) + 4.0 + h0*sqrt(0.3*x[0]*x[0] + 0.2*x[1]*x[1])/lx)*cos(pi*(-3.0*x[0] + 1.0*x[1])/lx)/lx - 2.0*pi*(cos(pi*(3.0*x[0] + 1.0*x[1])/lx) + 4.0 + h0*sqrt(0.3*x[0]*x[0] + 0.2*x[1]*x[1])/lx)*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx)/lx',
+        lx=lx, h0=depth, f0=f0, g=g)
+    out['res_uv_expr'] = Expression(
+        (
+            '''-3.0*pi*g*sin(pi*(3.0*x[0] + 1.0*x[1])/lx)/lx
+            + 0.5*pi*sin(pi*(-3.0*x[0] + 1.0*x[1])/lx)*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx)/lx
+            - 2.0*pi*sin(pi*(-2.0*x[0] + 1.0*x[1])/lx)*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx)/lx
+            - 4.0*pi/lx/lx*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx)
+            + 7.0*(1.0 + x[0]/lx)*(pi/lx)*(pi/lx)*sin(pi*(-2.0*x[0] + 1.0*x[1])/lx)
+            + 0.5*(1.0 + x[0]/lx)*(-3.0*pi/lx)*(pi/lx)*sin(pi*(-3.0*x[0] + 1.0*x[1])/lx)''',
+            '''-1.0*pi*g*sin(pi*(3.0*x[0] + 1.0*x[1])/lx)/lx
+            + 0.25*pi*sin(pi*(-3.0*x[0] + 1.0*x[1])/lx)*cos(pi*(-3.0*x[0] + 1.0*x[1])/lx)/lx
+            - 1.5*pi*sin(pi*(-2.0*x[0] + 1.0*x[1])/lx)*cos(pi*(-3.0*x[0] + 1.0*x[1])/lx)/lx
+            - 5.5*(1.0 + x[0]/lx)*(pi/lx)*(pi/lx)*sin(pi*(-3.0*x[0] + 1.0*x[1])/lx)
+            + 0.5*(1.0/lx)*(-3.0*pi/lx)*cos(pi*(-3.0*x[0] + 1.0*x[1])/lx)
+            - (1.0 + x[0]/lx)*(pi/lx)*(-2.0*pi/lx)*sin(pi*(-2.0*x[0] + 1.0*x[1])/lx)
+            + (1.0/lx)*(pi/lx)*cos(pi*(-2.0*x[0] + 1.0*x[1])/lx)'''
+        ), lx=lx, h0=depth, f0=f0, g=g)
+    out['options'] = {'mimetic': mimetic}
+    out['bnd_funcs'] = {1: {'elev': None, 'uv': None},
+                        2: {'elev': None, 'uv': None},
+                        3: {'elev': None, 'uv': None},
+                        4: {'elev': None, 'uv': None},
+                        }
+    return out
+
+
 def run(setup, refinement, order, export=True):
     """Run single test and return L2 error"""
     print '--- running {:} refinement {:}'.format(setup.__name__, refinement)
@@ -406,6 +456,13 @@ def run(setup, refinement, order, export=True):
     solver_obj.options.uv_source_2d = source_uv
     solver_obj.options.elev_source_2d = source_elev
     solver_obj.options.coriolis = coriolis_func
+    if 'visc_expr' in sdict:
+      viscosity_space = FunctionSpace(solver_obj.mesh2d, "CG", order)
+      viscosity_func = Function(viscosity_space, name='viscosity')
+      viscosity_func.project(sdict['visc_expr'])
+      solver_obj.options.h_viscosity = viscosity_func
+      solver_obj.options.use_tensor_form_viscosity = False
+      solver_obj.options.use_grad_depth_term_viscosity_2d = True
 
     # functions for boundary conditions
     # analytical elevation
@@ -537,7 +594,7 @@ def run_convergence(setup, ref_list, order, export=False, save_plot=False):
 # ---------------------------
 
 
-@pytest.fixture(params=[setup7, setup8], ids=["Setup7", "Setup8"])
+@pytest.fixture(params=[setup7, setup8, setup9], ids=["Setup7", "Setup8", "Setup9"])
 def choose_setup(request):
     return request.param
 


### PR DESCRIPTION
Implements Interior Penalty viscosity scheme for discontinuous velocity fields. Also adds (optionally) grad-div term, and makes the -grad(H)/H*stress term optional. Defaults are the same as before, i.e. only include div-grad term but do include -grad(H)/H term. The opposite choice for both, is more standard for SWE coastal models with some sort of turbulence scheme.

Test added to swe2d/test_steady_state_basin_mms.py

Any opinions on option names? Not sure tensor_form (for "div-grad only") is all that standard, so maybe use_div_grad_only_viscosity is better - or have a include_grad_div_viscosity_term instead?