### PR TITLE
Pressure projection

### DIFF
--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -1,7 +1,7 @@
 # Stommel gyre test case in 2D
 # ============================
 #
-# Wind-driven geostrophic gyre in larege basin.
+# Wind-driven geostrophic gyre in large basin.
 # Setup is according to [1].
 #
 # [1] Comblen, R., Lambrechts, J., Remacle, J.-F., and Legat, V. (2010).

--- a/examples/stommel2d/stommel2d_picard.py
+++ b/examples/stommel2d/stommel2d_picard.py
@@ -1,0 +1,92 @@
+# Stommel gyre test case in 2D
+# ============================
+#
+# Wind-driven geostrophic gyre in larege basin.
+# Setup is according to [1].
+#
+# [1] Comblen, R., Lambrechts, J., Remacle, J.-F., and Legat, V. (2010).
+#     Practical evaluation of five partly discontinuous finite element pairs
+#     for the non-conservative shallow water equations. International Journal
+#     for Numerical Methods in Fluids, 63(6):701-724.
+#
+# Tuomas Karna 2015-04-28
+
+# This is a version that runs much faster using much larger timesteps (2 hr instead of 45s.)
+# using an implicit time integration scheme (PressureProjectionPicard)
+
+from thetis import *
+
+lx = 1.0e6
+nx = 20
+mesh2d = RectangleMesh(nx, nx, lx, lx)
+outputdir = 'outputs_picard'
+print_output('Loaded mesh '+mesh2d.name)
+print_output('Exporting to '+outputdir)
+depth = 1000.0
+t_end = 75*12*2*3600
+t_export = 3600*2
+
+# bathymetry
+P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1v_2d = VectorFunctionSpace(mesh2d, 'CG', 1)
+bathymetry_2d = Function(P1_2d, name='Bathymetry')
+bathymetry_2d.assign(depth)
+
+# Coriolis forcing
+coriolis_2d = Function(P1_2d)
+f0, beta = 1.0e-4, 2.0e-11
+coriolis_2d.interpolate(
+    Expression('f0+beta*(x[1]-y_0)', f0=f0, beta=beta, y_0=0.0))
+
+# Wind stress
+wind_stress_2d = Function(P1v_2d, name='wind stress')
+tau_max = 0.1
+wind_stress_2d.interpolate(Expression(('tau_max*sin(pi*(x[1]/L - 0.5))', '0'), tau_max=tau_max, L=lx))
+
+# linear dissipation: tau_bot/(h*rho) = -bf_gamma*u
+linear_drag = Constant(1e-6)
+
+# --- create solver ---
+solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
+options = solver_obj.options
+options.nonlin = False
+options.coriolis = coriolis_2d
+options.wind_stress = wind_stress_2d
+options.linear_drag = linear_drag
+options.t_export = t_export
+options.t_end = t_end
+options.dt = 3600.*2.
+options.outputdir = outputdir
+options.u_advection = Constant(0.01)
+options.check_vol_conservation_2d = True
+options.fields_to_export = ['uv_2d', 'elev_2d']
+options.fields_to_export_hdf5 = ['uv_2d', 'elev_2d']
+options.timestepper_type = 'PressureProjectionPicard'
+options.use_linearized_semi_implicit_2d = True
+options.shallow_water_theta = 1.0
+options.solver_parameters_sw = {
+    'snes_type': 'ksponly',
+    'ksp_type': 'preonly',
+    #'ksp_view': True,
+    #'ksp_monitor': True,
+    'pc_type': 'fieldsplit',
+    'pc_fieldsplit_type': 'schur',
+    'pc_fieldsplit_schur_fact_type': 'full',
+    'pc_fieldsplit_schur_precondition': 'selfp',
+    'fieldsplit_0_ksp_type': 'gmres',
+    #'fieldsplit_0_ksp_converged_reason': True,
+    'fieldsplit_0_pc_type': 'sor',
+    'fieldsplit_1_ksp_type': 'fgmres',
+    'fieldsplit_1_ksp_converged_reason': True,
+    'fieldsplit_1_pc_type': 'hypre',
+}
+options.solver_parameters_momentum_implicit = {
+    'ksp_type': 'gmres',
+    #'ksp_view': True,
+    #'snes_monitor': True,
+    'ksp_converged_reason': True,
+    'pc_type': 'sor',
+    'pc_factor_mat_solver_package': 'mumps',
+}
+
+solver_obj.iterate()

