### PR TITLE
Add element family option

### DIFF
--- a/examples/bottomFriction/steadyChannel.py
+++ b/examples/bottomFriction/steadyChannel.py
@@ -56,8 +56,6 @@ bathymetry2d.assign(depth)
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry2d, layers)
 options = solver_obj.options
-options.nonlin = False
-options.mimetic = False
 options.solve_salt = False
 options.solve_temp = False
 options.solve_vert_diffusion = True

--- a/examples/channel2d/channel2d.py
+++ b/examples/channel2d/channel2d.py
@@ -51,8 +51,6 @@ bathymetry_2d.dat.data[:] = bath(x_func.dat.data, 0, 0)
 # --- create solver ---
 solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d, order=1)
 options = solver_obj.options
-options.cfl_2d = 1.0
-# options.nonlin = False
 options.t_export = t_export
 options.t_end = t_end
 options.outputdir = outputdir

--- a/examples/channel3d/channel3d.py
+++ b/examples/channel3d/channel3d.py
@@ -33,7 +33,6 @@ bathymetry_2d.interpolate(Expression('ho - (ho-hr)*x[0]/100e3',
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
 options = solver_obj.options
-# options.nonlin = False
 options.solve_salt = True
 options.solve_temp = False
 options.solve_vert_diffusion = False

--- a/examples/channel3d/channel3d_closed.py
+++ b/examples/channel3d/channel3d_closed.py
@@ -45,8 +45,6 @@ bathymetry_2d.interpolate(Expression('ho - (ho-hr)*x[0]/100e3',
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
 options = solver_obj.options
-# options.nonlin = False
-options.mimetic = False
 options.solve_salt = True
 options.solve_temp = False
 options.solve_vert_diffusion = False

--- a/examples/freshwaterCylinder/freshwaterCylinder.py
+++ b/examples/freshwaterCylinder/freshwaterCylinder.py
@@ -64,7 +64,6 @@ coriolis_2d.interpolate(
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, layers)
 options = solver_obj.options
-options.mimetic = False
 options.solve_salt = True
 options.solve_temp = False
 options.constant_temp = Constant(temp_const)

--- a/examples/geostrophicGyre/geoGyre2d.py
+++ b/examples/geostrophicGyre/geoGyre2d.py
@@ -39,7 +39,6 @@ coriolis_2d.interpolate(
 # --- create solver ---
 solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
 options = solver_obj.options
-options.cfl_2d = 1.0
 options.nonlin = False
 options.coriolis = coriolis_2d
 options.t_export = t_export

--- a/examples/idealizedEstuary/warnerEstuary.py
+++ b/examples/idealizedEstuary/warnerEstuary.py
@@ -58,7 +58,6 @@ simple_barotropic = False  # for testing flux boundary conditions
 # create solver
 solverobj = solver.FlowSolver(mesh2d, bathymetry_2d, layers)
 options = solverobj.options
-options.mimetic = False
 options.solve_salt = not simple_barotropic
 options.solve_temp = False
 options.constant_temp = Constant(temp_const)

--- a/examples/katophillips/katophillips.py
+++ b/examples/katophillips/katophillips.py
@@ -57,7 +57,6 @@ wind_stress_2d = Constant((wind_stress_x, 0))
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry2d, layers)
 options = solver_obj.options
-options.nonlin = False
 options.solve_salt = True
 options.solve_temp = False
 options.constant_temp = Constant(10.0)

--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -72,9 +72,6 @@ bathymetry_2d.assign(depth)
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, layers)
 options = solver_obj.options
-options.cfl_2d = 1.0
-# options.nonlin = False
-options.mimetic = False
 options.solve_salt = False
 options.constant_salt = Constant(salt_const)
 options.solve_temp = True

--- a/examples/lockExchange/runTestSuite.py
+++ b/examples/lockExchange/runTestSuite.py
@@ -104,9 +104,7 @@ bathymetry2d.assign(depth)
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry2d, layers)
 options = solver_obj.options
-options.cfl_2d = 1.0
-# options.nonlin = False
-options.mimetic = args.mimetic
+options.element_family = 'rt-dg' if args.mimetic else 'dg-dg'
 options.order = args.poly_order
 options.solve_salt = False
 options.constant_salt = Constant(salt_const)

--- a/examples/overflow/overflow.py
+++ b/examples/overflow/overflow.py
@@ -56,9 +56,6 @@ temp_const = 10.0
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, layers)
 options = solver_obj.options
-options.cfl_2d = 1.0
-# options.nonlin = False
-options.mimetic = False
 options.solve_salt = True
 options.solve_temp = False
 options.constant_temp = Constant(temp_const)

--- a/examples/rhineROFI/rhineROFI.py
+++ b/examples/rhineROFI/rhineROFI.py
@@ -69,7 +69,6 @@ simple_barotropic = False  # for debugging
 # create solver
 solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, layers)
 options = solver_obj.options
