### PR TITLE
Semi implicit new

### DIFF
--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -478,7 +478,8 @@ class CoupledSSPRKSemiImplicit(CoupledTimeIntegrator):
             solver.eq_sw, self.fields.solution_2d,
             fields, solver.dt,
             bnd_conditions=solver.bnd_functions['shallow_water'],
-            solver_parameters=solver.eq_sw.solver_parameters)
+            solver_parameters=solver.eq_sw.solver_parameters,
+            semi_implicit=options.use_linearized_semi_implicit_2d)
 
         # assign viscosity/diffusivity to correct equations
         if self.options.solve_vert_diffusion:

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -479,7 +479,7 @@ class CoupledSSPRKSemiImplicit(CoupledTimeIntegrator):
             fields, solver.dt,
             bnd_conditions=solver.bnd_functions['shallow_water'],
             solver_parameters=solver.eq_sw.solver_parameters,
-            semi_implicit=options.use_linearized_semi_implicit_2d)
+            semi_implicit=self.options.use_linearized_semi_implicit_2d)
 
         # assign viscosity/diffusivity to correct equations
         if self.options.solve_vert_diffusion:

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -44,6 +44,8 @@ class ModelOptions(AttrDict):
         """bool: Implicit 2D waves (only w. mode split)"""
         self.use_imex = False
         """bool: Use IMEX time integrator (only with mode split)"""
+        self.use_linearized_semi_implicit_2d = False
+        """bool: Use linearized semi-implicit time integration for the horizontal mode"""
         self.use_turbulence = False
         """bool: GLS turbulence model"""
         self.use_smooth_eddy_viscosity = False

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -486,12 +486,12 @@ class ShallowWaterEquations(Equation):
         self.add_term(HorizontalAdvectionTerm(*args), 'explicit')
         self.add_term(HorizontalViscosityTerm(*args), 'explicit')
         self.add_term(CoriolisTerm(*args), 'explicit')
-        self.add_term(WindStressTerm(*args), 'explicit')  # FIXME should be source
+        self.add_term(WindStressTerm(*args), 'source')
         self.add_term(QuadraticDragTerm(*args), 'explicit')
         self.add_term(LinearDragTerm(*args), 'explicit')
-        self.add_term(BottomDrag3DTerm(*args), 'explicit')  # FIXME should be source
-        self.add_term(InternalPressureGradientTerm(*args), 'explicit')  # FIXME should be source
-        self.add_term(SourceTerm(*args), 'explicit')  # FIXME should be source
+        self.add_term(BottomDrag3DTerm(*args), 'source')
+        self.add_term(InternalPressureGradientTerm(*args), 'source')
+        self.add_term(SourceTerm(*args), 'source')
 
     def get_time_step(self, u_mag=Constant(0.0)):
         """
@@ -622,7 +622,7 @@ class FreeSurfaceEquation(Equation):
 
         args = (function_space, bathymetry, nonlin)
         self.add_term(FreeSurfaceDivTerm(*args), 'explicit')
-        self.add_term(FreeSurfaceSourceTerm(*args), 'explicit')  # FIXME should be source
+        self.add_term(FreeSurfaceSourceTerm(*args), 'source')
 
     def get_time_step(self, u_mag=Constant(0.0)):
         """

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -124,7 +124,7 @@ class ExternalPressureGradientTerm(ShallowWaterTerm):
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         uv, eta = self.split_solution(solution)
         uv_old, eta_old = self.split_solution(solution_old)
-        total_h = self.get_total_depth(eta)  # FIXME should be eta_old
+        total_h = self.get_total_depth(eta_old)
 
         head = eta
 
@@ -174,7 +174,7 @@ class HUDivTerm(ShallowWaterTerm):
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         uv, eta = self.split_solution(solution)
         uv_old, eta_old = self.split_solution(solution_old)
-        total_h = self.get_total_depth(eta)  # FIXME should be eta_old
+        total_h = self.get_total_depth(eta_old)
 
         hu_by_parts = self.u_is_dg or self.u_is_hdiv
         if hu_by_parts:
@@ -189,12 +189,13 @@ class HUDivTerm(ShallowWaterTerm):
                 ds_bnd = ds(int(bnd_marker))
                 if funcs is not None:
                     eta_ext, uv_ext = self.get_bnd_functions(eta, uv, bnd_marker, bnd_conditions)
+                    eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
-                    h_av = self.bathymetry + 0.5*(eta + eta_ext)
-                    un_jump = inner(uv - uv_ext, self.normal)
+                    h_av = self.bathymetry + 0.5*(eta_old + eta_ext_old)
                     eta_jump = eta - eta_ext
