### PR TITLE
Update for communicator changes in Firedrake

### DIFF
--- a/examples/lockExchange/runTestSuite.py
+++ b/examples/lockExchange/runTestSuite.py
@@ -47,7 +47,9 @@ parser.add_argument('-Re', '--reynolds_number', type=float, default=2.0,
                     help='mesh Reynolds number for Smagorinsky scheme')
 args = parser.parse_args()
 args_dict = vars(args)
-if commrank == 0:
+
+comm = COMM_WORLD
+if comm.rank == 0:
     print 'Running test case with setup:'
     for k in sorted(args_dict.keys()):
         print ' - {0:15s} : {1:}'.format(k, args_dict[k])

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -40,6 +40,7 @@ bathymetry_2d.assign(depth)
 x_func = Function(P1_2d).interpolate(Expression('x[0]'))
 x_min = x_func.dat.data.min()
 x_max = x_func.dat.data.max()
+comm = x_func.comm
 x_min = comm.allreduce(x_min, op=MPI.MIN)
 x_max = comm.allreduce(x_max, op=MPI.MAX)
 lx = x_max - x_min

--- a/examples/waveEq2d/channel2d_waveEq.py
+++ b/examples/waveEq2d/channel2d_waveEq.py
@@ -32,6 +32,7 @@ bathymetry_2d.assign(depth)
 x_func = Function(P1_2d).interpolate(Expression('x[0]'))
 x_min = x_func.dat.data.min()
 x_max = x_func.dat.data.max()
+comm = x_func.comm
 x_min = comm.allreduce(x_min, op=MPI.MIN)
 x_max = comm.allreduce(x_max, op=MPI.MAX)
 lx = x_max - x_min

--- a/examples/waveEq3d/channel3d_waveEq.py
+++ b/examples/waveEq3d/channel3d_waveEq.py
@@ -33,6 +33,7 @@ bathymetry_2d.assign(depth)
 x_func = Function(P1_2d).interpolate(Expression('x[0]'))
 x_min = x_func.dat.data.min()
 x_max = x_func.dat.data.max()
+comm = x_func.comm
 x_min = comm.allreduce(x_min, op=MPI.MIN)
 x_max = comm.allreduce(x_max, op=MPI.MAX)
 lx = x_max - x_min

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -19,7 +19,7 @@ class FlowSolver2d(FrozenClass):
     def __init__(self, mesh2d, bathymetry_2d, order=1, options=None):
         self._initialized = False
         self.mesh2d = mesh2d
-
+        self.comm = mesh2d.comm
         # add boundary length info
         bnd_len = compute_boundary_length(self.mesh2d)
         self.mesh2d.boundary_len = bnd_len
@@ -59,9 +59,9 @@ class FlowSolver2d(FrozenClass):
         if self.dt is None:
             mesh2d_dt = self.eq_sw.get_time_step(u_mag=self.options.u_advection)
             dt = self.options.cfl_2d*float(mesh2d_dt.dat.data.min()/20.0)
-            dt = comm.allreduce(dt, op=MPI.MIN)
+            dt = self.comm.allreduce(dt, op=MPI.MIN)
             self.dt = dt
-        if commrank == 0:
+        if self.comm.rank == 0:
             print 'dt =', self.dt
             sys.stdout.flush()
 
@@ -273,7 +273,7 @@ class FlowSolver2d(FrozenClass):
         norm_h = norm(self.fields.solution_2d.split()[1])
         norm_u = norm(self.fields.solution_2d.split()[0])
 
-        if commrank == 0:
+        if self.comm.rank == 0:
             line = ('{iexp:5d} {i:5d} T={t:10.2f} '
                     'eta norm: {e:10.4f} u norm: {u:10.4f} {cpu:5.2f}')
             print(line.format(iexp=self.i_export, i=self.iteration, t=self.simulation_time, e=norm_h,

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -15,9 +15,6 @@ import coffee.base as ast  # NOQA
 from collections import OrderedDict, namedtuple  # NOQA
 from thetis.field_defs import field_metadata
 
-comm = op2.MPI.comm
-commrank = op2.MPI.comm.rank
-
 ds_surf = ds_t
 ds_bottom = ds_b
 # NOTE some functions now depend on FlowSolver object
@@ -116,8 +113,8 @@ class FieldDict(AttrDict):
         super(FieldDict, self).__setattr__(key, value)
 
 
-def print_info(msg):
-    if commrank == 0:
+def print_info(msg, comm=COMM_WORLD):
+    if comm.rank == 0:
         print(msg)
 
 
@@ -154,13 +151,14 @@ def element_continuity(fiat_element):
         return ElementContinuity(dg, dg, dg)
 
 
-def create_directory(path):
-    if commrank == 0:
+def create_directory(path, comm=COMM_WORLD):
+    if comm.rank == 0:
         if os.path.exists(path):
             if not os.path.isdir(path):
                 raise Exception('file with same name exists', path)
         else:
             os.makedirs(path)
+    comm.barrier()
     return path
 
 


### PR DESCRIPTION
Rather than there always being a global communicator, we now build
meshes by passing in a communicator.  All subsequent operations are then
collective only over that communicator.  This defaults to COMM_WORLD.