-options.mimetic = False
 options.solve_salt = not simple_barotropic
 options.solve_temp = False
 options.constant_temp = Constant(temp_const)

--- a/examples/rhineROFI/rhineROFI2d.py
+++ b/examples/rhineROFI/rhineROFI2d.py
@@ -61,9 +61,6 @@ bathymetry_2d.interpolate(Expression('(x[0] > 0.0) ? H*(1-x[0]/Lriver) + HInlet*
 # create solver
 solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
 options = solver_obj.options
-options.mimetic = False
-options.cfl_2d = 1.0
-# options.nonlin = False
 options.coriolis = Constant(coriolis_f)
 options.h_viscosity = Constant(10.0)
 options.t_export = t_export

--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -46,7 +46,6 @@ linear_drag = Constant(1e-6)
 # --- create solver ---
 solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
 options = solver_obj.options
-options.cfl_2d = 1.0
 options.nonlin = False
 options.coriolis = coriolis_2d
 options.wind_stress = wind_stress_2d

--- a/examples/stommel3d/stommel3d.py
+++ b/examples/stommel3d/stommel3d.py
@@ -48,7 +48,6 @@ linear_drag = Constant(1e-6)
 # --- create solver ---
 solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, layers)
 options = solver_obj.options
-options.cfl_2d = 1.0
 options.nonlin = False
 options.solve_salt = False
 options.solve_temp = False

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -70,7 +70,6 @@ solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
 
 options = solver_obj.options
 options.nonlin = False
-options.mimetic = False
 options.solve_salt = True
 options.solve_temp = False
 options.solve_vert_diffusion = False

--- a/examples/waveEq2d/channel2d_waveEq.py
+++ b/examples/waveEq2d/channel2d_waveEq.py
@@ -48,7 +48,6 @@ t_end = 10*T_cycle + 1e-3
 # --- create solver ---
 solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
 options = solver_obj.options
-options.cfl_2d = 1.0
 options.nonlin = False  # use linear wave equation
 options.t_export = t_export
 options.t_end = t_end

--- a/test/barotropicChannel/test_closed_channel.py
+++ b/test/barotropicChannel/test_closed_channel.py
@@ -38,7 +38,6 @@ def test_closed_channel(do_export=False):
     # create solver
     solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
     options = solver_obj.options
-    # options.nonlin = False
     options.solve_salt = False
     options.solve_temp = False
     options.solve_vert_diffusion = False

--- a/test/bottomFriction/test_bottom_friction.py
+++ b/test/bottomFriction/test_bottom_friction.py
@@ -29,7 +29,7 @@ import pytest
 import numpy
 
 
-def run_bottom_friction(parabolic_visosity=False, mimetic=False,
+def run_bottom_friction(parabolic_visosity=False, element_family='dg-dg',
                         do_assert=True, do_export=False):
     physical_constants['z0_friction'].assign(1.5e-3)
 
@@ -62,7 +62,7 @@ def run_bottom_friction(parabolic_visosity=False, mimetic=False,
     solver_obj = solver.FlowSolver(mesh2d, bathymetry2d, layers)
     options = solver_obj.options
     options.nonlin = False
-    options.mimetic = mimetic
+    options.element_family = element_family
     options.solve_salt = False
     options.solve_temp = False
     options.solve_vert_diffusion = True
@@ -138,13 +138,13 @@ def parabolic_visosity(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False], ids=['rt', 'dg'])
-def mimetic(request):
+@pytest.fixture(params=['rt-dg', 'dg-dg'])
+def element_family(request):
     return request.param
 
 
-def test_bottom_friction(parabolic_visosity, mimetic):
-    run_bottom_friction(do_assert=True, do_export=False, parabolic_visosity=parabolic_visosity, mimetic=mimetic)
+def test_bottom_friction(parabolic_visosity, element_family):
+    run_bottom_friction(do_assert=True, do_export=False, parabolic_visosity=parabolic_visosity, element_family=element_family)
 
 
 if __name__ == '__main__':

--- a/test/continuity3d/test_continuity_mes.py
+++ b/test/continuity3d/test_continuity_mes.py
@@ -9,7 +9,7 @@ from scipy import stats
 import pytest
 
 
-def setup1(lx, h0, mimetic=True):
+def setup1(lx, h0, element_family='dg-dg'):
     """
     Linear bath, zero elev, constant uv
 
@@ -43,16 +43,16 @@ def setup1(lx, h0, mimetic=True):
             v_str,
             w_str,
         ), lx=lx, h0=h0)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
 def setup1dg(lx, h0):
     """Linear bath, zero elev, constant uv"""
-    return setup1(lx, h0, mimetic=False)
+    return setup1(lx, h0, element_family='dg-dg')
 
 
-def setup2(lx, h0, mimetic=True):
+def setup2(lx, h0, element_family='rt-dg'):
     """
     Constant bath and elev, uv depends on (x,y)
 
@@ -81,16 +81,16 @@ def setup2(lx, h0, mimetic=True):
          '0.0',
          '-(0.12*pi*cos(0.2*pi*(1.0*x[0] + 3.0*x[1])/lx)/lx + 0.6*pi*cos(0.2*pi*(3.0*x[0] + 1.0*x[1])/lx)/lx)'),
         lx=lx)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
 def setup2dg(lx, h0):
     """Constant bath and elev, uv depends on (x,y)"""
