### PR TITLE
New firedrake matrix types

### DIFF
--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -194,6 +194,7 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
 
     # Use direct solver for 2D
     # options.solver_parameters_sw = {
+    #     'mat_type': 'aij',
     #     'ksp_type': 'preonly',
     #     'pc_type': 'lu',
     #     'pc_factor_mat_solver_package': 'mumps',

--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -46,6 +46,7 @@ options.fields_to_export = ['uv_2d', 'elev_2d']
 solver_obj.options.timestepper_type = 'cranknicolson'
 solver_obj.options.shallow_water_theta = 1.0
 solver_obj.options.solver_parameters_sw = {
+    'mat_type': 'aij',
     'ksp_type': 'preonly',
     'pc_type': 'lu',
     'pc_factor_mat_solver_package': 'mumps',

--- a/test/firedrake/test_implicit_friction.py
+++ b/test/firedrake/test_implicit_friction.py
@@ -104,6 +104,7 @@ def test_implicit_friction(do_export=False, do_assert=True):
     # ----- define solver
 
     sp = {}
+    # sp['mat_type'] = 'aij',
     # sp['ksp_type'] = 'cg'
     # sp['pc_type'] = 'lu'
     # sp['snes_rtol'] = 1.0e-12

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -341,6 +341,7 @@ def options(request):
 
 
 def test_steady_state_basin_convergence(setup, options):
-    sp = {'ksp_type': 'preonly', 'pc_type': 'lu', 'snes_monitor': True}
+    sp = {'ksp_type': 'preonly', 'pc_type': 'lu', 'snes_monitor': True,
+          'mat_type': 'aij'}
     run_convergence(setup, [1, 2, 4, 6], 1, options=options,
                     solver_parameters=sp, save_plot=False)

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -87,8 +87,6 @@ def setup_unsteady():
     solver_obj.options.timestepper_type = 'cranknicolson'
     solver_obj.options.t_end = 2.0
     solver_obj.options.shallow_water_theta = 1.0
-    # coffee optimisation currently broken for this case:
-    parameters['coffee'] = {}
     solver_obj.options.solver_parameters_sw = {
         'mat_type': 'aij',
         'ksp_type': 'preonly',

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -69,11 +69,9 @@ def setup_steady():
     solver_obj = basic_setup()
     solver_obj.options.timestepper_type = 'steadystate'
     solver_obj.options.t_end = 0.499
-    # this is currently needed because althhough thesis
-    # automatically switches off matnest when using 'lu',
     # firedrake-adjoint does not remember that in the adjoint solve
-    parameters['matnest'] = False
     solver_obj.options.solver_parameters_sw = {
+        'mat_type': 'aij',
         'ksp_type': 'preonly',
         'pc_type': 'lu',
         'pc_factor_mat_solver_package': 'mumps',
@@ -89,13 +87,10 @@ def setup_unsteady():
     solver_obj.options.timestepper_type = 'cranknicolson'
     solver_obj.options.t_end = 2.0
     solver_obj.options.shallow_water_theta = 1.0
-    # this is currently needed because althhough thesis
-    # automatically switches off matnest when using 'lu',
-    # firedrake-adjoint does not remember that in the adjoint solve
-    parameters['matnest'] = False
     # coffee optimisation currently broken for this case:
     parameters['coffee'] = {}
     solver_obj.options.solver_parameters_sw = {
+        'mat_type': 'aij',
         'ksp_type': 'preonly',
         'pc_type': 'lu',
         'pc_factor_mat_solver_package': 'mumps',

--- a/thetis/limiter.py
+++ b/thetis/limiter.py
@@ -19,19 +19,19 @@ def assert_function_space(fs, family, degree):
     outer product.
     """
     ufl_elem = fs.ufl_element()
+    if isinstance(ufl_elem, ufl.VectorElement):
+        ufl_elem = ufl_elem.sub_elements()[0]
+
     if ufl_elem.family() == 'TensorProductElement':
-        if ufl_elem.num_sub_elements() > 0:
-            # VectorElement case
-            assert isinstance(ufl_elem, ufl.VectorElement)
-            ufl_elem = ufl_elem.sub_elements()[0]
         # extruded mesh
-        assert ufl_elem._A.family() == family,\
+        A, B = ufl_elem.sub_elements()
+        assert A.family() == family,\
             'horizontal space must be {0:s}'.format(family)
-        assert ufl_elem._B.family() == family,\
+        assert B.family() == family,\
             'vertical space must be {0:s}'.format(family)
-        assert ufl_elem._A.degree() == degree,\
+        assert A.degree() == degree,\
             'degree of horizontal space must be {0:d}'.format(degree)
-        assert ufl_elem._B.degree() == degree,\
+        assert B.degree() == degree,\
             'degree of vertical space must be {0:d}'.format(degree)
     else:
         # assume 2D mesh

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -504,8 +504,10 @@ class CrankNicolson(TimeIntegrator):
         self.update_solver()
 
     def update_solver(self):
-        nest = not ('pc_type' in self.solver_parameters and self.solver_parameters['pc_type'] == 'lu')
-        prob = NonlinearVariationalProblem(self.F, self.solution, nest=nest)
+        # Ensure LU assembles monolithic matrices
+        if self.solver_parameters.get('pc_type') == 'lu':
+            self.solver_parameters['mat_type'] = 'aij'
+        prob = NonlinearVariationalProblem(self.F, self.solution)
         self.solver = NonlinearVariationalSolver(prob,
                                                  solver_parameters=self.solver_parameters,
                                                  options_prefix=self.name)
@@ -544,8 +546,10 @@ class SteadyState(TimeIntegrator):
         self.update_solver()
 
     def update_solver(self):
-        nest = not ('pc_type' in self.solver_parameters and self.solver_parameters['pc_type'] == 'lu')
-        prob = NonlinearVariationalProblem(self.F, self.solution, nest=nest)
+        # Ensure LU assembles monolithic matrices
+        if self.solver_parameters.get('pc_type') == 'lu':
+            self.solver_parameters['mat_type'] = 'aij'
+        prob = NonlinearVariationalProblem(self.F, self.solution)
         self.solver = NonlinearVariationalSolver(prob,
                                                  solver_parameters=self.solver_parameters,
                                                  options_prefix=self.name)


### PR DESCRIPTION
Update to new way of specifying assembled matrix type in firedrake.  The requisite change in dolfin-adjoint will hopefully merge imminently.  That side of things also fixes remembering the assembled matrix type (so no need to specify it globally in the adjoint tests).