### PR TITLE
Logging

### DIFF
--- a/examples/bottomFriction/steadyChannel.py
+++ b/examples/bottomFriction/steadyChannel.py
@@ -122,4 +122,4 @@ if __name__ == '__main__':
     volume = lx*ly*depth
     uv_l2_err = errornorm(log_uv, uv_p1_dg)/numpy.sqrt(volume)
     assert uv_l2_err < l2_tol, 'L2 error is too large: {:} > {:}'.format(uv_l2_err, l2_tol)
-    print('L2 error {:.4f} PASSED'.format(uv_l2_err))
+    print_output('L2 error {:.4f} PASSED'.format(uv_l2_err))

--- a/examples/bottomFriction/steadyChannel.py
+++ b/examples/bottomFriction/steadyChannel.py
@@ -83,7 +83,7 @@ gls_options = options.gls_options
 gls_options.apply_defaults('k-omega')
 gls_options.stability_name = 'CB'
 options.outputdir = outputdir + '_' + gls_options.closure_name + '-' + gls_options.stability_name
-print_info('Exporting to ' + options.outputdir)
+print_output('Exporting to ' + options.outputdir)
 
 solver_obj.create_function_spaces()
 

--- a/examples/channel2d/channel2d.py
+++ b/examples/channel2d/channel2d.py
@@ -20,8 +20,8 @@ from thetis import *
 
 outputdir = 'outputs'
 mesh2d = Mesh('channel_mesh.msh')
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 # total duration in seconds
 t_end = 6 * 3600
 # estimate of max advective velocity used to estimate time step

--- a/examples/channel3d/channel3d.py
+++ b/examples/channel3d/channel3d.py
@@ -15,8 +15,8 @@ from thetis import *
 n_layers = 6
 outputdir = 'outputs'
 mesh2d = Mesh('channel_mesh.msh')
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 t_end = 48 * 3600
 u_mag = Constant(2.5)
 t_export = 100.0

--- a/examples/channel3d/channel3d_closed.py
+++ b/examples/channel3d/channel3d_closed.py
@@ -25,8 +25,8 @@ from thetis import *
 n_layers = 6
 outputdir = 'outputs_closed'
 mesh2d = Mesh('channel_mesh.msh')
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 t_end = 48 * 3600
 u_mag = Constant(4.2)
 t_export = 100.0

--- a/examples/freshwaterCylinder/freshwaterCylinder.py
+++ b/examples/freshwaterCylinder/freshwaterCylinder.py
@@ -41,7 +41,7 @@ physical_constants['rho0'].assign(1025.0)
 outputdir = 'outputs'
 layers = 20
 mesh2d = Mesh('tartinville_physical.msh')
-print_info('Loaded mesh ' + mesh2d.name)
+print_output('Loaded mesh ' + mesh2d.name)
 dt = 25.0
 t_end = 288 * 3600
 t_export = 900.0

--- a/examples/idealizedEstuary/warnerEstuary.py
+++ b/examples/idealizedEstuary/warnerEstuary.py
@@ -33,7 +33,7 @@ nx = int(round(100*refinement[reso_str]))
 ny = 2
 layers = int(round(10*refinement[reso_str]))
 mesh2d = RectangleMesh(nx, ny, lx, ly)
-print_info('Exporting to ' + outputdir)
+print_output('Exporting to ' + outputdir)
 dt = 25.0  # 25.0/refinement[reso_str]  # TODO tune dt
 t_end = 20*24*3600
 # export every 9 min, day 16 is export 2720

--- a/examples/katophillips/katophillips.py
+++ b/examples/katophillips/katophillips.py
@@ -40,7 +40,7 @@ mesh2d = PeriodicRectangleMesh(nx, ny, lx, ly, direction='x', reorder=True)
 mesh2d.coordinates.dat.data[:, 0] -= lx/2
 mesh2d.coordinates.dat.data[:, 1] -= ly/2
 
-print_info('Exporting to ' + outputdir)
+print_output('Exporting to ' + outputdir)
 dt = 60.0
 t_end = 30 * 3600.0
 t_export = 5*60.0

--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -56,7 +56,7 @@ temp_left = 19.088
 temp_right = 34.81
 salt_const = 35.0
 
-print_info('Exporting to '+outputdir)
+print_output('Exporting to '+outputdir)
 dt = 75.0/refinement[reso_str]
 if reso_str == 'fine':
     dt /= 2.0

--- a/examples/lockExchange/runTestSuite.py
+++ b/examples/lockExchange/runTestSuite.py
@@ -50,9 +50,9 @@ args_dict = vars(args)
 
 comm = COMM_WORLD
 if comm.rank == 0:
-    print 'Running test case with setup:'
+    print_output('Running test case with setup:')
     for k in sorted(args_dict.keys()):
-        print ' - {0:15s} : {1:}'.format(k, args_dict[k])
+        print_output(' - {0:15s} : {1:}'.format(k, args_dict[k]))
 
 limiter_str = 'limiter' if args.use_limiter else ''
 space_str = 'RT' if args.mimetic else 'DG'

--- a/examples/lockExchange/runTestSuite.py
+++ b/examples/lockExchange/runTestSuite.py
@@ -88,7 +88,7 @@ temp_left = 19.088
 temp_right = 34.81
 salt_const = 35.0
 
-print_info('Exporting to ' + outputdir)
+print_output('Exporting to ' + outputdir)
 dt = 75.0/refinement[reso_str]
 if reso_str == 'fine':
     dt /= 2.0

--- a/examples/overflow/overflow.py
+++ b/examples/overflow/overflow.py
@@ -34,7 +34,7 @@ reso_str = 'medium'
 refinement = {'medium': 1}
 layers = int(round(50*refinement[reso_str]))
 mesh2d = Mesh('mesh_{0:s}.msh'.format(reso_str))
-print_info('Loaded mesh '+mesh2d.name)
+print_output('Loaded mesh '+mesh2d.name)
 dt = 5.0/refinement[reso_str]
 t_end = 25 * 3600
 t_export = 15*60.0

--- a/examples/rhineROFI/rhineROFI.py
+++ b/examples/rhineROFI/rhineROFI.py
@@ -28,8 +28,8 @@ if reso == 'fine':
     layers = 24
 outputdir = 'outputs_{:}'.format(reso)
 mesh2d = Mesh('mesh_rhineRofi_{:}.msh'.format(reso))
-print_info('Loaded mesh ' + mesh2d.name)
-print_info('Exporting to ' + outputdir)
+print_output('Loaded mesh ' + mesh2d.name)
+print_output('Exporting to ' + outputdir)
 
 # Physical parameters
 eta_amplitude = 1.00  # mean (Fisher et al. 2009 tidal range 2.00 )

--- a/examples/rhineROFI/rhineROFI2d.py
+++ b/examples/rhineROFI/rhineROFI2d.py
@@ -21,8 +21,8 @@ from thetis import *
 reso = 'coarse'
 outputdir = 'outputs_2d_{:}'.format(reso)
 mesh2d = Mesh('mesh_rhineRofi_{:}.msh'.format(reso))
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 
 # Physical parameters
 eta_amplitude = 1.00  # mean (Fisher et al. 2009 tidal range 2.00 )