-    return setup2(lx, h0, mimetic=False)
+    return setup2(lx, h0, element_family='dg-dg')
 
 
-def setup3(lx, h0, mimetic=True):
+def setup3(lx, h0, element_family='rt-dg'):
     """Non-trivial bath and elev, u=1, v=0"""
     out = {}
     out['bath_expr'] = Expression(
@@ -120,16 +120,16 @@ def setup3(lx, h0, mimetic=True):
             v_str,
             w_str,
         ), lx=lx, h0=h0)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
 def setup3dg(lx, h0):
     """Non-trivial bath and elev, u=1, v=0"""
-    return setup2(lx, h0, mimetic=False)
+    return setup2(lx, h0, element_family='dg-dg')
 
 
-def setup4(lx, h0, mimetic=True):
+def setup4(lx, h0, element_family='rt-dg'):
     """Non-trivial bath and elev, uv depends on (x,y)"""
     out = {}
     out['bath_expr'] = Expression(
@@ -159,16 +159,16 @@ def setup4(lx, h0, mimetic=True):
             v_str,
             w_str,
         ), lx=lx, h0=h0)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
 def setup4dg(lx, h0):
     """Non-trivial bath and elev, uv depends on (x,y)"""
-    return setup3(lx, h0, mimetic=False)
+    return setup3(lx, h0, element_family='dg-dg')
 
 
-def setup5(lx, h0, mimetic=True):
+def setup5(lx, h0, element_family='rt-dg'):
     """Non-trivial bath and elev, uv depends on (x,y,z)"""
     out = {}
     out['bath_expr'] = Expression(
@@ -198,13 +198,13 @@ def setup5(lx, h0, mimetic=True):
             v_str,
             w_str,
         ), lx=lx, h0=h0)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
 def setup5dg(lx, h0):
     """Non-trivial bath and elev, uv depends on (x,y,z)"""
-    return setup4(lx, h0, mimetic=False)
+    return setup4(lx, h0, element_family='dg-dg')
 
 
 def run(setup, refinement, order, do_export=True):
@@ -235,7 +235,7 @@ def run(setup, refinement, order, do_export=True):
 
     solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
     solver_obj.options.order = order
-    solver_obj.options.mimetic = False
+    solver_obj.options.element_family = 'dg-dg'
     solver_obj.options.solve_salt = False
     solver_obj.options.solve_temp = False
     solver_obj.options.u_advection = Constant(1.0)