-                    eta_rie = 0.5*(eta + eta_ext) + sqrt(h_av/g_grav)*un_jump
                     un_rie = 0.5*inner(uv + uv_ext, self.normal) + sqrt(g_grav/h_av)*eta_jump
+                    un_jump = inner(uv_old - uv_ext_old, self.normal)
+                    eta_rie = 0.5*(eta_old + eta_ext_old) + sqrt(h_av/g_grav)*un_jump
                     h_rie = self.bathymetry + eta_rie
                     f += h_rie*un_rie*self.eta_test*ds_bnd
         else:
@@ -223,24 +224,23 @@ class HorizontalAdvectionTerm(ShallowWaterTerm):
 
         if horiz_advection_by_parts:
             # f = -inner(nabla_div(outer(uv, self.U_test)), uv)
-            f = -(Dx(uv[0]*self.U_test[0], 0)*uv[0] +
-                  Dx(uv[0]*self.U_test[1], 0)*uv[1] +
-                  Dx(uv[1]*self.U_test[0], 1)*uv[0] +
-                  Dx(uv[1]*self.U_test[1], 1)*uv[1])*dx
+            f = -(Dx(uv_old[0]*self.U_test[0], 0)*uv[0] +
+                  Dx(uv_old[0]*self.U_test[1], 0)*uv[1] +
+                  Dx(uv_old[1]*self.U_test[0], 1)*uv[0] +
+                  Dx(uv_old[1]*self.U_test[1], 1)*uv[1])*dx
             if self.u_is_dg:
-                uv_av = avg(uv)
-                un_av = dot(uv_av, self.normal('-'))
+                un_av = dot(avg(uv_old), self.normal('-'))
                 # NOTE solver can stagnate
                 # s = 0.5*(sign(un_av) + 1.0)
                 # NOTE smooth sign change between [-0.02, 0.02], slow
                 # s = 0.5*tanh(100.0*un_av) + 0.5
                 # uv_up = uv('-')*s + uv('+')*(1-s)
                 # NOTE mean flux
-                uv_up = uv_av
-                f += (uv_up[0]*jump(self.U_test[0], uv[0]*self.normal[0]) +
-                      uv_up[1]*jump(self.U_test[1], uv[0]*self.normal[0]) +
-                      uv_up[0]*jump(self.U_test[0], uv[1]*self.normal[1]) +
-                      uv_up[1]*jump(self.U_test[1], uv[1]*self.normal[1]))*dS
+                uv_up = avg(uv)
+                f += (uv_up[0]*jump(self.U_test[0], uv_old[0]*self.normal[0]) +
+                      uv_up[1]*jump(self.U_test[1], uv_old[0]*self.normal[0]) +
+                      uv_up[0]*jump(self.U_test[0], uv_old[1]*self.normal[1]) +
+                      uv_up[1]*jump(self.U_test[1], uv_old[1]*self.normal[1]))*dS
                 # Lax-Friedrichs stabilization
                 if uv_lax_friedrichs is not None:
                     gamma = 0.5*abs(un_av)*uv_lax_friedrichs
@@ -250,19 +250,20 @@ class HorizontalAdvectionTerm(ShallowWaterTerm):
                         ds_bnd = ds(int(bnd_marker))
                         if funcs is None:
                             # impose impermeability with mirror velocity
-                            un = dot(uv, self.normal)
-                            uv_ext = uv - 2*un*self.normal
-                            gamma = 0.5*abs(un)*uv_lax_friedrichs
+                            n = self.normal
+                            uv_ext = uv - 2*dot(uv, n)*n
+                            gamma = 0.5*abs(dot(uv_old, n))*uv_lax_friedrichs
                             f += gamma*dot(self.U_test, uv-uv_ext)*ds_bnd
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker))
                 if funcs is not None:
                     eta_ext, uv_ext = self.get_bnd_functions(eta, uv, bnd_marker, bnd_conditions)
+                    eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
+                    eta_jump = eta_old - eta_ext_old
+                    un_rie = 0.5*inner(uv_old + uv_ext_old, self.normal) + sqrt(g_grav/self.bathymetry)*eta_jump
                     uv_av = 0.5*(uv_ext + uv)
-                    eta_jump = eta - eta_ext
-                    un_rie = 0.5*inner(uv + uv_ext, self.normal) + sqrt(g_grav/self.bathymetry)*eta_jump
                     f += (uv_av[0]*self.U_test[0]*un_rie +
                           uv_av[1]*self.U_test[1]*un_rie)*ds_bnd
         return -f