--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -17,8 +17,8 @@ lx = 1.0e6
 nx = 20
 mesh2d = RectangleMesh(nx, nx, lx, lx)
 outputdir = 'outputs'
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 depth = 1000.0
 t_end = 75*12*2*3600
 t_export = 3600*2

--- a/examples/stommel3d/stommel3d.py
+++ b/examples/stommel3d/stommel3d.py
@@ -18,8 +18,8 @@ lx = 1.0e6
 nx = 20
 mesh2d = RectangleMesh(nx, nx, lx, lx)
 outputdir = 'outputs'
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 depth = 1000.0
 layers = 6
 t_end = 75*12*2*3600.

--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -94,7 +94,7 @@ dJdc = compute_gradient(J, c, forget=False)
 out = File('gradient_J.pvd')
 out.write(dJdc)
 J0 = assemble(integral)
-print "Functional evaluated by hand: ", J0
+print_info("Functional evaluated by hand: ", J0)
 
 parameters["adjoint"]["stop_annotating"] = True
 
@@ -110,8 +110,8 @@ def jfunc(m):
     return Jm
 
 success = replay_dolfin(tol=0.0, stop=False)
-print solver_obj.fields.solution_2d.vector().array()[0:10]
+print_info(solver_obj.fields.solution_2d.vector().array()[0:10])
 Jhat = ReducedFunctional(J, c)
-print "Output of Jhat: ", Jhat(drag_func)
+print_info("Output of Jhat: ", Jhat(drag_func))
 minconv = taylor_test(jfunc, c, J0, dJdc, seed=1e-4)
 assert minconv > 1.95

--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -16,7 +16,7 @@ ly = 50.0
 nx = 20.0
 ny = 10.0
 mesh2d = RectangleMesh(nx, ny, lx, ly)
-print_info('Exporting to ' + outputdir)
+print_output('Exporting to ' + outputdir)
 
 # total duration in seconds
 t_end = 20.

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -66,7 +66,7 @@ solver_obj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
 # p = 2.5*x/lx + 0.5
 # sigma = -depth * (0.5*np.tanh(p*(-2.0*z/depth - 1.0))/np.tanh(p) + 0.5)
 # coords.dat.data[:, 2] = sigma
-# print coords.dat.data[:, 2].min(), coords.dat.data[:, 2].max()
+# print_output(coords.dat.data[:, 2].min(), coords.dat.data[:, 2].max())
 
 options = solver_obj.options
 options.nonlin = False

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -28,8 +28,8 @@ if sloped:
     suffix = '_sloped'
 outputdir = 'outputs' + suffix
 
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 
 # bathymetry
 P1_2d = FunctionSpace(mesh2d, 'CG', 1)

--- a/examples/waveEq2d/channel2d_waveEq.py
+++ b/examples/waveEq2d/channel2d_waveEq.py
@@ -20,8 +20,8 @@ elev_amp = 1.0
 u_mag = Constant(0.5)
 
 outputdir = 'outputs_wave_eq_2d'
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 
 # bathymetry
 P1_2d = FunctionSpace(mesh2d, 'CG', 1)

--- a/examples/waveEq3d/channel3d_waveEq.py
+++ b/examples/waveEq3d/channel3d_waveEq.py
@@ -21,8 +21,8 @@ n_layers = 6
 u_mag = Constant(0.5)
 
 outputdir = 'outputs'
-print_info('Loaded mesh '+mesh2d.name)
-print_info('Exporting to '+outputdir)
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
 
 # bathymetry
 P1_2d = FunctionSpace(mesh2d, 'CG', 1)

--- a/test/barotropicChannel/test_closed_channel.py
+++ b/test/barotropicChannel/test_closed_channel.py
@@ -20,8 +20,8 @@ def test_closed_channel(do_export=False):
     n_layers = 6
     outputdir = 'outputs'
     mesh2d = Mesh('mesh_coarse.msh')
-    print_info('Loaded mesh '+mesh2d.name)
-    print_info('Exporting to '+outputdir)
+    print_output('Loaded mesh '+mesh2d.name)
+    print_output('Exporting to '+outputdir)
     t_end = 24 * 3600
     u_mag = Constant(2.5)
     t_export = 300.0