@@ -245,8 +245,8 @@ def run(setup, refinement, order, do_export=True):
     solver_obj.options.dt_2d = 10.0
     solver_obj.options.update(sdict['options'])
 
-    assert solver_obj.options.mimetic is False, ('this test is not suitable '
-                                                 'for mimetic elements')
+    assert solver_obj.options.element_family == 'dg-dg', ('this test is not suitable '
+                                                          'for mimetic elements')
     # NOTE use symmetic uv condition to get correct w
     bnd_mom = {'symm': None}
     solver_obj.bnd_functions['momentum'] = {1: bnd_mom, 2: bnd_mom,

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -9,7 +9,7 @@ from scipy import stats
 import pytest
 
 
-def run(refinement, order=1, mimetic=False, warped_mesh=False, do_export=True):
+def run(refinement, order=1, element_family='dg-dg', warped_mesh=False, do_export=True):
     print '--- running refinement {:}'.format(refinement)
     # domain dimensions - channel in x-direction
     lx = 15.0e3
@@ -53,7 +53,7 @@ def run(refinement, order=1, mimetic=False, warped_mesh=False, do_export=True):
 
     solverobj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
     solverobj.options.order = order
-    solverobj.options.mimetic = mimetic
+    solverobj.options.element_family = element_family
     solverobj.options.nonlin = False
     solverobj.options.use_ale_moving_mesh = False
     solverobj.options.u_advection = Constant(1.0)
@@ -133,7 +133,7 @@ def run_convergence(ref_list, saveplot=False, **options):
     """Runs test for a list of refinements and computes error convergence rate"""
     order = options.get('order', 1)
     options.setdefault('do_export', False)
-    space_str = 'rt' if options.get('mimetic') else 'dg'
+    space_str = options.get('element_family')
     l2_err = []
     for r in ref_list:
         l2_err.append(run(r, **options))
@@ -202,4 +202,4 @@ def test_horizontal_viscosity(warped):
 # ---------------------------
 
 if __name__ == '__main__':
-    run_convergence([1, 2, 3], order=1, warped_mesh=True, mimetic=False, do_export=True, saveplot=True)
+    run_convergence([1, 2, 3], order=1, warped_mesh=True, element_family='dg-dg', do_export=True, saveplot=True)

--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -9,7 +9,7 @@ from scipy import stats
 import pytest
 
 
-def run(refinement, order=1, implicit=False, mimetic=False, do_export=True):
+def run(refinement, order=1, implicit=False, element_family='dg-dg', do_export=True):
     print '--- running refinement {:}'.format(refinement)
     # domain dimensions - channel in x-direction
     lx = 7.0e3
@@ -49,7 +49,7 @@ def run(refinement, order=1, implicit=False, mimetic=False, do_export=True):
 
     solverobj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
     solverobj.options.order = order
-    solverobj.options.mimetic = mimetic
+    solverobj.options.element_family = element_family
     solverobj.options.nonlin = False
     solverobj.options.use_ale_moving_mesh = False
     solverobj.options.u_advection = Constant(1.0)
@@ -133,7 +133,7 @@ def run_convergence(ref_list, saveplot=False, **options):
     """Runs test for a list of refinements and computes error convergence rate"""
     order = options.get('order', 1)
     options.setdefault('do_export', False)
-    space_str = 'rt' if options.get('mimetic') else 'dg'
+    space_str = options.get('element_family')
     l2_err = []
     for r in ref_list:
         l2_err.append(run(r, **options))
@@ -186,8 +186,8 @@ def run_convergence(ref_list, saveplot=False, **options):
 # ---------------------------
 
 
-@pytest.fixture(params=[True, False], ids=['mimetic', 'dg'])
-def mimetic(request):
+@pytest.fixture(params=['rt-dg', 'dg-dg'])
+def element_family(request):
     return request.param
 
 
@@ -201,17 +201,12 @@ def implicit(request):
     return request.param
 
 
-def test_vertical_viscosity(order, implicit, mimetic):
-    run_convergence([1, 2, 3], order=order, implicit=implicit, mimetic=mimetic)
+def test_vertical_viscosity(order, implicit, element_family):
+    run_convergence([1, 2, 3], order=order, implicit=implicit, element_family=element_family)
 
 # ---------------------------
 # run individual setup for debugging
 # ---------------------------
 
 if __name__ == '__main__':
-    # run(2, order=0, implicit=True)
-    run_convergence([1, 2, 3], order=1, implicit=False, mimetic=False, saveplot=True)
-    # run_convergence([1, 2, 4, 8], order=0, implicit=True, mimetic=True, saveplot=True)
-    # run_convergence([1, 2, 4, 8], order=1, implicit=True, mimetic=True, saveplot=True)
-    # run_convergence([1, 2, 4, 8], order=0, implicit=True, mimetic=False, saveplot=True)
-    # run_convergence([1, 2, 4, 8], order=1, implicit=True, mimetic=False, saveplot=True)
+    run_convergence([1, 2, 3], order=1, implicit=False, element_family='dg-dg', saveplot=True)

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -144,7 +144,7 @@ def run(setup, refinement, order, do_export=True, options=None,
 
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
     solver_obj.options.order = order
-    solver_obj.options.mimetic = True
+    solver_obj.options.element_family = 'rt-dg'
     solver_obj.options.u_advection = Constant(1.0)
     solver_obj.options.no_exports = not do_export
     solver_obj.options.outputdir = outputdir
@@ -328,16 +328,13 @@ def setup(request):
 
 
 @pytest.fixture(params=[
-    {'mimetic': False,
-     'continuous_pressure': False,
+    {'element_family': 'dg-dg',
      'timestepper_type': 'cranknicolson'},
-    {'mimetic': True,
-     'continuous_pressure': False,
+    {'element_family': 'rt-dg',
      'timestepper_type': 'cranknicolson'},
-    {'mimetic': False,
-     'continuous_pressure': True,
+    {'element_family': 'dg-cg',
      'timestepper_type': 'cranknicolson'}],
-    ids=["DG", "mimetic", "P1DGP2"]
+    ids=["dg-dg", "rt-dg", "dg-cg"]
 )
 def options(request):
     return request.param

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -5,9 +5,9 @@ import pytest
 
 
 @pytest.mark.parametrize("options", [
-    {"no_exports": True},  # default: mimetic
-    {"no_exports": True, "mimetic": False, "continuous_pressure": True},
-], ids=["mimetic", "pndp(n+1)"])
+    {"no_exports": True, "element_family": "rt-dg"},
+    {"no_exports": True, "element_family": "dg-cg"},
+], ids=["rt-dg", "dg-cg"])
 def test_steady_state_channel_mms(options):
     lx = 5e3
     ly = 1e3
@@ -130,4 +130,4 @@ def test_steady_state_channel_mms(options):
 
 
 if __name__ == '__main__':
-    test_steady_state_channel_mms({"no_exports": True, "mimetic": False, "continuous_pressure": True})
+    test_steady_state_channel_mms({"no_exports": True, "element_family": "dg-cg"})

--- a/test/tracerEq/test_consistency.py
+++ b/test/tracerEq/test_consistency.py
@@ -15,7 +15,7 @@ from thetis import *
 import pytest
 
 
-def run_tracer_consistency(mimetic=False, meshtype='regular', do_export=False):
+def run_tracer_consistency(element_family='dg-dg', meshtype='regular', do_export=False):
     t_cycle = 2000.0  # standing wave period
     depth = 50.0
     lx = np.sqrt(9.81*depth)*t_cycle  # wave length
@@ -36,7 +36,7 @@ def run_tracer_consistency(mimetic=False, meshtype='regular', do_export=False):
     elif meshtype == 'warped':
         warped = True
 
-    run_description = 'mimetic={:} meshtype={:}'.format(mimetic, meshtype)
+    run_description = 'element_family={:} meshtype={:}'.format(element_family, meshtype)
     print_info('Running test: ' + run_description)
 
     suffix = ''
@@ -75,7 +75,7 @@ def run_tracer_consistency(mimetic=False, meshtype='regular', do_export=False):
 
     options = solver_obj.options
     options.nonlin = False
-    options.mimetic = False
+    options.element_family = 'dg-dg'
     options.solve_salt = True
     options.solve_temp = False
     options.solve_vert_diffusion = False
@@ -120,11 +120,11 @@ def run_tracer_consistency(mimetic=False, meshtype='regular', do_export=False):
     assert max_abs_overshoot < overshoot_tol, msg
 
 
-@pytest.mark.parametrize('mimetic', [True, False])
+@pytest.mark.parametrize('element_family', ['dg-dg', 'rt-dg'])
 @pytest.mark.parametrize('meshtype', ['regular', 'sloped', 'warped'])
-def test_consistency_dg_regular(mimetic, meshtype):
-    run_tracer_consistency(mimetic=mimetic, meshtype=meshtype, do_export=False)
+def test_consistency_dg_regular(element_family, meshtype):
+    run_tracer_consistency(element_family=element_family, meshtype=meshtype, do_export=False)
 
 
 if __name__ == '__main__':
-    run_tracer_consistency(mimetic=False, meshtype='warped', do_export=True)
+    run_tracer_consistency(element_family='dg-dg', meshtype='warped', do_export=True)

--- a/test/tracerEq/test_h-diffusion_mes.py
+++ b/test/tracerEq/test_h-diffusion_mes.py
@@ -53,7 +53,7 @@ def run(refinement, order=1, warped_mesh=False, do_export=True):
 
     solverobj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
     solverobj.options.order = order
-    solverobj.options.mimetic = False
+    solverobj.options.element_family = 'dg-dg'
     solverobj.options.nonlin = False
     solverobj.options.use_ale_moving_mesh = True
     solverobj.options.u_advection = Constant(1.0)

--- a/test/tracerEq/test_steady_adv-diff_mms.py
+++ b/test/tracerEq/test_steady_adv-diff_mms.py
@@ -9,7 +9,7 @@ from scipy import stats
 import pytest
 
 
-def setup1(lx, ly, h0, kappa0, mimetic=True):
+def setup1(lx, ly, h0, kappa0, element_family='rt-dg'):
     """
     Constant bathymetry and u velocty, zero diffusivity, non-trivial tracer
     """
@@ -31,7 +31,7 @@ def setup1(lx, ly, h0, kappa0, mimetic=True):
     out['res_expr'] = Expression(
         '0.6*pi*cos(0.2*pi*(3.0*x[0] + 1.0*x[1])/lx)/lx',
         lx=lx)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
@@ -39,10 +39,10 @@ def setup1dg(lx, ly, h0, kappa0):
     """
     Constant bathymetry and u velocty, zero diffusivity, non-trivial tracer
     """
-    return setup1(lx, ly, h0, kappa0, mimetic=False)
+    return setup1(lx, ly, h0, kappa0, element_family='dg-dg')
 
 
-def setup2(lx, ly, h0, kappa0, mimetic=True):
+def setup2(lx, ly, h0, kappa0, element_family='rt-dg'):
     """
     constant bathymetry, zero velocity, constant kappa, x-varying T
     """
@@ -66,7 +66,7 @@ def setup2(lx, ly, h0, kappa0, mimetic=True):
     out['res_expr'] = Expression(
         '9*(pi*pi)*kappa0*sin(3*pi*x[0]/lx)/(lx*lx)',
         kappa0=kappa0, lx=lx)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
@@ -74,10 +74,10 @@ def setup2dg(lx, ly, h0, kappa0):
     """
     constant bathymetry, zero velocity, constant kappa, x-varying T
     """
-    return setup2(lx, ly, h0, kappa0, mimetic=False)
+    return setup2(lx, ly, h0, kappa0, element_family='dg-dg')
 
 
-def setup3(lx, ly, h0, kappa0, mimetic=True):
+def setup3(lx, ly, h0, kappa0, element_family='rt-dg'):
     """
     constant bathymetry, zero kappa, non-trivial velocity and T
     """
@@ -101,7 +101,7 @@ def setup3(lx, ly, h0, kappa0, mimetic=True):
     out['res_expr'] = Expression(
         '-0.4*pi*(0.3*h0*cos(pi*(0.3*x[1]/ly + 0.3*x[0]/lx))*cos(pi*x[2]/h0)/ly + 0.3*h0*cos(pi*(0.3*x[1]/ly + 0.3*x[0]/lx))/ly + 2*h0*cos(pi*(x[1]/ly + 2*x[0]/lx))*cos(pi*x[2]/h0)/lx + 2*h0*cos(pi*(x[1]/ly + 2*x[0]/lx))/lx)*sin(0.5*pi*x[2]/h0)*cos(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))/h0 - 0.75*pi*(0.8*cos(0.5*pi*x[2]/h0) + 0.2)*sin(pi*(0.3*x[1]/ly + 0.3*x[0]/lx))*sin(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))*sin(pi*x[2]/h0)/ly - 1.5*pi*(0.8*cos(0.5*pi*x[2]/h0) + 0.2)*sin(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))*sin(pi*(x[1]/ly + 2*x[0]/lx))*sin(pi*x[2]/h0)/lx',
         h0=h0, lx=lx, ly=ly)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
@@ -109,10 +109,10 @@ def setup3dg(lx, ly, h0, kappa0):
     """
     constant bathymetry, zero kappa, non-trivial velocity and T
     """
-    return setup3(lx, ly, h0, kappa0, mimetic=False)
+    return setup3(lx, ly, h0, kappa0, element_family='dg-dg')
 
 
-def setup4(lx, ly, h0, kappa0, mimetic=True):
+def setup4(lx, ly, h0, kappa0, element_family='rt-dg'):
     """
     constant bathymetry, constant kappa, non-trivial velocity and T
     """
@@ -138,7 +138,7 @@ def setup4(lx, ly, h0, kappa0, mimetic=True):
     out['res_expr'] = Expression(
         '-0.4*pi*(0.3*h0*cos(pi*(0.3*x[1]/ly + 0.3*x[0]/lx))*cos(pi*x[2]/h0)/ly + 0.3*h0*cos(pi*(0.3*x[1]/ly + 0.3*x[0]/lx))/ly + 2*h0*cos(pi*(x[1]/ly + 2*x[0]/lx))*cos(pi*x[2]/h0)/lx + 2*h0*cos(pi*(x[1]/ly + 2*x[0]/lx))/lx)*sin(0.5*pi*x[2]/h0)*cos(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))/h0 - 0.75*pi*(0.8*cos(0.5*pi*x[2]/h0) + 0.2)*sin(pi*(0.3*x[1]/ly + 0.3*x[0]/lx))*sin(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))*sin(pi*x[2]/h0)/ly - 0.5625*(pi*pi)*kappa0*(0.8*cos(0.5*pi*x[2]/h0) + 0.2)*cos(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))/(ly*ly) - 1.5*pi*(0.8*cos(0.5*pi*x[2]/h0) + 0.2)*sin(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))*sin(pi*(x[1]/ly + 2*x[0]/lx))*sin(pi*x[2]/h0)/lx + 2.25*(pi*pi)*kappa0*(0.8*cos(0.5*pi*x[2]/h0) + 0.2)*cos(pi*(0.75*x[1]/ly + 1.5*x[0]/lx))/(lx*lx)',
         h0=h0, kappa0=kappa0, lx=lx, ly=ly)
-    out['options'] = {'mimetic': mimetic}
+    out['options'] = {'element_family': element_family}
     return out
 
 
@@ -146,7 +146,7 @@ def setup4dg(lx, ly, h0, kappa0):
     """
     constant bathymetry, constant kappa, non-trivial velocity and T
     """
-    return setup4(lx, ly, h0, kappa0, mimetic=False)
+    return setup4(lx, ly, h0, kappa0, element_family='dg-dg')
 
 
 def run(setup, refinement, order, do_export=True):

--- a/test/tracerEq/test_v-diffusion_mes.py
+++ b/test/tracerEq/test_v-diffusion_mes.py
@@ -49,7 +49,7 @@ def run(refinement, order=1, implicit=False, do_export=True):
 
     solverobj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
     solverobj.options.order = order
-    solverobj.options.mimetic = False
+    solverobj.options.element_family = 'dg-dg'
     solverobj.options.nonlin = False
     solverobj.options.use_ale_moving_mesh = False
     solverobj.options.u_advection = Constant(1.0)

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -19,10 +19,8 @@ class ModelOptions(AttrDict, FrozenClass):
         super(ModelOptions, self).__init__()
         self.order = 1
         """int: Polynomial degree of elements"""
-        self.mimetic = True
-        """bool: Use mimetic elements for uvw instead of DG"""
-        self.continuous_pressure = False
-        """bool: Use PnDG-P(n+1) velocity, pressure pair"""
+        self.element_family = 'rt-dg'
+        """str: Finite element family. Currently 'dg-dg', 'rt-dg', or 'dg-cg' velocity-pressure pairs are supported."""
         self.nonlin = True
         """bool: Use nonlinear shallow water equations"""
         self.solve_salt = True

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -124,11 +124,11 @@ class FlowSolver(FrozenClass):
         w_v_elt = FiniteElement('CG', interval, self.options.order+1)
         w_elt = HDiv(TensorProductElement(w_h_elt, w_v_elt))
         # final spaces
-        if self.options.mimetic:
+        if self.options.element_family == 'rt-dg':
             # self.U = FunctionSpace(self.mesh, UW_elt)  # uv
             self.function_spaces.U = FunctionSpace(self.mesh, u_elt, name='U')  # uv
             self.function_spaces.W = FunctionSpace(self.mesh, w_elt, name='W')  # w
-        else:
+        elif self.options.element_family == 'dg-dg':
             self.function_spaces.U = VectorFunctionSpace(self.mesh, 'DG', self.options.order,
                                                          vfamily='DG', vdegree=self.options.order,
                                                          name='U')
@@ -136,6 +136,8 @@ class FlowSolver(FrozenClass):
             self.function_spaces.W = VectorFunctionSpace(self.mesh, 'DG', self.options.order,
                                                          vfamily='DG', vdegree=self.options.order,
                                                          name='W')
+        else:
+            raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
         # auxiliary function space that will be used to transfer data between 2d/3d modes
         self.function_spaces.Uproj = self.function_spaces.U
 
@@ -152,9 +154,9 @@ class FlowSolver(FrozenClass):
         self.function_spaces.P1DG_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='P1DG_2d')
         self.function_spaces.P1DGv_2d = VectorFunctionSpace(self.mesh2d, 'DG', 1, name='P1DGv_2d')
         # 2D velocity space
-        if self.options.mimetic:
+        if self.options.element_family == 'rt-dg':
             self.function_spaces.U_2d = FunctionSpace(self.mesh2d, 'RT', self.options.order+1)
-        else:
+        elif self.options.element_family == 'dg-dg':
             self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.order, name='U_2d')
         self.function_spaces.Uproj_2d = self.function_spaces.U_2d
         # TODO is this needed?

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -75,20 +75,18 @@ class FlowSolver2d(FrozenClass):
         self.function_spaces.P1v_2d = VectorFunctionSpace(self.mesh2d, 'CG', 1)
         self.function_spaces.P1DG_2d = FunctionSpace(self.mesh2d, 'DG', 1)
         self.function_spaces.P1DGv_2d = VectorFunctionSpace(self.mesh2d, 'DG', 1)
-        if self.options.mimetic and self.options.continuous_pressure:
-            raise ValueError("Cannot combine options mimetic and continuous_pressure")
         # 2D velocity space
-        if self.options.mimetic:
+        if self.options.element_family == 'rt-dg':
             self.function_spaces.U_2d = FunctionSpace(self.mesh2d, 'RT', self.options.order+1)
             self.function_spaces.H_2d = FunctionSpace(self.mesh2d, 'DG', self.options.order)
-        elif self.options.continuous_pressure:
+        elif self.options.element_family == 'dg-cg':
             self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.order, name='U_2d')
             self.function_spaces.H_2d = FunctionSpace(self.mesh2d, 'CG', self.options.order+1)
-        else:
+        elif self.options.element_family == 'dg-dg':
             self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.order, name='U_2d')
             self.function_spaces.H_2d = FunctionSpace(self.mesh2d, 'DG', self.options.order)
-        # TODO can this be omitted?
-        # self.function_spaces.U_scalar_2d = FunctionSpace(self.mesh2d, 'DG', self.options.order)
+        else:
+            raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d])
 
         self._isfrozen = True


### PR DESCRIPTION
Currently supported options are `option.element_family = 'dg-dg'`, `'rt-dg'` and `'dg-cg'`. 
Replaces `options.mimetic` and `options.continuous_pressure`.