--- a/examples/stommel2d/stommel2d_picard.py
+++ b/examples/stommel2d/stommel2d_picard.py
@@ -67,14 +67,11 @@ options.shallow_water_theta = 1.0
 options.solver_parameters_sw = {
     'snes_type': 'ksponly',
     'ksp_type': 'preonly',
-    #'ksp_view': True,
-    #'ksp_monitor': True,
     'pc_type': 'fieldsplit',
     'pc_fieldsplit_type': 'schur',
     'pc_fieldsplit_schur_fact_type': 'full',
     'pc_fieldsplit_schur_precondition': 'selfp',
     'fieldsplit_0_ksp_type': 'gmres',
-    #'fieldsplit_0_ksp_converged_reason': True,
     'fieldsplit_0_pc_type': 'sor',
     'fieldsplit_1_ksp_type': 'fgmres',
     'fieldsplit_1_ksp_converged_reason': True,
@@ -82,8 +79,6 @@ options.solver_parameters_sw = {
 }
 options.solver_parameters_momentum_implicit = {
     'ksp_type': 'gmres',
-    #'ksp_view': True,
-    #'snes_monitor': True,
     'ksp_converged_reason': True,
     'pc_type': 'sor',
     'pc_factor_mat_solver_package': 'mumps',

--- a/examples/stommel2d/stommel2d_picard.py
+++ b/examples/stommel2d/stommel2d_picard.py
@@ -1,7 +1,7 @@
 # Stommel gyre test case in 2D
 # ============================
 #
-# Wind-driven geostrophic gyre in larege basin.
+# Wind-driven geostrophic gyre in large basin.
 # Setup is according to [1].
 #
 # [1] Comblen, R., Lambrechts, J., Remacle, J.-F., and Legat, V. (2010).

--- a/examples/stommel2d/stommel2d_picard.py
+++ b/examples/stommel2d/stommel2d_picard.py
@@ -73,7 +73,7 @@ options.solver_parameters_sw = {
     'pc_fieldsplit_schur_precondition': 'selfp',
     'fieldsplit_0_ksp_type': 'gmres',
     'fieldsplit_0_pc_type': 'sor',
-    'fieldsplit_1_ksp_type': 'fgmres',
+    'fieldsplit_1_ksp_type': 'gmres',
     'fieldsplit_1_ksp_converged_reason': True,
     'fieldsplit_1_pc_type': 'hypre',
 }

--- a/examples/stommel2d/stommel2d_picard.py
+++ b/examples/stommel2d/stommel2d_picard.py
@@ -77,7 +77,7 @@ options.solver_parameters_sw = {
     'fieldsplit_1_ksp_converged_reason': True,
     'fieldsplit_1_pc_type': 'hypre',
 }
-options.solver_parameters_momentum_implicit = {
+options.solver_parameters_sw_momentum = {
     'ksp_type': 'gmres',
     'ksp_converged_reason': True,
     'pc_type': 'sor',

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -8,13 +8,13 @@ import pytest
 import math
 
 
-@pytest.mark.parametrize("timesteps,max_rel_err",[
-  (10,0.02), (20,5e-3)])
+@pytest.mark.parametrize("timesteps,max_rel_err", [
+    (10, 0.02), (20, 5e-3)])
 # with nonlin=True and nx=100 this converges for the series
 #  (10,0.02), (20,5e-3), (40, 1.25e-3)
 # with nonlin=False further converge is possible
 @pytest.mark.parametrize("timestepper", [
-  'cranknicolson', 'pressureprojectionpicard',])
+    'cranknicolson', 'pressureprojectionpicard', ])
 def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=False):
 
     lx = 5e3
@@ -28,7 +28,7 @@ def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=Fal
     c = math.sqrt(g*depth)
     period = 2*lx/c
     dt = period/n
-    t_end = period-0.1*dt # make sure we don't overshoot
+    t_end = period-0.1*dt  # make sure we don't overshoot
 
     x = SpatialCoordinate(mesh2d)
     elev_init = cos(pi*x[0]/lx)
@@ -47,7 +47,7 @@ def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=Fal
     solver_obj.options.element_family = 'dg-dg'
     solver_obj.options.timestepper_type = timestepper
     solver_obj.options.shallow_water_theta = 0.5
-    if timestepper=='cranknicolson':
+    if timestepper == 'cranknicolson':
         solver_obj.options.solver_parameters_sw = {
             'ksp_type': 'preonly',
             'pc_type': 'lu',
@@ -55,17 +55,17 @@ def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=Fal
             'snes_monitor': False,
             'snes_type': 'newtonls',
         }
-    elif timestepper=='pressureprojectionpicard':
+    elif timestepper == 'pressureprojectionpicard':
         # solver options for the linearized wave equation terms
         solver_obj.options.solver_parameters_sw = {
-            'snes_type': 'ksponly', # we've linearized, so no snes needed
-            'ksp_type': 'preonly', # we solve the full schur complement exactly, so no need for outer krylov
+            'snes_type': 'ksponly',  # we've linearized, so no snes needed
+            'ksp_type': 'preonly',  # we solve the full schur complement exactly, so no need for outer krylov
             'pc_type': 'fieldsplit',
             'pc_fieldsplit_type': 'schur',
             'pc_fieldsplit_schur_fact_type': 'full',
             'pc_fieldsplit_schur_precondition': 'selfp',
             # velocity mass block:
-            'fieldsplit_0_ksp_type': 'preonly', # NOTE: this is only an exact solver for the velocity mass block if velocity is DG
+            'fieldsplit_0_ksp_type': 'preonly',  # NOTE: this is only an exact solver for the velocity mass block if velocity is DG
             'fieldsplit_0_pc_type': 'ilu',
             'fieldsplit_1_ksp_type': 'fgmres',
             # schur complement:
@@ -74,11 +74,11 @@ def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=Fal
             'fieldsplit_1_ksp_converged_reason': True,
         }
         options.solver_parameters_momentum_implicit = {
-                'snes_monitor': True,
-                'ksp_type': 'gmres',
-                'ksp_converged_reason': True,
-                'pc_type': 'bjacobi',
-                'pc_bjacobi_type': 'ilu',
+            'snes_monitor': True,
+            'ksp_type': 'gmres',
+            'ksp_converged_reason': True,
+            'pc_type': 'bjacobi',
+            'pc_bjacobi_type': 'ilu',
         }
     solver_obj.options.dt = dt
 

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -67,7 +67,7 @@ def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=Fal
             # velocity mass block:
             'fieldsplit_0_ksp_type': 'preonly',  # NOTE: this is only an exact solver for the velocity mass block if velocity is DG
             'fieldsplit_0_pc_type': 'ilu',
-            'fieldsplit_1_ksp_type': 'fgmres',
+            'fieldsplit_1_ksp_type': 'gmres',
             # schur complement:
             'fieldsplit_1_pc_type': 'gamg',
             'fieldsplit_1_ksp_max_it': 100,

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -73,7 +73,7 @@ def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=Fal
             'fieldsplit_1_ksp_max_it': 100,
             'fieldsplit_1_ksp_converged_reason': True,
         }
