### PR TITLE
Viscosity for DG0/RT spaces

### DIFF
--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -101,9 +101,9 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
 
     u_max = 1.0
     w_max = 1.2e-2
-    dt_hor_adv = 1.0/20.0*delta_x/np.sqrt(2)/u_max
-    dt_vert_adv = 1.0/3.0*delta_z/w_max
-    dt_visc = 1.0/120.0*(delta_x/np.sqrt(2))**2/nu_scale
+    dt_hor_adv = 1.0/10.0/(poly_order + 1)*delta_x/np.sqrt(2)/u_max
+    dt_vert_adv = 1.0/1.5/(poly_order + 1)*delta_z/w_max
+    dt_visc = 1.0/60.0/(poly_order + 1)*(delta_x/np.sqrt(2))**2/nu_scale
     print_output('Max dt for hor. advection: {:}'.format(dt_hor_adv))
     print_output('Max dt for vert. advection: {:}'.format(dt_vert_adv))
     print_output('Max dt for viscosity: {:}'.format(dt_visc))

--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -101,9 +101,10 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
 
     u_max = 1.0
     w_max = 1.2e-2
-    dt_hor_adv = 1.0/10.0/(poly_order + 1)*delta_x/np.sqrt(2)/u_max
-    dt_vert_adv = 1.0/1.5/(poly_order + 1)*delta_z/w_max
-    dt_visc = 1.0/60.0/(poly_order + 1)*(delta_x/np.sqrt(2))**2/nu_scale
+    dt_factor = 0.5 if element_family == 'rt-dg' else 1.0
+    dt_hor_adv = dt_factor*1.0/10.0/(poly_order + 1)*delta_x/np.sqrt(2)/u_max
+    dt_vert_adv = dt_factor*1.0/1.5/(poly_order + 1)*delta_z/w_max
+    dt_visc = dt_factor*1.0/60.0/(poly_order + 1)*(delta_x/np.sqrt(2))**2/nu_scale
     print_output('Max dt for hor. advection: {:}'.format(dt_hor_adv))
     print_output('Max dt for vert. advection: {:}'.format(dt_vert_adv))
     print_output('Max dt for viscosity: {:}'.format(dt_visc))

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -186,7 +186,11 @@ def run_convergence(ref_list, saveplot=False, **options):
 # ---------------------------
 
 # NOTE mimetic elements do not converge optimally, rate is 1.48
-# NOTE h. viscosity does not work for p0 yet
+
+
+@pytest.fixture(params=[0, 1])
+def order(request):
+    return request.param
 
 
 @pytest.fixture(params=[True, False], ids=['warped', 'regular'])
@@ -194,12 +198,12 @@ def warped(request):
     return request.param
 
 
-def test_horizontal_viscosity(warped):
-    run_convergence([1, 2, 3], order=1, warped_mesh=warped)
+def test_horizontal_viscosity(warped, order):
+    run_convergence([1, 2, 3], order=order, warped_mesh=warped)
 
 # ---------------------------
 # run individual setup for debugging
 # ---------------------------
 
 if __name__ == '__main__':
