### PR TITLE
Extrude upwards

### DIFF
--- a/examples/bottomFriction/steadyChannel.py
+++ b/examples/bottomFriction/steadyChannel.py
@@ -71,7 +71,7 @@ options.dt = dt
 options.t_end = t_end
 options.outputdir = outputdir
 options.u_advection = u_mag
-options.check_salt_deviation = True
+options.check_salt_overshoot = True
 options.timer_labels = ['mode2d', 'momentum_eq', 'vert_diffusion', 'turbulence']
 options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
                             'w_3d', 'w_mesh_3d', 'salt_3d',

--- a/examples/channel3d/channel3d.py
+++ b/examples/channel3d/channel3d.py
@@ -50,7 +50,7 @@ options.t_export = t_export
 options.t_end = t_end
 options.outputdir = outputdir
 options.u_advection = u_mag
-options.check_salt_deviation = True
+options.check_salt_overshoot = True
 options.timer_labels = ['mode2d', 'momentum_eq', 'vert_diffusion']
 options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
                             'w_3d', 'w_mesh_3d', 'salt_3d',

--- a/examples/channel3d/channel3d_closed.py
+++ b/examples/channel3d/channel3d_closed.py
@@ -52,7 +52,7 @@ options.use_bottom_friction = False
 options.use_ale_moving_mesh = False
 options.uv_lax_friedrichs = Constant(1.0)
 options.tracer_lax_friedrichs = Constant(1.0)
-options.use_imex = True
+# options.use_imex = True
 # options.use_semi_implicit_2d = False
 # options.use_mode_split = False
 # options.baroclinic = True
@@ -63,7 +63,7 @@ options.u_advection = u_mag
 options.check_vol_conservation_2d = True
 options.check_vol_conservation_3d = True
 options.check_salt_conservation = True
-options.check_salt_deviation = True
+options.check_salt_overshoot = True
 options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
                             'w_3d', 'w_mesh_3d', 'salt_3d',
                             'uv_dav_2d', 'uv_bottom_2d']

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -78,7 +78,6 @@ options.u_advection = u_mag
 options.check_vol_conservation_2d = True
 options.check_vol_conservation_3d = True
 options.check_salt_conservation = True
-# options.check_salt_deviation = True
 options.check_salt_overshoot = True
 options.outputdir = outputdir
 options.timer_labels = []

--- a/test/barotropicChannel/test_closed_channel.py
+++ b/test/barotropicChannel/test_closed_channel.py
@@ -53,7 +53,7 @@ def test_closed_channel(do_export=False):
     options.no_exports = not do_export
     options.outputdir = outputdir
     options.u_advection = u_mag
-    options.check_salt_deviation = True
+    options.check_salt_overshoot = True
     options.timer_labels = ['mode2d', 'momentum_eq', 'vert_diffusion']
     options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
                                 'w_3d', 'w_mesh_3d', 'salt_3d',

--- a/test/bottomFriction/test_implicit_friction_parabolic.py
+++ b/test/bottomFriction/test_implicit_friction_parabolic.py
@@ -7,8 +7,10 @@ Tuomas Karna 2015-09-16
 from thetis import *
 from thetis.momentum_eq import VerticalMomentumEquation
 import time as time_mod
+import pytest
 
 
+@pytest.mark.skipif(True, reason='this is obsolete')
 def test_implicit_friction_parabolic(do_assert=True, do_export=False):
     physical_constants['z0_friction'] = 1.5e-3
 
@@ -59,7 +61,7 @@ def test_implicit_friction_parabolic(do_assert=True, do_export=False):
     options.no_exports = not do_export
     options.outputdir = outputdir
     options.u_advection = u_mag
-    options.check_salt_deviation = True
+    options.check_salt_overshoot = True
     options.timer_labels = ['mode2d', 'momentum_eq', 'vert_diffusion', 'turbulence']
     options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
                                 'w_3d', 'w_mesh_3d', 'salt_3d',

--- a/test/bottomFriction/test_implicit_friction_turbulence.py
+++ b/test/bottomFriction/test_implicit_friction_turbulence.py
@@ -60,7 +60,7 @@ def test_implicit_friction_turbulence(do_assert=True, do_export=False):
     options.no_exports = not do_export
     options.outputdir = outputdir
     options.u_advection = u_mag
-    options.check_salt_deviation = True
+    options.check_salt_overshoot = True
     options.timer_labels = ['mode2d', 'momentum_eq', 'vert_diffusion', 'turbulence']
     # options.fields_to_export = []
     options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',

--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -11,7 +11,10 @@ def mesh2d():
 
 @pytest.fixture(scope="module")
 def mesh(mesh2d):
-    return ExtrudedMesh(mesh2d, layers=10, layer_height=-0.1)
+    fs = FunctionSpace(mesh2d, 'CG', 1)
+    bathymetry_2d = Function(fs).assign(1.0)
+    n_layers = 10
+    return utility.extrude_mesh_sigma(mesh2d, n_layers, bathymetry_2d)
 
 
 @pytest.fixture(params=["p1xp1", "P2xP2", "p1DGxp1DG", "P2DGxP2DG"])


### PR DESCRIPTION
3d mesh used to be extruded downwards from free surface to bottom which had some nasty side effects. For example, the top/bottom faces in firedrake corresponded to bottom/top faces in thetis. It also affected the sign of the jacobian of 3d elements etc.

This changes the extrusion direction to be from bottom to top, achievable with fairly minor changes to the code.