@@ -274,7 +275,9 @@ class HorizontalViscosityTerm(ShallowWaterTerm):
     """
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         uv, eta = self.split_solution(solution)
-        total_h = self.get_total_depth(eta)
+        # the only nonlinearity is in the grad H/H term
+        uv_old, eta_old = self.split_solution(solution_old)
+        total_h = self.get_total_depth(eta_old)
 
         nu = fields_old.get('viscosity_h')
         if nu is None:
@@ -355,7 +358,8 @@ class WindStressTerm(ShallowWaterTerm):
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         wind_stress = fields_old.get('wind_stress')
         uv, eta = self.split_solution(solution)
-        total_h = self.get_total_depth(eta)
+        uv_old, eta_old = self.split_solution(solution_old)
+        total_h = self.get_total_depth(eta_old)
         f = 0
         if wind_stress is not None:
             f += -dot(wind_stress, self.U_test)/total_h/rho_0*dx
@@ -369,7 +373,7 @@ class QuadraticDragTerm(ShallowWaterTerm):
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         uv, eta = self.split_solution(solution)
         uv_old, eta_old = self.split_solution(solution_old)
-        total_h = self.get_total_depth(eta)
+        total_h = self.get_total_depth(eta_old)
         mu_manning = fields_old.get('mu_manning')
         f = 0
         if mu_manning is not None:
@@ -399,7 +403,8 @@ class BottomDrag3DTerm(ShallowWaterTerm):
     """
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         uv, eta = self.split_solution(solution)
-        total_h = self.get_total_depth(eta)
+        uv_old, eta_old = self.split_solution(solution_old)
+        total_h = self.get_total_depth(eta_old)
         bottom_drag = fields_old.get('bottom_drag')
         uv_bottom = fields_old.get('uv_bottom')
         f = 0

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -128,7 +128,7 @@ class FlowSolver2d(FrozenClass):
                                                                        fields, self.dt,
                                                                        bnd_conditions=self.bnd_functions['shallow_water'],
                                                                        solver_parameters=self.eq_sw.solver_parameters,