-        options.solver_parameters_momentum_implicit = {
+        options.solver_parameters_sw_momentum = {
             'snes_monitor': True,
             'ksp_type': 'gmres',
             'ksp_converged_reason': True,

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -1,0 +1,104 @@
+# Test for temporal convergence of cranknicolson and pressureprojection picard timesteppers,
+# tests convergence of a single period of a standing wave in a rectangular channel.
+# This only tests against a linear solution, so does not really test whether the splitting
+# in pressureprojectionpicard between nonlinear momentum and linearized wave equation terms is correct.
+# pressureprojectionpicard does need two iterations to ensure 2nd order convergence
+from thetis import *
+import pytest
+import math
+
+
+@pytest.mark.parametrize("timesteps,max_rel_err",[
+  (10,0.02), (20,5e-3)])
+# with nonlin=True and nx=100 this converges for the series
+#  (10,0.02), (20,5e-3), (40, 1.25e-3)
+# with nonlin=False further converge is possible
+@pytest.mark.parametrize("timestepper", [
+  'cranknicolson', 'pressureprojectionpicard',])
+def test_steady_state_channel(timesteps, max_rel_err, timestepper, do_export=False):
+
+    lx = 5e3
+    ly = 1e3
+    nx = 50
+    mesh2d = RectangleMesh(nx, 1, lx, ly)
+
+    n = timesteps
+    depth = 100.
+    g = physical_constants['g_grav'].dat.data[0]
+    c = math.sqrt(g*depth)
+    period = 2*lx/c
+    dt = period/n
+    t_end = period-0.1*dt # make sure we don't overshoot
+
+    x = SpatialCoordinate(mesh2d)
+    elev_init = cos(pi*x[0]/lx)
+
+    # bathymetry
+    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    bathymetry_2d = Function(p1_2d, name="bathymetry")
+    bathymetry_2d.assign(depth)
+
+    # --- create solver ---
+    solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d, order=1)
+    solver_obj.options.nonlin = True
+    solver_obj.options.t_export = dt
+    solver_obj.options.t_end = t_end
+    solver_obj.options.no_exports = not do_export
+    solver_obj.options.element_family = 'dg-dg'
+    solver_obj.options.timestepper_type = timestepper
+    solver_obj.options.shallow_water_theta = 0.5
+    if timestepper=='cranknicolson':
+        solver_obj.options.solver_parameters_sw = {
+            'ksp_type': 'preonly',
+            'pc_type': 'lu',
+            'pc_factor_mat_solver_package': 'mumps',
+            'snes_monitor': False,
+            'snes_type': 'newtonls',
+        }
+    elif timestepper=='pressureprojectionpicard':
+        # solver options for the linearized wave equation terms
+        solver_obj.options.solver_parameters_sw = {
+            'snes_type': 'ksponly', # we've linearized, so no snes needed
+            'ksp_type': 'preonly', # we solve the full schur complement exactly, so no need for outer krylov
+            'pc_type': 'fieldsplit',
+            'pc_fieldsplit_type': 'schur',
+            'pc_fieldsplit_schur_fact_type': 'full',
+            'pc_fieldsplit_schur_precondition': 'selfp',
+            # velocity mass block:
+            'fieldsplit_0_ksp_type': 'preonly', # NOTE: this is only an exact solver for the velocity mass block if velocity is DG
+            'fieldsplit_0_pc_type': 'ilu',
+            'fieldsplit_1_ksp_type': 'fgmres',
+            # schur complement:
+            'fieldsplit_1_pc_type': 'gamg',
+            'fieldsplit_1_ksp_max_it': 100,
+            'fieldsplit_1_ksp_converged_reason': True,
+        }
+        options.solver_parameters_momentum_implicit = {
+                'snes_monitor': True,
+                'ksp_type': 'gmres',
+                'ksp_converged_reason': True,
+                'pc_type': 'bjacobi',
+                'pc_bjacobi_type': 'ilu',
+        }
+    solver_obj.options.dt = dt
+
+    # boundary conditions
+    solver_obj.bnd_functions['shallow_water'] = {}
+    parameters['quadrature_degree'] = 5
+
+    solver_obj.create_equations()
+    solver_obj.assign_initial_conditions(elev=elev_init)
+
+    solver_obj.iterate()
+
+    uv, eta = solver_obj.fields.solution_2d.split()
+
+    area = lx*ly
+    rel_err = errornorm(elev_init, eta)/math.sqrt(area)
+    print_output(rel_err)
+    assert(rel_err < max_rel_err)
+    print_output("PASSED")
+
+
+if __name__ == '__main__':
+    test_steady_state_channel(do_export=True)

--- a/test/swe2d/test_steady_state_channel.py
+++ b/test/swe2d/test_steady_state_channel.py
@@ -26,7 +26,6 @@ def test_steady_state_channel(do_export=False):
     solver_obj.options.t_export = dt
     solver_obj.options.t_end = n*dt
     solver_obj.options.no_exports = not do_export
-    # NOTE had to set to something else than Cr-Ni, otherwise overriding below has no effect
     solver_obj.options.timestepper_type = 'cranknicolson'
     solver_obj.options.shallow_water_theta = 1.0
     solver_obj.options.solver_parameters_sw = {

--- a/test/swe2d/test_steady_state_channel.py
+++ b/test/swe2d/test_steady_state_channel.py
@@ -8,15 +8,15 @@ def test_steady_state_channel(do_export=False):
     lx = 5e3
     ly = 1e3
     # we don't expect converge as the reference solution neglects the advection term
-    mesh2d = RectangleMesh(5, 1, lx, ly)
+    mesh2d = RectangleMesh(10, 1, lx, ly)
 
     # bathymetry
     p1_2d = FunctionSpace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name="bathymetry")
     bathymetry_2d.assign(100.0)
 
-    n = 20  # number of timesteps
-    dt = 100.
+    n = 200  # number of timesteps
+    dt = 1000.
     g = physical_constants['g_grav'].dat.data[0]
     f = g/lx  # linear friction coef.
 
@@ -60,9 +60,8 @@ def test_steady_state_channel(do_export=False):
     eta_ana = interpolate(Expression("1-x[0]/lx", lx=lx), p1_2d)
     area = lx*ly
     l2norm = errornorm(eta_ana, eta)/math.sqrt(area)
-    rel_err = math.sqrt(l2norm/area)
-    print_output(rel_err)
-    assert(rel_err < 1e-3)
+    print_output(l2norm)
+    assert(l2norm < 1e-2)
     print_output("PASSED")
 
 

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -56,8 +56,7 @@ def test_steady_state_channel_mms(options):
         solver_obj.options.t_export = dt
         solver_obj.options.t_end = n*dt
         solver_obj.options.uv_source_2d = source_func
-        solver_obj.options.timestepper_type = 'cranknicolson'
-        solver_obj.options.shallow_water_theta = 1.0
+        solver_obj.options.timestepper_type = 'steadystate'
         solver_obj.options.solver_parameters_sw = {
             'ksp_type': 'preonly',
             'pc_type': 'lu',
@@ -90,11 +89,6 @@ def test_steady_state_channel_mms(options):
 
         if do_exports:
             File('source_{}.pvd'.format(i)).write(source_func)
-        # subtract out time derivative
-        solver_obj.timestepper.F -= (solver_obj.eq_sw.mass_term(solver_obj.timestepper.solution) -
-                                     solver_obj.eq_sw.mass_term(solver_obj.timestepper.solution_old))
-        solver_obj.timestepper.update_solver()
-
         solver_obj.iterate()
 
         uv, eta = solver_obj.fields.solution_2d.split()

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -162,6 +162,13 @@ class ModelOptions(AttrDict, FrozenClass):
             'pc_fieldsplit_type': 'multiplicative',
         }
         """PETSc solver parameters for 2D shallow water equations"""
+        self.solver_parameters_sw_momentum = {
+            'ksp_type': 'gmres',
+            'pc_type': 'bjacobi',
+            'sub_ksp_type': 'preonly',
+            'sub_pc_type': 'sor',
+        }
+        """PETSc solver parameters for 2D depth averaged momentum equation"""
         self.solver_parameters_momentum_explicit = {
             'snes_type': 'ksponly',
             'ksp_type': 'cg',

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -188,6 +188,25 @@ class FlowSolver2d(FrozenClass):
                                                           fields, self.dt,
                                                           bnd_conditions=self.bnd_functions['shallow_water'],
                                                           solver_parameters=self.options.solver_parameters_sw)
+        elif self.options.timestepper_type.lower() == 'pressureprojectionpicard':
+
+            u_test = TestFunction(self.function_spaces.U_2d)
+            self.eq_mom = shallowwater_eq.ShallowWaterMomentumEquation(
+                u_test, self.function_spaces.H_2d, self.function_spaces.U_2d,
+                self.fields.bathymetry_2d,
+                nonlin=self.options.nonlin,
+                include_grad_div_viscosity_term=self.options.include_grad_div_viscosity_term,
+                include_grad_depth_viscosity_term=self.options.include_grad_depth_viscosity_term
+            )
+            self.eq_mom.bnd_functions = self.bnd_functions['shallow_water']
+            self.timestepper = timeintegrator.PressureProjectionPicard(self.eq_sw, self.eq_mom, self.fields.solution_2d,
+                                                                       fields, self.dt,
+                                                                       bnd_conditions=self.bnd_functions['shallow_water'],
+                                                                       solver_parameters=self.options.solver_parameters_sw,
+                                                                       solver_parameters_mom=self.options.solver_parameters_momentum_implicit,
+                                                                       semi_implicit=self.options.use_linearized_semi_implicit_2d,
+                                                                       theta=self.options.shallow_water_theta)
+
         elif self.options.timestepper_type.lower() == 'sspimex':
             # TODO meaningful solver params
             sp_impl = {

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -203,7 +203,7 @@ class FlowSolver2d(FrozenClass):
                                                                        fields, self.dt,
                                                                        bnd_conditions=self.bnd_functions['shallow_water'],
                                                                        solver_parameters=self.options.solver_parameters_sw,
-                                                                       solver_parameters_mom=self.options.solver_parameters_momentum_implicit,
+                                                                       solver_parameters_mom=self.options.solver_parameters_sw_momentum,
                                                                        semi_implicit=self.options.use_linearized_semi_implicit_2d,
                                                                        theta=self.options.shallow_water_theta)
 

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -625,8 +625,10 @@ class PressureProjectionPicard(TimeIntegrator):
             )
         )
 