-    run_convergence([1, 2, 3], order=1, warped_mesh=True, element_family='dg-dg', do_export=True, saveplot=True)
+    run_convergence([1, 2, 3], order=0, warped_mesh=False, element_family='dg-dg', do_export=True, saveplot=True)

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -27,7 +27,7 @@ def run(refinement, order=1, element_family='dg-dg', warped_mesh=False, do_expor
     # set time steps
     # stable explicit time step for diffusion
     dx = lx/nx
-    alpha = 1.0/200.0  # TODO theoretical alpha...
+    alpha = 1.0/350.0  # TODO theoretical alpha...
     dt = alpha * dx**2/h_viscosity
     # simulation run time
     t_end = 3000.0
@@ -188,22 +188,23 @@ def run_convergence(ref_list, saveplot=False, **options):
 # NOTE mimetic elements do not converge optimally, rate is 1.48
 
 
-@pytest.fixture(params=[0, 1])
-def order(request):
-    return request.param
-
-
 @pytest.fixture(params=[True, False], ids=['warped', 'regular'])
 def warped(request):
     return request.param
 
 
-def test_horizontal_viscosity(warped, order):
-    run_convergence([1, 2, 3], order=order, warped_mesh=warped)
+@pytest.mark.parametrize(('family', 'order'),
+                         [('dg-dg', 0),
+                          ('dg-dg', 1),
+                          pytest.mark.xfail(reason='rt-0 still broken')(('rt-dg', 0)),
+                          ('rt-dg', 1)])
+def test_horizontal_viscosity(warped, order, family):
+    run_convergence([1, 2, 3], order=order, warped_mesh=warped,
+                    element_family=family)
 
 # ---------------------------
 # run individual setup for debugging
 # ---------------------------
 
 if __name__ == '__main__':
-    run_convergence([1, 2, 3], order=0, warped_mesh=False, element_family='dg-dg', do_export=True, saveplot=True)
+    run_convergence([1, 2, 3], order=1, warped_mesh=True, element_family='rt-dg', do_export=True, saveplot=True)

--- a/test/tracerEq/test_h-diffusion_mes.py
+++ b/test/tracerEq/test_h-diffusion_mes.py
@@ -80,7 +80,8 @@ def run(refinement, order=1, warped_mesh=False, do_export=True):
     salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
     salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
 
-    p1dg_ho = FunctionSpace(solverobj.mesh, 'DG', order + 2)
+    p1dg_ho = FunctionSpace(solverobj.mesh, 'DG', order + 2,
+                            vfamily='DG', vdegree=order + 2)
     salt_ana_ho = Function(p1dg_ho, name='salt analytical')
 
     elev_init = Function(solverobj.function_spaces.H_2d, name='elev init')
@@ -186,17 +187,22 @@ def run_convergence(ref_list, saveplot=False, **options):
 # ---------------------------
 
 
+@pytest.fixture(params=[0, 1])
+def order(request):
+    return request.param
+
+
 @pytest.fixture(params=[True, False], ids=['warped', 'regular'])
 def warped(request):
     return request.param
 
 
-def test_horizontal_diffusion(warped):
-    run_convergence([1, 2, 3], order=1, warped_mesh=warped)
+def test_horizontal_diffusion(warped, order):
+    run_convergence([1, 2, 3], order=order, warped_mesh=warped)
 
 # ---------------------------
 # run individual setup for debugging
 # ---------------------------
 
 if __name__ == '__main__':
-    run_convergence([1, 2, 3], order=1, warped_mesh=True, do_export=True, saveplot=True)
+    run_convergence([1, 2, 3], order=0, warped_mesh=False, do_export=True, saveplot=True)

--- a/test/tracerEq/test_v-diffusion_mes.py
+++ b/test/tracerEq/test_v-diffusion_mes.py
@@ -181,7 +181,7 @@ def run_convergence(ref_list, saveplot=False, **options):
 # ---------------------------
 
 
-@pytest.fixture(params=[0, 1], ids=['order-0', 'order-1'])
+@pytest.fixture(params=[0, 1])
 def order(request):
     return request.param
 
@@ -199,5 +199,4 @@ def test_vertical_diffusion(order, implicit):
 # ---------------------------
 
 if __name__ == '__main__':
-    # run(2, order=0, implicit=True)
-    run_convergence([1, 2, 3], order=1, implicit=True)
+    run_convergence([1, 2, 3], order=0, implicit=True)

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -439,7 +439,7 @@ class CoupledSSPIMEX(CoupledTimeIntegrator):
                 if self.options.solve_salt:
                     self.timestepper_salt_3d.solve_stage(k, t, self.solver.dt, self.fields.salt_3d,
                                                          update_forcings3d)
-                    if self.options.use_limiter_for_tracers and last_step:
+                    if self.options.use_limiter_for_tracers:
                         self.solver.tracer_limiter.apply(self.fields.salt_3d)
             with timed_stage('momentum_eq'):
                 self.timestepper_mom_3d.solve_stage(k, t, self.solver.dt, self.fields.uv_3d)

--- a/thetis/momentum_eq.py
+++ b/thetis/momentum_eq.py
@@ -256,7 +256,7 @@ class HorizontalViscosityTerm(MomentumTerm):
                         self.v_elem_size*self.normal[2]**2)
             sigma = 5.0*degree_h*(degree_h + 1)/elemsize
             if degree_h == 0:
-                raise NotImplementedError('horizontal visc not implemented for p0')
+                sigma = 1.5/elemsize
             alpha = avg(sigma)
             ds_interior = (self.dS_h + self.dS_v)
             f += alpha*inner(tensor_jump(self.normal, self.test),

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -47,8 +47,10 @@ class ShallowWaterTerm(Term):
         # define measures with a reasonable quadrature degree
         p = self.function_space.ufl_element().degree()
         self.quad_degree = 2*p + 1
-        self.dx = dx(degree=self.quad_degree)
-        self.dS = dS(degree=self.quad_degree)
+        self.dx = dx(degree=self.quad_degree,
+                     domain=self.function_space.ufl_domain())
+        self.dS = dS(degree=self.quad_degree,
+                     domain=self.function_space.ufl_domain())
 
     def get_bnd_functions(self, eta_in, uv_in, bnd_id, bnd_conditions):
         """
@@ -324,6 +326,8 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
             # with X=2, theta=6: cot(theta)~10, 3*X*cot(theta)~60
             p = self.u_space.ufl_element().degree()
             alpha = 5.*p*(p+1)
+            if p == 0:
+                alpha = 1.5
             f += (
                 + alpha/avg(h)*inner(tensor_jump(self.u_test, n), stress_jump)*self.dS
                 - inner(avg(grad(self.u_test)), stress_jump)*self.dS

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -287,7 +287,7 @@ class FlowSolver(FrozenClass):
             self.fields.smag_visc_3d = Function(self.function_spaces.P1)
         if self.options.salt_jump_diff_factor is not None:
             self.fields.salt_jump_diff = Function(self.function_spaces.P1)
-        if self.options.use_limiter_for_tracers:
+        if self.options.use_limiter_for_tracers and self.options.order > 0:
             self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.H)
         else:
             self.tracer_limiter = None
@@ -719,6 +719,7 @@ class FlowSolver(FrozenClass):
         self.options.check_temp_conservation *= self.options.solve_temp
         self.options.check_temp_overshoot *= self.options.solve_temp
         self.options.check_vol_conservation_3d *= self.options.use_ale_moving_mesh
+        self.options.use_limiter_for_tracers *= self.options.order > 0
 
         t_epsilon = 1.0e-5
         cputimestamp = time_mod.clock()

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -561,7 +561,8 @@ class FlowSolver(FrozenClass):
         if self.options.smagorinsky_factor is not None:
             self.smagorinsky_diff_solver = SmagorinskyViscosity(self.fields.uv_p1_3d, self.fields.smag_visc_3d,
                                                                 self.options.smagorinsky_factor, self.fields.h_elem_size_3d,
-                                                                self.fields.max_h_diff)
+                                                                self.fields.max_h_diff,
+                                                                weak_form=self.options.order == 0)
         if self.options.use_parabolic_viscosity:
             self.parabolic_viscosity_solver = ParabolicViscosity(self.fields.uv_bottom_3d,
                                                                  self.fields.bottom_drag_3d,

--- a/thetis/tracer_eq.py
+++ b/thetis/tracer_eq.py
@@ -201,7 +201,7 @@ class HorizontalDiffusionTerm(TracerTerm):
                         self.v_elem_size*self.normal[2]**2)
             sigma = 5.0*degree_h*(degree_h + 1)/elemsize
             if degree_h == 0:
-                raise NotImplementedError('horizontal diffusion not implemented for p0')
+                sigma = 1.5/elemsize
             alpha = avg(sigma)
             ds_interior = (self.dS_h + self.dS_v)
             f += alpha*inner(jump(self.test, self.normal),


### PR DESCRIPTION
Updated diffusion operators to handle DG0/RT spaces. DG0 uses the same IP term implementation, only a different penalty parameter value.

Sits on top of #62.