--- a/test/bottomFriction/test_bottom_friction.py
+++ b/test/bottomFriction/test_bottom_friction.py
@@ -129,7 +129,7 @@ def run_bottom_friction(parabolic_visosity=False, element_family='dg-dg',
         volume = lx*ly*depth
         uv_l2_err = errornorm(log_uv, uv_p1_dg)/numpy.sqrt(volume)
         assert uv_l2_err < l2_tol, 'L2 error is too large: {:} > {:}'.format(uv_l2_err, l2_tol)
-        print('L2 error {:.4f} PASSED'.format(uv_l2_err))
+        print_output('L2 error {:.4f} PASSED'.format(uv_l2_err))
 
 
 @pytest.fixture(params=[pytest.mark.skip(reason='travis is timing out')(True),

--- a/test/bottomFriction/test_bottom_friction.py
+++ b/test/bottomFriction/test_bottom_friction.py
@@ -47,7 +47,7 @@ def run_bottom_friction(parabolic_visosity=False, element_family='dg-dg',
     ly = ny*dx
     mesh2d = PeriodicRectangleMesh(nx, ny, lx, ly, direction='x', reorder=True)
 
-    print_info('Exporting to ' + outputdir)
+    print_output('Exporting to ' + outputdir)
     dt = 25.0
     t_end = 5 * 3600.0  # sufficient to reach ~steady state
     t_export = 400.0

--- a/test/callback/test_diagnostic_hdf5_output.py
+++ b/test/callback/test_diagnostic_hdf5_output.py
@@ -27,7 +27,7 @@ def test_callbacks(tmp_outputdir):
     u_mag = Constant(0.5)
 
     outputdir = tmp_outputdir
-    print_info('Exporting to ' + outputdir)
+    print_output('Exporting to ' + outputdir)
 
     # bathymetry
     p1_2d = FunctionSpace(mesh2d, 'CG', 1)

--- a/test/continuity3d/test_continuity_mes.py
+++ b/test/continuity3d/test_continuity_mes.py
@@ -209,7 +209,7 @@ def setup5dg(lx, h0):
 
 def run(setup, refinement, order, do_export=True):
     """Run single test and return L2 error"""
-    print '--- running {:} refinement {:}'.format(setup.__name__, refinement)
+    print_output('--- running {:} refinement {:}'.format(setup.__name__, refinement))
     setup_name = setup.__name__
     # domain dimensions
     lx = 15e3
@@ -292,23 +292,23 @@ def run(setup, refinement, order, do_export=True):
         out_uv.write(uv_analytical)
         solver_obj.export()
 
-    print 'w_pro', w_proj_3d.dat.data[:, 2].min(), w_proj_3d.dat.data[:, 2].max()
-    print 'w_ana', w_analytical.dat.data[:, 2].min(), w_analytical.dat.data[:, 2].max()
+    print_output('w_pro {:} {:}'.format(w_proj_3d.dat.data[:, 2].min(), w_proj_3d.dat.data[:, 2].max()))
+    print_output('w_ana {:} {:}'.format(w_analytical.dat.data[:, 2].min(), w_analytical.dat.data[:, 2].max()))
 
     # compute flux through bottom boundary
     normal = FacetNormal(solver_obj.mesh)
     bottom_flux = assemble(inner(uvw, normal)*ds_bottom)
     bottom_flux_ana = assemble(inner(w_analytical, normal)*ds_bottom)
-    print 'flux through bot', bottom_flux, bottom_flux_ana
+    print_output('flux through bot {:} {:}'.format(bottom_flux, bottom_flux_ana))
 
     err_msg = '{:}: Bottom impermeability violated: bottom flux {:.4g}'.format(setup_name, bottom_flux)
     assert abs(bottom_flux) < 1e-6, err_msg
 
     l2_err_w = errornorm(w_ana_ho, w_proj_3d)/numpy.sqrt(area)
-    print 'L2 error w  {:.12f}'.format(l2_err_w)
+    print_output('L2 error w  {:.12f}'.format(l2_err_w))
     w_ana_ho.project(sdict['uv_expr'])
     l2_err_uv = errornorm(w_ana_ho, solver_obj.fields.uv_3d)/numpy.sqrt(area)
-    print 'L2 error uv {:.12f}'.format(l2_err_uv)
+    print_output('L2 error uv {:.12f}'.format(l2_err_uv))
 
     return l2_err_w, l2_err_uv
 
@@ -352,14 +352,14 @@ def run_convergence(setup, ref_list, order, do_export=False, save_plot=False):
             imgfile += '.png'
             img_dir = create_directory('plots')
             imgfile = os.path.join(img_dir, imgfile)
-            print 'saving figure', imgfile
+            print_output('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
             assert abs(slope - expected_slope)/expected_slope < slope_rtol, err_msg
-            print '{:}: {:} convergence rate {:.4f} PASSED'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f} PASSED'.format(setup_name, field_str, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
     check_convergence(x_log, y_log_w, order, 'w', save_plot)

--- a/test/firedrake/test_divergence_2d.py
+++ b/test/firedrake/test_divergence_2d.py
@@ -12,7 +12,7 @@ op2.init(log_level=WARNING)
 
 
 def compute(refinement=1, order=1, do_export=False):
-    print '--- soving refinement', refinement
+    print('--- soving refinement {:}'.format(refinement))
     n = 5*refinement
     mesh = UnitSquareMesh(n, n)
 
@@ -44,7 +44,7 @@ def compute(refinement=1, order=1, do_export=False):
     uv_ana.project(uv_expr)
 
     if do_export:
-        print 'analytical div', div_uv.dat.data.min(), div_uv.dat.data.max()
+        print('analytical div {:} {:}'.format(div_uv.dat.data.min(), div_uv.dat.data.max()))
         # export analytical solutions
         out_uv = File('uv.pvd')
         out_div = File('div.pvd')
@@ -72,15 +72,15 @@ def compute(refinement=1, order=1, do_export=False):
     solve(a == l, div_uv)
 
     if do_export:
-        print 'numerical div', div_uv.dat.data.min(), div_uv.dat.data.max()
+        print('numerical div {:} {:}'.format(div_uv.dat.data.min(), div_uv.dat.data.max()))
         # export numerical solutions
         out_uv.write(uv)
         out_div.write(div_uv)
 
     l2err_uv = errornorm(uv_ana, uv)
     l2err_div = errornorm(div_ana, div_uv)
-    print 'L2 norm uv ', l2err_uv
-    print 'L2 norm div', l2err_div
+    print('L2 norm uv {:}'.format(l2err_uv))
+    print('L2 norm div'.format(l2err_div))
     return l2err_uv, l2err_div
 
 
@@ -122,14 +122,14 @@ def convergence_test(ref_list, order=1, export=False, saveplot=False):
             imgfile += '.png'
             imgdir = '.'
             imgfile = os.path.join(imgdir, imgfile)
-            print 'saving figure', imgfile
+            print('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(test_name, slope, expected_slope)
             assert abs(slope - expected_slope)/expected_slope < slope_rtol, err_msg
-            print '{:}: {:} convergence rate {:.4f} PASSED'.format(test_name, field_str, slope)
+            print('{:}: {:} convergence rate {:.4f} PASSED'.format(test_name, field_str, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(test_name, field_str, slope)
+            print('{:}: {:} convergence rate {:.4f}'.format(test_name, field_str, slope))
         return slope
     check_convergence(x_log, y_log_div, order, 'divergence_2d', 'div', saveplot)
     check_convergence(x_log, y_log_uv, order + 1, 'divergence_2d', 'uv', saveplot)

--- a/test/firedrake/test_implicit_diffusion.py
+++ b/test/firedrake/test_implicit_diffusion.py
@@ -63,7 +63,7 @@ def test_implicit_diffusion(do_export=False, do_assert=True):
     dt = dz*dz/nu_v / 10
     n_iter = np.ceil(t_end/dt)
     dt = t_end/n_iter
-    print 'dt', dt
+    print('dt {:}'.format(dt))
     dt_const = Constant(dt)
 
     # analytical solution
@@ -176,8 +176,8 @@ def test_implicit_diffusion(do_export=False, do_assert=True):
     if do_export:
         sol_file.write(solution)
         ana_file.write(ana_sol)
-    print 'sol', solution.dat.data.min(), solution.dat.data.max()
-    print 'ana', ana_sol.dat.data.min(), ana_sol.dat.data.max()
+    print('sol {:} {:}'.format(solution.dat.data.min(), solution.dat.data.max()))
+    print('ana {:} {:}'.format(ana_sol.dat.data.min(), ana_sol.dat.data.max()))
     # time loop
     while t < t_end + t_init:
         # solve
@@ -197,11 +197,11 @@ def test_implicit_diffusion(do_export=False, do_assert=True):
     if do_export:
         sol_file.write(solution)
         ana_file.write(ana_sol)
-    print 'sol', solution.dat.data.min(), solution.dat.data.max()
-    print 'ana', ana_sol.dat.data.min(), ana_sol.dat.data.max()
+    print('sol {:} {:}'.format(solution.dat.data.min(), solution.dat.data.max()))
+    print('ana {:} {:}'.format(ana_sol.dat.data.min(), ana_sol.dat.data.max()))
 
     l2_err = errornorm(ana_sol, solution)/area
-    print 'L2 error:', l2_err
+    print('L2 error: {:}'.format(l2_err))
     if do_assert:
         l2_threshold = 1e-4
         assert l2_err < l2_threshold, 'L2 error exceeds threshold'

--- a/test/firedrake/test_implicit_friction.py
+++ b/test/firedrake/test_implicit_friction.py
@@ -66,9 +66,9 @@ def test_implicit_friction(do_export=False, do_assert=True):
 
     viscosity_v.project(Expression('kappa * u_bf * -x[2] * (bath + x[2] + z0) / (bath + z0)',
                         kappa=kappa, u_bf=u_bf, bath=depth, z0=z0))
-    print 'Cd', drag
-    print 'u_bf', u_bf
-    print 'nu', viscosity_v.dat.data.min(), viscosity_v.dat.data.max()
+    print('Cd {:}'.format(drag))
+    print('u_bf {:}'.format(u_bf))
+    print('nu {:}'.format(viscosity_v.dat.data.min(), viscosity_v.dat.data.max()))
 
     # --- solve mom eq
     test = TestFunction(v)
@@ -136,7 +136,7 @@ def test_implicit_friction(do_export=False, do_assert=True):
 
         if do_export:
             out_file.write(solution)
-        print '{:4d}  T={:9.1f} s  cpu={:.2f} s'.format(it, t, t1-t0)
+        print('{:4d}  T={:9.1f} s  cpu={:.2f} s'.format(it, t, t1-t0))
 
     if do_assert:
         target_u_min = 0.4
@@ -147,16 +147,16 @@ def test_implicit_friction(do_export=False, do_assert=True):
         uvw = solution_p1_dg.dat.data
         w_max = np.max(np.abs(uvw[:, 2]))
         v_max = np.max(np.abs(uvw[:, 1]))
-        print 'w', w_max
-        print 'v', v_max
+        print('w {:}'.format(w_max))
+        print('v {:}'.format(v_max))
         assert w_max < target_zero, 'z velocity component too large'
         assert v_max < target_zero, 'y velocity component too large'
         u_min = uvw[:, 0].min()
         u_max = uvw[:, 0].max()
-        print 'u', u_min, u_max
+        print('u {:} {:}'.format(u_min, u_max))
         assert np.abs(u_min - target_u_min) < target_u_tol, 'minimum u velocity is wrong'
         assert np.abs(u_max - target_u_max) < target_u_tol, 'maximum u velocity is wrong'
-        print ' *** PASSED ***'
+        print('*** PASSED ***')
 
 if __name__ == '__main__':
     test_implicit_friction()

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -10,7 +10,7 @@ import pytest
 
 
 def run(refinement, order=1, element_family='dg-dg', warped_mesh=False, do_export=True):
-    print '--- running refinement {:}'.format(refinement)
+    print_output('--- running refinement {:}'.format(refinement))
     # domain dimensions - channel in x-direction
     lx = 15.0e3
     ly = 6.0e3/refinement
@@ -113,7 +113,7 @@ def run(refinement, order=1, element_family='dg-dg', warped_mesh=False, do_expor
         t += dt
         i += 1
         if t >= next_export_t - 1e-8:
-            print('{:3d} i={:5d} t={:8.2f} s uv={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.uv_3d)))
+            print_output('{:3d} i={:5d} t={:8.2f} s uv={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.uv_3d)))
             export_func()
             next_export_t += solverobj.options.t_export
             iexport += 1
@@ -124,7 +124,7 @@ def run(refinement, order=1, element_family='dg-dg', warped_mesh=False, do_expor
     uv_ana_ho.project(ana_uv_expr)
     # compute L2 norm
     l2_err = errornorm(uv_ana_ho, solverobj.fields.uv_3d)/numpy.sqrt(area)
-    print 'L2 error {:.12f}'.format(l2_err)
+    print_output('L2 error {:.12f}'.format(l2_err))
 
     return l2_err
 
@@ -169,14 +169,14 @@ def run_convergence(ref_list, saveplot=False, **options):
             imgfile += '.png'
             imgdir = create_directory('plots')
             imgfile = os.path.join(imgdir, imgfile)
-            print 'saving figure', imgfile
+            print_output('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
             assert slope > expected_slope*(1 - slope_rtol), err_msg
-            print '{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope)
+            print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
     check_convergence(x_log, y_log, order+1, 'uv', saveplot)

--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -10,7 +10,7 @@ import pytest
 
 
 def run(refinement, order=1, implicit=False, element_family='dg-dg', do_export=True):
-    print '--- running refinement {:}'.format(refinement)
+    print_output('--- running refinement {:}'.format(refinement))
     # domain dimensions - channel in x-direction
     lx = 7.0e3
     ly = 5.0e3
@@ -113,7 +113,7 @@ def run(refinement, order=1, implicit=False, element_family='dg-dg', do_export=T
         t += dt
         i += 1
         if t >= next_export_t - 1e-8:
-            print('{:3d} i={:5d} t={:8.2f} s uv={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.uv_3d)))
+            print_output('{:3d} i={:5d} t={:8.2f} s uv={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.uv_3d)))
             export_func()
             next_export_t += solverobj.options.t_export
             iexport += 1
@@ -124,7 +124,7 @@ def run(refinement, order=1, implicit=False, element_family='dg-dg', do_export=T
     uv_ana_ho.project(ana_uv_expr)
     # compute L2 norm
     l2_err = errornorm(uv_ana_ho, solverobj.fields.uv_3d)/numpy.sqrt(area)
-    print 'L2 error {:.12f}'.format(l2_err)
+    print_output('L2 error {:.12f}'.format(l2_err))
 
     return l2_err
 
@@ -169,14 +169,14 @@ def run_convergence(ref_list, saveplot=False, **options):
             imgfile += '.png'
             imgdir = create_directory('plots')
             imgfile = os.path.join(imgdir, imgfile)
-            print 'saving figure', imgfile
+            print_output('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
             assert slope > expected_slope*(1 - slope_rtol), err_msg
-            print '{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope)
+            print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
     check_convergence(x_log, y_log, order+1, 'uv', saveplot)

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -107,7 +107,7 @@ def setup9(x, lx, ly, h0, f0, nu0, g):
 def run(setup, refinement, order, do_export=True, options=None,
         solver_parameters=None):
     """Run single test and return L2 error"""
-    print '--- running {:} refinement {:}'.format(setup.__name__, refinement)
+    print_output('--- running {:} refinement {:}'.format(setup.__name__, refinement))
     # domain dimensions
     lx = 15e3
     ly = 10e3
@@ -139,7 +139,7 @@ def run(setup, refinement, order, do_export=True, options=None,
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(sdict['bath_expr'])
     if bathymetry_2d.dat.data.min() < 0.0:
-        print 'bath', bathymetry_2d.dat.data.min(), bathymetry_2d.dat.data.max()
+        print_output('bath {:} {:}'.format(bathymetry_2d.dat.data.min(), bathymetry_2d.dat.data.max()))
         raise Exception('Negative bathymetry')
 
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
@@ -240,7 +240,7 @@ def run(setup, refinement, order, do_export=True, options=None,
         #         else:
         #             name = str(d[k])
         #     bnd_str += '{:}: {:}, '.format(k, name)
-        # print('bnd {:}: {:}'.format(bnd_id, bnd_str))
+        # print_output('bnd {:}: {:}'.format(bnd_id, bnd_str))
 
     solver_obj.assign_initial_conditions(elev=elev_ana, uv_init=uv_ana)
     if solver_parameters is not None:
@@ -253,8 +253,8 @@ def run(setup, refinement, order, do_export=True, options=None,
 
     elev_l2_err = errornorm(elev_ana_ho, solver_obj.fields.solution_2d.split()[1])/numpy.sqrt(area)
     uv_l2_err = errornorm(uv_ana_ho, solver_obj.fields.solution_2d.split()[0])/numpy.sqrt(area)
-    print 'elev L2 error {:.12f}'.format(elev_l2_err)
-    print 'uv L2 error {:.12f}'.format(uv_l2_err)
+    print_output('elev L2 error {:.12f}'.format(elev_l2_err))
+    print_output('uv L2 error {:.12f}'.format(uv_l2_err))
     return elev_l2_err, uv_l2_err
 
 
@@ -299,14 +299,14 @@ def run_convergence(setup, ref_list, order, do_export=False, save_plot=False,
             imgfile += '.png'
             img_dir = create_directory('plots')
             imgfile = os.path.join(img_dir, imgfile)
-            print 'saving figure', imgfile
+            print_output('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
             assert abs(slope - expected_slope)/expected_slope < slope_rtol, err_msg
-            print '{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope)
+            print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
     check_convergence(x_log, y_log_elev, order+1, 'elev', save_plot)

--- a/test/swe2d/test_steady_state_channel.py
+++ b/test/swe2d/test_steady_state_channel.py
@@ -62,9 +62,9 @@ def test_steady_state_channel(do_export=False):
     area = lx*ly
     l2norm = errornorm(eta_ana, eta)/math.sqrt(area)
     rel_err = math.sqrt(l2norm/area)
-    print rel_err
+    print_output(rel_err)
     assert(rel_err < 1e-3)
-    print "PASSED"
+    print_output("PASSED")
 
 
 if __name__ == '__main__':

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -114,19 +114,19 @@ def test_steady_state_channel_mms(options):
     # NOTE: these currently only pass for order==1
     expected_order = order + 1
     eta_errs = numpy.array(eta_errs)
-    print 'eta errors:', eta_errs
-    print 'convergence:', eta_errs[:-1]/eta_errs[1:], eta_errs[0]/eta_errs[-1]
+    print_output('eta errors: {:}'.format(eta_errs))
+    print_output('convergence: {:} {:}'.format(eta_errs[:-1]/eta_errs[1:], eta_errs[0]/eta_errs[-1]))
     assert(all(eta_errs[:-1]/eta_errs[1:] > 2.**expected_order*0.75))
     assert(eta_errs[0]/eta_errs[-1] > (2.**expected_order)**(len(eta_errs)-1)*0.75)
-    print "PASSED"
+    print_output("PASSED")
 
     expected_order = order + 1
     u_errs = numpy.array(u_errs)
-    print 'u errors:', u_errs
-    print 'convergence:', u_errs[:-1]/u_errs[1:], u_errs[0]/u_errs[-1]
+    print_output('u errors: {:}'.format(u_errs))
+    print_output('convergence: {:} {:}'.format(u_errs[:-1]/u_errs[1:], u_errs[0]/u_errs[-1]))
     assert(all(u_errs[:-1]/u_errs[1:] > 2.**expected_order*0.75))
     assert(u_errs[0]/u_errs[-1] > (2.**expected_order)**(len(u_errs)-1)*0.75)
-    print "PASSED"
+    print_output("PASSED")
 
 
 if __name__ == '__main__':

--- a/test/tracerEq/test_consistency.py
+++ b/test/tracerEq/test_consistency.py
@@ -37,7 +37,7 @@ def run_tracer_consistency(element_family='dg-dg', meshtype='regular', do_export
         warped = True
 
     run_description = 'element_family={:} meshtype={:}'.format(element_family, meshtype)
-    print_info('Running test: ' + run_description)
+    print_output('Running test: ' + run_description)
 
     suffix = ''
     if sloped:

--- a/test/tracerEq/test_h-diffusion_mes.py
+++ b/test/tracerEq/test_h-diffusion_mes.py
@@ -10,7 +10,7 @@ import pytest
 
 
 def run(refinement, order=1, warped_mesh=False, do_export=True):
-    print '--- running refinement {:}'.format(refinement)
+    print_output('--- running refinement {:}'.format(refinement))
     # domain dimensions - channel in x-direction
     lx = 15.0e3
     ly = 6.0e3/refinement
@@ -114,7 +114,7 @@ def run(refinement, order=1, warped_mesh=False, do_export=True):
         t += dt
         i += 1
         if t >= next_export_t - 1e-8:
-            print('{:3d} i={:5d} t={:8.2f} s salt={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.salt_3d)))
+            print_output('{:3d} i={:5d} t={:8.2f} s salt={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.salt_3d)))
             export_func()
             next_export_t += solverobj.options.t_export
             iexport += 1
@@ -125,7 +125,7 @@ def run(refinement, order=1, warped_mesh=False, do_export=True):
     salt_ana_ho.project(ana_salt_expr)
     # compute L2 norm
     l2_err = errornorm(salt_ana_ho, solverobj.fields.salt_3d)/numpy.sqrt(area)
-    print 'L2 error {:.12f}'.format(l2_err)
+    print_output('L2 error {:.12f}'.format(l2_err))
 
     return l2_err
 
@@ -169,14 +169,14 @@ def run_convergence(ref_list, saveplot=False, **options):
             imgfile += '.png'
             imgdir = create_directory('plots')
             imgfile = os.path.join(imgdir, imgfile)
-            print 'saving figure', imgfile
+            print_output('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
             assert slope > expected_slope*(1 - slope_rtol), err_msg
-            print '{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope)
+            print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
     check_convergence(x_log, y_log, order+1, 'salt', saveplot)

--- a/test/tracerEq/test_steady_adv-diff_mms.py
+++ b/test/tracerEq/test_steady_adv-diff_mms.py
@@ -151,7 +151,7 @@ def setup4dg(lx, ly, h0, kappa0):
 
 def run(setup, refinement, order, do_export=True):
     """Run single test and return L2 error"""
-    print '--- running {:} refinement {:}'.format(setup.__name__, refinement)
+    print_output('--- running {:} refinement {:}'.format(setup.__name__, refinement))
     # domain dimensions
     lx = 15e3
     ly = 10e3
@@ -258,7 +258,7 @@ def run(setup, refinement, order, do_export=True):
         solver_obj.export()
 
     l2_err = errornorm(trac_ana_ho, solver_obj.fields.salt_3d)/numpy.sqrt(area)
-    print 'L2 error {:.12f}'.format(l2_err)
+    print_output('L2 error {:.12f}'.format(l2_err))
 
     return l2_err
 
@@ -300,14 +300,14 @@ def run_convergence(setup, ref_list, order, do_export=False, save_plot=False):
             imgfile += '.png'
             img_dir = create_directory('plots')
             imgfile = os.path.join(img_dir, imgfile)
-            print 'saving figure', imgfile
+            print_output('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
             assert abs(slope - expected_slope)/expected_slope < slope_rtol, err_msg
-            print '{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope)
+            print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
     check_convergence(x_log, y_log, order+1, 'tracer', save_plot)

--- a/test/tracerEq/test_v-diffusion_mes.py
+++ b/test/tracerEq/test_v-diffusion_mes.py
@@ -10,7 +10,7 @@ import pytest
 
 
 def run(refinement, order=1, implicit=False, do_export=True):
-    print '--- running refinement {:}'.format(refinement)
+    print_output('--- running refinement {:}'.format(refinement))
     # domain dimensions - channel in x-direction
     lx = 7.0e3
     ly = 5.0e3
@@ -109,7 +109,7 @@ def run(refinement, order=1, implicit=False, do_export=True):
         t += dt
         i += 1
         if t >= next_export_t - 1e-8:
-            print('{:3d} i={:5d} t={:8.2f} s salt={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.salt_3d)))
+            print_output('{:3d} i={:5d} t={:8.2f} s salt={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.salt_3d)))
             export_func()
             next_export_t += solverobj.options.t_export
             iexport += 1
@@ -120,7 +120,7 @@ def run(refinement, order=1, implicit=False, do_export=True):
     salt_ana_ho.project(ana_salt_expr)
     # compute L2 norm
     l2_err = errornorm(salt_ana_ho, solverobj.fields.salt_3d)/numpy.sqrt(area)
-    print 'L2 error {:.12f}'.format(l2_err)
+    print_output('L2 error {:.12f}'.format(l2_err))
 
     return l2_err
 
@@ -164,14 +164,14 @@ def run_convergence(ref_list, saveplot=False, **options):
             imgfile += '.png'
             imgdir = create_directory('plots')
             imgfile = os.path.join(imgdir, imgfile)
-            print 'saving figure', imgfile
+            print_output('saving figure {:}'.format(imgfile))
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
             assert slope > expected_slope*(1 - slope_rtol), err_msg
-            print '{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope)
+            print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
-            print '{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope)
+            print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
     check_convergence(x_log, y_log, order+1, 'salt', saveplot)

--- a/thetis/__init__.py
+++ b/thetis/__init__.py
@@ -3,6 +3,7 @@ import timeintegrator  # NOQA
 import solver  # NOQA
 import solver2d  # NOQA
 from callback import DiagnosticCallback  # NOQA
+from log import *
 
-op2.init(log_level=WARNING)  # DEBUG, INFO, WARNING, ERROR, CRITICAL
+op2.init(log_level=WARNING)
 parameters['assembly_cache']['enabled'] = False

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -129,8 +129,7 @@ class DiagnosticCallback(object):
 
     def push_to_log(self, time, args):
         """Print diagnostic status message to log"""
-        # TODO update to use real logger object
-        print_info(self.__str__(args))
+        print_output(self.__str__(args))
 
     def push_to_hdf5(self, solver_obj, time, args):
         """Append values to export file."""

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -8,6 +8,7 @@ from .utility import *
 from abc import ABCMeta, abstractproperty, abstractmethod
 import h5py
 from collections import defaultdict
+from .log import *
 
 
 class CallbackManager(defaultdict):

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -6,6 +6,7 @@ Tuomas Karna 2015-07-06
 from __future__ import absolute_import
 from .utility import *
 from . import timeintegrator
+from .log import *
 
 # TODO turbulence update. move out from _update_all_dependencies ?
 

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -275,9 +275,9 @@ class CoupledSSPRKSync(CoupledTimeIntegrator):
         for i in range(1, len(self.dt_frac)):
             prev_end_time = self.start_frac[i-1] + self.dt_frac[i-1]
             self.stage_w.append(prev_end_time*(1.0 - self.start_frac[i]))
-        print_info('dt_frac ' + str(self.dt_frac))
-        print_info('start_frac ' + str(self.start_frac))
-        print_info('stage_w ' + str(self.stage_w))
+        print_output('dt_frac ' + str(self.dt_frac))
+        print_output('start_frac ' + str(self.start_frac))
+        print_output('stage_w ' + str(self.stage_w))
 
     def initialize(self):
         """Assign initial conditions to all necessary fields"""
@@ -294,7 +294,7 @@ class CoupledSSPRKSync(CoupledTimeIntegrator):
         for i, f in enumerate(self.dt_frac):
             m = int(np.ceil(f*self.solver.dt/self.solver.dt_2d))
             dt = f*self.solver.dt/m
-            print_info('stage {0:d} {1:.6f} {2:d} {3:.4f}'.format(i, dt, m, f))
+            print_output('stage {0:d} {1:.6f} {2:d} {3:.4f}'.format(i, dt, m, f))
             self.M.append(m)
             self.dt_2d.append(dt)
         self._initialized = True
@@ -617,9 +617,9 @@ class CoupledSSPRKSemiImplicit(CoupledTimeIntegrator):
         for i in range(1, len(self.dt_frac)):
             prev_end_time = self.start_frac[i-1] + self.dt_frac[i-1]
             self.stage_w.append(prev_end_time*(1.0 - self.start_frac[i]))
-        print_info('dt_frac ' + str(self.dt_frac))
-        print_info('start_frac ' + str(self.start_frac))
-        print_info('stage_w ' + str(self.stage_w))
+        print_output('dt_frac ' + str(self.dt_frac))
+        print_output('start_frac ' + str(self.start_frac))
+        print_output('stage_w ' + str(self.stage_w))
         self.n_stages = self.timestepper_mom_3d.n_stages
 
     def initialize(self):
@@ -643,7 +643,7 @@ class CoupledSSPRKSemiImplicit(CoupledTimeIntegrator):
         for i, f in enumerate(self.dt_frac):
             m = int(np.ceil(f*self.solver.dt/self.solver.dt_2d))
             dt = f*self.solver.dt/m
-            print_info('stage {0:d} {1:.6f} {2:d} {3:.4f}'.format(i, dt, m, f))
+            print_output('stage {0:d} {1:.6f} {2:d} {3:.4f}'.format(i, dt, m, f))
             self.M.append(m)
             self.dt_2d.append(dt)
         self._initialized = True

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -260,7 +260,7 @@ class NaiveFieldExporter(ExporterBase):
 
             filename = self.gen_filename(iexport)
             if self.verbose:
-                print 'saving state to', filename
+                print_output('saving state to %s', filename)
             np.savez(filename, xyz=self.xyz, connectivity=self.connectivity,
                      data=global_data)
         self.next_export_ix = iexport+1
@@ -283,7 +283,7 @@ class NaiveFieldExporter(ExporterBase):
         if comm.rank == 0:
             filename = self.gen_filename(iexport)
             if self.verbose:
-                print 'loading state from', filename
+                print_output('loading state from %s', filename)
             npzfile = np.load(filename)
             global_data = npzfile['data']
             assert global_data.shape[0] == self.n_global_nodes,\
@@ -334,7 +334,7 @@ class HDF5Exporter(ExporterBase):
             'Function space does not match'
         filename = self.gen_filename(iexport)
         if self.verbose:
-            print('saving {:} state to {:}'.format(function.name(), filename))
+            print_output('saving {:} state to {:}'.format(function.name(), filename))
         with DumbCheckpoint(filename, mode=FILE_CREATE, comm=function.comm) as f:
             f.store(function)
         self.next_export_ix = iexport + 1
@@ -354,7 +354,7 @@ class HDF5Exporter(ExporterBase):
             'Function space does not match'
         filename = self.gen_filename(iexport)
         if self.verbose:
-            print('loading {:} state from {:}'.format(function.name(), filename))
+            print_output('loading {:} state from {:}'.format(function.name(), filename))
         with DumbCheckpoint(filename, mode=FILE_READ, comm=function.comm) as f:
             f.load(function)
 

--- a/thetis/log.py
+++ b/thetis/log.py
@@ -1,0 +1,49 @@
+"""
+Loggers for Thetis
+
+Creates two logger instances, one for general model output and one for debug,
+warning, error etc. messages.
+
+To print to the model output stream, use :func:`~.print_output`.
+
+Debug, warning etc. messages are issued with :func:`~.debug`, :func:`~.info`,
+:func:`~.warning`, :func:`~.error`, :func:`~.critical` methods.
+"""
+
+from thetis.utility import COMM_WORLD
+import logging
+
+__all__ = ('logger', 'output_logger',
+           'debug', 'info', 'warning', 'error', 'critical', 'print_output')
+
+
+def get_new_logger(name, fmt='%(levelname)s %(message)s'):
+    logger = logging.getLogger(name)
+
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt))
+
+    if COMM_WORLD.rank != 0:
+        handler = logging.NullHandler()
+
+    logger.addHandler(handler)
+    return logger
+
+
+# create conventional logger for error etc messages
+logger = get_new_logger('thetis')
+logger.setLevel(logging.DEBUG)
+log = logger.log
+debug = logger.debug
+info = logger.info
+warning = logger.warning
+error = logger.error
+critical = logger.critical
+
+# create additional logger for model output
+output_logger = get_new_logger('thetis_output', fmt='%(message)s')
+output_logger.setLevel(logging.INFO)
+print_output = output_logger.info

--- a/thetis/log.py
+++ b/thetis/log.py
@@ -9,7 +9,6 @@ To print to the model output stream, use :func:`~.print_output`.
 Debug, warning etc. messages are issued with :func:`~.debug`, :func:`~.info`,
 :func:`~.warning`, :func:`~.error`, :func:`~.critical` methods.
 """
-
 from thetis.utility import COMM_WORLD
 import logging
 

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -18,6 +18,7 @@ import weakref
 from .field_defs import field_metadata
 from .options import ModelOptions
 from . import callback
+from .log import *
 
 
 class FlowSolver(FrozenClass):
@@ -99,9 +100,8 @@ class FlowSolver(FrozenClass):
             self.dt_2d = self.dt
             self.M_modesplit = 1
 
-        print_output('dt = {0:f}'.format(self.dt), comm=comm)
-        print_output('2D dt = {0:f} {1:d}'.format(self.dt_2d, self.M_modesplit),
-                     comm=comm)
+        print_output('dt = {0:f}'.format(self.dt))
+        print_output('2D dt = {0:f} {1:d}'.format(self.dt_2d, self.M_modesplit))
         sys.stdout.flush()
 
     def create_function_spaces(self):

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -652,13 +652,12 @@ class FlowSolver(FrozenClass):
         norm_h = norm(self.fields.elev_2d)
         norm_u = norm(self.fields.uv_3d)
 
-        comm = self.comm
-        if comm.rank == 0:
-            line = ('{iexp:5d} {i:5d} T={t:10.2f} '
-                    'eta norm: {e:10.4f} u norm: {u:10.4f} {cpu:5.2f}')
-            print(line.format(iexp=self.i_export, i=self.iteration, t=self.simulation_time, e=norm_h,
-                              u=norm_u, cpu=cputime))
-            sys.stdout.flush()
+        line = ('{iexp:5d} {i:5d} T={t:10.2f} '
+                'eta norm: {e:10.4f} u norm: {u:10.4f} {cpu:5.2f}')
+        print_output(line.format(iexp=self.i_export, i=self.iteration,
+                                 t=self.simulation_time, e=norm_h,
+                                 u=norm_u, cpu=cputime))
+        sys.stdout.flush()
 
     def iterate(self, update_forcings=None, update_forcings3d=None,
                 export_func=None):

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -99,9 +99,9 @@ class FlowSolver(FrozenClass):
             self.dt_2d = self.dt
             self.M_modesplit = 1
 
-        print_info('dt = {0:f}'.format(self.dt), comm=comm)
-        print_info('2D dt = {0:f} {1:d}'.format(self.dt_2d, self.M_modesplit),
-                   comm=comm)
+        print_output('dt = {0:f}'.format(self.dt), comm=comm)
+        print_output('2D dt = {0:f} {1:d}'.format(self.dt_2d, self.M_modesplit),
+                     comm=comm)
         sys.stdout.flush()
 
     def create_function_spaces(self):
@@ -386,14 +386,14 @@ class FlowSolver(FrozenClass):
                 self.timestepper = coupled_timeintegrator.CoupledSSPRKSync(weakref.proxy(self))
         else:
             self.timestepper = coupled_timeintegrator.CoupledSSPRKSingleMode(weakref.proxy(self))
-        print_info('using {:} time integrator'.format(self.timestepper.__class__.__name__))
+        print_output('using {:} time integrator'.format(self.timestepper.__class__.__name__))
 
         # compute maximal diffusivity for explicit schemes
         degree_h, degree_v = self.function_spaces.H.ufl_element().degree()
         max_diff_alpha = 1.0/360.0/max((degree_h*(degree_h + 1)), 1.0)  # FIXME depends on element type and order
         self.fields.max_h_diff.assign(max_diff_alpha/self.dt * self.fields.h_elem_size_3d**2)
         d = self.fields.max_h_diff.dat.data
-        print_info('max h diff {:} - {:}'.format(d.min(), d.max()))
+        print_output('max h diff {:} - {:}'.format(d.min(), d.max()))
 
         # ----- File exporters
         # create export_managers and store in a list

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -13,6 +13,7 @@ from . import exporter
 from .field_defs import field_metadata
 from .options import ModelOptions
 from . import callback
+from .log import *
 
 
 class FlowSolver2d(FrozenClass):

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -63,7 +63,7 @@ class FlowSolver2d(FrozenClass):
             dt = self.comm.allreduce(dt, op=MPI.MIN)
             self.dt = dt
         if self.comm.rank == 0:
-            print 'dt =', self.dt
+            print_output('dt = {:}'.format(self.dt))
             sys.stdout.flush()
 
     def create_function_spaces(self):
@@ -302,12 +302,12 @@ class FlowSolver2d(FrozenClass):
         norm_h = norm(self.fields.solution_2d.split()[1])
         norm_u = norm(self.fields.solution_2d.split()[0])
 
-        if self.comm.rank == 0:
-            line = ('{iexp:5d} {i:5d} T={t:10.2f} '
-                    'eta norm: {e:10.4f} u norm: {u:10.4f} {cpu:5.2f}')
-            print(line.format(iexp=self.i_export, i=self.iteration, t=self.simulation_time, e=norm_h,
-                              u=norm_u, cpu=cputime))
-            sys.stdout.flush()
+        line = ('{iexp:5d} {i:5d} T={t:10.2f} '
+                'eta norm: {e:10.4f} u norm: {u:10.4f} {cpu:5.2f}')
+        print_output(line.format(iexp=self.i_export, i=self.iteration,
+                                 t=self.simulation_time, e=norm_h,
+                                 u=norm_u, cpu=cputime))
+        sys.stdout.flush()
 
     def iterate(self, update_forcings=None,
                 export_func=None):

--- a/thetis/stability_functions.py
+++ b/thetis/stability_functions.py
@@ -34,8 +34,8 @@ def compute_normalized_frequencies(shear2, buoy2, k, eps):
     """
     alpha_buoy = k**2/eps**2*buoy2
     alpha_shear = k**2/eps**2*shear2
-    # print '{:8s} {:8.3e} {:8.3e}'.format('M2', shear2.min(), shear2.max())
-    # print '{:8s} {:8.3e} {:8.3e}'.format('N2', buoy2.min(), buoy2.max())
+    # print_output('{:8s} {:8.3e} {:8.3e}'.format('M2', shear2.min(), shear2.max()))
+    # print_output('{:8s} {:8.3e} {:8.3e}'.format('N2', buoy2.min(), buoy2.max()))
     # print_output('{:8s} {:10.3e} {:10.3e}'.format('a_buoy', alpha_buoy.min(), alpha_buoy.max()))
     # print_output('{:8s} {:10.3e} {:10.3e}'.format('a_shear', alpha_shear.min(), alpha_shear.max()))
     return alpha_buoy, alpha_shear

--- a/thetis/stability_functions.py
+++ b/thetis/stability_functions.py
@@ -36,8 +36,8 @@ def compute_normalized_frequencies(shear2, buoy2, k, eps):
     alpha_shear = k**2/eps**2*shear2
     # print '{:8s} {:8.3e} {:8.3e}'.format('M2', shear2.min(), shear2.max())
     # print '{:8s} {:8.3e} {:8.3e}'.format('N2', buoy2.min(), buoy2.max())
-    # print_info('{:8s} {:10.3e} {:10.3e}'.format('a_buoy', alpha_buoy.min(), alpha_buoy.max()))
-    # print_info('{:8s} {:10.3e} {:10.3e}'.format('a_shear', alpha_shear.min(), alpha_shear.max()))
+    # print_output('{:8s} {:10.3e} {:10.3e}'.format('a_buoy', alpha_buoy.min(), alpha_buoy.max()))
+    # print_output('{:8s} {:10.3e} {:10.3e}'.format('a_shear', alpha_shear.min(), alpha_shear.max()))
     return alpha_buoy, alpha_shear
 
 

--- a/thetis/turbulence.py
+++ b/thetis/turbulence.py
@@ -222,9 +222,9 @@ class GLSModelOptions(AttrDict):
 
     def print_summary(self):
         """Prints all defined parameters and their values."""
-        print_info('GLS Turbulence model parameters')
+        print_output('GLS Turbulence model parameters')
         for k in sorted(self.keys()):
-            print_info('  {:16s} : {:}'.format(k, self[k]))
+            print_output('  {:16s} : {:}'.format(k, self[k]))
 
 
 def set_func_min_val(f, minval):

--- a/thetis/turbulence.py
+++ b/thetis/turbulence.py
@@ -648,7 +648,7 @@ class GenericLengthScaleModel(object):
                 len_max = np.sqrt(galp*k_arr/(n2_pos + n2_pos_eps))
                 np.minimum(self.l.dat.data, len_max, self.l.dat.data)
             if self.l.dat.data.max() > 10.0:
-                print ' * large L: {:f}'.format(self.l.dat.data.max())
+                warning(' * large L: {:f}'.format(self.l.dat.data.max()))
 
             # update stability functions
             s_m, s_h = self.stability_func.evaluate(self.m2.dat.data,
@@ -669,17 +669,17 @@ class GenericLengthScaleModel(object):
             set_func_min_val(self.viscosity, o.visc_min)
             set_func_min_val(self.diffusivity, o.diff_min)
 
-            # print '{:8s} {:10.3e} {:10.3e}'.format('k', self.k.dat.data.min(), self.k.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('eps', self.epsilon.dat.data.min(), self.epsilon.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('L', self.l.dat.data.min(), self.l.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('M2', self.m2.dat.data.min(), self.m2.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('N2', self.n2.dat.data.min(), self.n2.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('N2+', self.n2_pos.dat.data.min(), self.n2_pos.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('N2-', self.n2_neg.dat.data.min(), self.n2_neg.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('s_h', s_h.min(), s_h.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('s_m', s_m.min(), s_m.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('nuv', self.viscosity.dat.data.min(), self.viscosity.dat.data.max())
-            # print '{:8s} {:10.3e} {:10.3e}'.format('muv', self.diffusivity.dat.data.min(), self.diffusivity.dat.data.max())
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('k', self.k.dat.data.min(), self.k.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('eps', self.epsilon.dat.data.min(), self.epsilon.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('L', self.l.dat.data.min(), self.l.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('M2', self.m2.dat.data.min(), self.m2.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('N2', self.n2.dat.data.min(), self.n2.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('N2+', self.n2_pos.dat.data.min(), self.n2_pos.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('N2-', self.n2_neg.dat.data.min(), self.n2_neg.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('s_h', s_h.min(), s_h.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('s_m', s_m.min(), s_m.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('nuv', self.viscosity.dat.data.min(), self.viscosity.dat.data.max()))
+            # print_output('{:8s} {:10.3e} {:10.3e}'.format('muv', self.diffusivity.dat.data.min(), self.diffusivity.dat.data.max()))
 
 
 class TKESourceTerm(TracerTerm):

--- a/thetis/turbulence.py
+++ b/thetis/turbulence.py
@@ -68,6 +68,7 @@ from __future__ import absolute_import
 from .tracer_eq import *
 from .utility import *
 from .stability_functions import *
+from .log import *
 
 
 class GLSModelOptions(AttrDict):

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -95,7 +95,6 @@ class FieldDict(AttrDict):
                         (isinstance(fs, WithGeometry) and
                          isinstance(fs.topological, MixedFunctionSpace)))
             if not is_mixed and key not in field_metadata:
-                print type(fs)
                 msg = 'Trying to add a field "{:}" that has no metadata. ' \
                       'Add field_metadata entry to field_defs.py'.format(key)
                 raise Exception(msg)
@@ -114,11 +113,6 @@ class FieldDict(AttrDict):
         self._check_inputs(key, value)
         self._set_functionname(key, value)
         super(FieldDict, self).__setattr__(key, value)
-
-
-def print_info(msg, comm=COMM_WORLD):
-    if comm.rank == 0:
-        print(msg)
 
 
 ElementContinuity = namedtuple("ElementContinuity", ["dg", "horizontal_dg", "vertical_dg"])


### PR DESCRIPTION
Use python logger for model output and errors.

Implements two loggers:

- one for generic model output messages, issued with `print_output`. This is at `INFO` level. Will only print the message with no header:

```
>>> print_output('some output')
some output
```
- one for debug, warning, error etc messages, issued with `debug`, `warning`, `error`, ... Prints log level as a header:

```
>>> warning('some warning')
WARNING some warning
```

Sits on top of #55 .