+        uv_test, eta_test = split(self.equation.test)
+        mass_term_star = inner(uv_test, self.uv_star)*dx + inner(eta_test, eta_old)*dx
         self.F = (
-            self.equation.mass_term(self.solution)-self.equation.mass_term(self.solution_old) -
+            self.equation.mass_term(self.solution)-mass_term_star-
             self.dt_const*(
                 theta_const*self.equation.residual('implicit', self.solution, solution_nl, self.fields, self.fields, bnd_conditions)
                 + (1-theta_const)*self.equation.residual('implicit', self.solution_old, self.solution_old, self.fields_old, self.fields_old, bnd_conditions)

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -580,7 +580,7 @@ class PressureProjectionPicard(TimeIntegrator):
             self.solver_parameters.setdefault('snes_type', 'ksponly')
             self.solver_parameters_mom.setdefault('snes_type', 'ksponly')
         else:
-            # not sure this combination makes much sense: keep both systems nonline
+            # not sure this combination makes much sense: keep both systems nonlinear
             self.solver_parameters.setdefault('snes_type', 'newtonls')
             self.solver_parameters_mom.setdefault('snes_type', 'newtonls')
         # number of picard iterations

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -661,8 +661,10 @@ class PressureProjectionPicard(TimeIntegrator):
         self.solver_mom = NonlinearVariationalSolver(prob,
                                                      solver_parameters=self.solver_parameters_mom,
                                                      options_prefix=self.name+'_mom')
-        nest = not ('pc_type' in self.solver_parameters and self.solver_parameters['pc_type'] == 'lu')
-        prob = NonlinearVariationalProblem(self.F, self.solution, nest=nest)
+        # Ensure LU assembles monolithic matrices
+        if self.solver_parameters.get('pc_type') == 'lu':
+            self.solver_parameters['mat_type'] = 'aij'
+        prob = NonlinearVariationalProblem(self.F, self.solution)
         self.solver = NonlinearVariationalSolver(prob,
                                                  solver_parameters=self.solver_parameters,
                                                  options_prefix=self.name)


### PR DESCRIPTION
New timestepper for 2D equations that combines a pressure projection approach with Picard iterations. Solves a preliminary (depth-averaged) separate momentum equation first (using the free surface elevation from the previous timestep or Picard iteration). Then solves the coupled system containing only the wave equations terms (mass terms and free surface gradient and continuity divergence term). These two solves can be iterated with a Picard iteration to increase the coupling between the free surface update and the full momentum equation, and in case this is combined with the use_linearized_semi_implicit_2d option (recommended) to reduce the error due to linearizing the advection and continuity divergence terms. With nonlinear terms that are merely quadratic, the second order accuracy of Crank Nicolson can thus be restored with 2 Picard iterations.

If use_linearized_semi_implicit_2d is combined with DG velocity (dg-dg or dg-cg), the mass term is easily inverted using preonly+ilu and thus the coupled linearized wave equations can be cheaply solved by solving the Schur complement exactly, i.e. no further iterations of the outer solver on the coupled system are necessary. For rt-dg, preonly+jacobi is a pretty good approximation to the inverse rt mass matrix. Further speedup can be achieved (this is still on a branch) by assembling the Schur complement explicitly as a matrix.