-                                                                       semi_implicit=options.use_linearized_semi_implicit_2d)
+                                                                       semi_implicit=self.options.use_linearized_semi_implicit_2d)
 
         elif self.options.timestepper_type.lower() == 'forwardeuler':
             self.timestepper = timeintegrator.ForwardEuler(self.eq_sw, self.fields.solution_2d,
@@ -140,7 +140,7 @@ class FlowSolver2d(FrozenClass):
                                                             fields, self.dt,
                                                             bnd_conditions=self.bnd_functions['shallow_water'],
                                                             solver_parameters=self.eq_sw.solver_parameters,
-                                                            semi_implicit=options.use_linearized_semi_implicit_2d)
+                                                            semi_implicit=self.options.use_linearized_semi_implicit_2d)
         elif self.options.timestepper_type.lower() == 'sspimex':
             # TODO meaningful solver params
             sp_impl = {

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -127,7 +127,9 @@ class FlowSolver2d(FrozenClass):
             self.timestepper = timeintegrator.SSPRK33StageSemiImplicit(self.eq_sw, self.fields.solution_2d,
                                                                        fields, self.dt,
                                                                        bnd_conditions=self.bnd_functions['shallow_water'],
-                                                                       solver_parameters=self.eq_sw.solver_parameters)
+                                                                       solver_parameters=self.eq_sw.solver_parameters,
+                                                                       semi_implicit=options.use_linearized_semi_implicit_2d)
+
         elif self.options.timestepper_type.lower() == 'forwardeuler':
             self.timestepper = timeintegrator.ForwardEuler(self.eq_sw, self.fields.solution_2d,
                                                            fields, self.dt,
@@ -137,7 +139,8 @@ class FlowSolver2d(FrozenClass):
             self.timestepper = timeintegrator.CrankNicolson(self.eq_sw, self.fields.solution_2d,
                                                             fields, self.dt,
                                                             bnd_conditions=self.bnd_functions['shallow_water'],
-                                                            solver_parameters=self.eq_sw.solver_parameters)
+                                                            solver_parameters=self.eq_sw.solver_parameters,
+                                                            semi_implicit=options.use_linearized_semi_implicit_2d)
         elif self.options.timestepper_type.lower() == 'sspimex':
             # TODO meaningful solver params
             sp_impl = {

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -280,11 +280,15 @@ class SSPRK33StageSemiImplicit(TimeIntegrator):
 
     CFL coefficient is 1.0
     """
-    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters={}):
+    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, 
+            solver_parameters={}, semi_implicit=False):
         """Creates forms for the time integrator"""
         super(SSPRK33StageSemiImplicit, self).__init__(equation, solver_parameters)
         self.solver_parameters.setdefault('snes_monitor', False)
-        self.solver_parameters.setdefault('snes_type', 'newtonls')
+        if semi_implicit:
+            self.solver_parameters.setdefault('snes_type', 'ksponly')
+        else:
+            self.solver_parameters.setdefault('snes_type', 'newtonls')
 
         self.explicit = True
         self.CFL_coeff = 1.0
@@ -301,11 +305,22 @@ class SSPRK33StageSemiImplicit(TimeIntegrator):
 
         self.dt_const = Constant(dt)
 
+        if semi_implicit:
+            # linearize around previous sub-timestep using the fact that all terms are written in the form A(u_nl) u
+            sol_nl0 = self.solution_old
+            sol_nl1 = self.sol0
+            sol_nl2 = self.sol1
+        else:
+            # solve the full nonlinear residual form
+            solution_nl0 = self.sol0
+            solution_nl1 = self.sol1
+            solution_nl2 = self.sol2
+
         # FIXME old solution should be set correctly, this is consistent with old formulation
         args = (self.fields, self.fields, bnd_conditions)
         self.F_0 = (self.equation.mass_term(self.sol0) - self.equation.mass_term(self.solution_old) -
                     self.dt_const*(
-                        self.theta*self.equation.residual('implicit', self.sol0, self.sol0, *args) +
+                        self.theta*self.equation.residual('implicit', self.sol0, sol_nl0, *args) +
                         (1-self.theta)*self.equation.residual('implicit', self.solution_old, self.solution_old, *args) +
                         self.equation.residual('explicit', self.solution_old, self.solution_old, *args) +
                         self.equation.residual('source', self.solution_old, self.solution_old, *args))
@@ -313,7 +328,7 @@ class SSPRK33StageSemiImplicit(TimeIntegrator):
         self.F_1 = (self.equation.mass_term(self.sol1) -
                     3.0/4.0*self.equation.mass_term(self.solution_old) - 1.0/4.0*self.equation.mass_term(self.sol0) -
                     1.0/4.0*self.dt_const*(
-                        self.theta*self.equation.residual('implicit', self.sol1, self.sol1, *args) +
+                        self.theta*self.equation.residual('implicit', self.sol1, sol_nl1, *args) +
                         (1-self.theta)*self.equation.residual('implicit', self.sol0, self.sol0, *args) +
                         self.equation.residual('explicit', self.sol0, self.sol0, *args) +
                         self.equation.residual('source', self.solution_old, self.solution_old, *args))
@@ -321,7 +336,7 @@ class SSPRK33StageSemiImplicit(TimeIntegrator):
         self.F_2 = (self.equation.mass_term(self.solution) -
                     1.0/3.0*self.equation.mass_term(self.solution_old) - 2.0/3.0*self.equation.mass_term(self.sol1) -
                     2.0/3.0*self.dt_const*(
-                        self.theta*self.equation.residual('implicit', self.solution, self.solution, *args) +
+                        self.theta*self.equation.residual('implicit', self.solution, sol_nl2, *args) +
                         (1-self.theta)*self.equation.residual('implicit', self.sol1, self.sol1, *args) +
                         self.equation.residual('explicit', self.sol1, self.sol1, *args) +
                         self.equation.residual('source', self.solution_old, self.solution_old, *args))

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -280,8 +280,8 @@ class SSPRK33StageSemiImplicit(TimeIntegrator):
 
     CFL coefficient is 1.0
     """
-    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, 
-            solver_parameters={}, semi_implicit=False):
+    def __init__(self, equation, solution, fields, dt, bnd_conditions=None,
+                 solver_parameters={}, semi_implicit=False):
         """Creates forms for the time integrator"""
         super(SSPRK33StageSemiImplicit, self).__init__(equation, solver_parameters)
         self.solver_parameters.setdefault('snes_monitor', False)
@@ -312,9 +312,9 @@ class SSPRK33StageSemiImplicit(TimeIntegrator):
             sol_nl2 = self.sol1
         else:
             # solve the full nonlinear residual form
-            solution_nl0 = self.sol0
-            solution_nl1 = self.sol1
-            solution_nl2 = self.sol2
+            sol_nl0 = self.sol0
+            sol_nl1 = self.sol1
+            sol_nl2 = self.solution
 
         # FIXME old solution should be set correctly, this is consistent with old formulation
         args = (self.fields, self.fields, bnd_conditions)


### PR DESCRIPTION
 Introduce semi-implicit time integration for SWE.

This is semi-implicit in the Casulli sense. By writing all terms in the
form A(u_nl)u we can easily switch between explicit (u_nl=u=u_old),
semi-implict (u_nl=u_old, u=u_new) and fully implicit (u_nl=u=u_new).
Currently only for CrankNicolson timeintegrator in combination with SWE.
