### PR TITLE
Fix Travis timeout

### DIFF
--- a/test/bottomFriction/test_bottom_friction.py
+++ b/test/bottomFriction/test_bottom_friction.py
@@ -132,13 +132,14 @@ def run_bottom_friction(parabolic_visosity=False, element_family='dg-dg',
         print_output('L2 error {:.4f} PASSED'.format(uv_l2_err))
 
 
-@pytest.fixture(params=[pytest.mark.skip(reason='travis is timing out')(True),
+@pytest.fixture(params=[pytest.mark.not_travis(reason='travis timeout')(True),
                         False], ids=['parabolic_visosity', 'gls_model'])
 def parabolic_visosity(request):
     return request.param
 
 
-@pytest.fixture(params=['rt-dg', 'dg-dg'])
+@pytest.fixture(params=[pytest.mark.not_travis(reason='travis timeout')('rt-dg'),
+                        'dg-dg'])
 def element_family(request):
     return request.param
 

--- a/test/continuity3d/test_continuity_mes.py
+++ b/test/continuity3d/test_continuity_mes.py
@@ -376,8 +376,7 @@ def run_convergence(setup, ref_list, order, do_export=False, save_plot=False):
 # standard tests for pytest
 # ---------------------------
 
-
-@pytest.mark.not_travis
+@pytest.mark.not_travis(reason='travis out-of-memory')
 def test_setup5_dg():
     run_convergence(setup5dg, [1, 2, 3], 1, save_plot=False)
 

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -194,10 +194,10 @@ def warped(request):
 
 
 @pytest.mark.parametrize(('family', 'order'),
-                         [('dg-dg', 0),
+                         [pytest.mark.not_travis(reason='travis timeout')(('dg-dg', 0)),
                           ('dg-dg', 1),
                           pytest.mark.xfail(reason='rt-0 still broken')(('rt-dg', 0)),
-                          ('rt-dg', 1)])
+                          pytest.mark.not_travis(reason='travis timeout')(('rt-dg', 1))])
 def test_horizontal_viscosity(warped, order, family):
     run_convergence([1, 2, 3], order=order, warped_mesh=warped,
                     element_family=family)

--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -186,7 +186,7 @@ def run_convergence(ref_list, saveplot=False, **options):
 # ---------------------------
 
 
-@pytest.fixture(params=['rt-dg', 'dg-dg'])
+@pytest.fixture(params=[pytest.mark.not_travis(reason='travis timeout')('rt-dg'), 'dg-dg'])
 def element_family(request):
     return request.param
 
@@ -196,7 +196,7 @@ def order(request):
     return request.param
 
 
-@pytest.fixture(params=[pytest.mark.xfail(reason='mysterious travis bug')(True), False], ids=['implicit', 'explicit'])
+@pytest.fixture(params=[pytest.mark.not_travis(reason='mysterious travis bug')(True), False], ids=['implicit', 'explicit'])
 def implicit(request):
     return request.param
 

--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -196,7 +196,7 @@ def order(request):
     return request.param
 
 
-@pytest.fixture(params=[pytest.mark.not_travis(reason='mysterious travis bug')(True), False], ids=['implicit', 'explicit'])
+@pytest.fixture(params=[pytest.mark.skip(reason='mysterious travis bug')(True), False], ids=['implicit', 'explicit'])
 def implicit(request):
     return request.param
 

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -321,7 +321,9 @@ def run_convergence(setup, ref_list, order, do_export=False, save_plot=False,
 # ---------------------------
 
 
-@pytest.fixture(params=[setup7, setup8, setup9],
+@pytest.fixture(params=[pytest.mark.not_travis(reason='travis timeout')(setup7),
+                        setup8,
+                        pytest.mark.not_travis(reason='travis timeout')(setup9)],
                 ids=["Setup7", "Setup8", "Setup9"])
 def setup(request):
     return request.param
@@ -330,10 +332,10 @@ def setup(request):
 @pytest.fixture(params=[
     {'element_family': 'dg-dg',
      'timestepper_type': 'cranknicolson'},
-    {'element_family': 'rt-dg',
-     'timestepper_type': 'cranknicolson'},
-    {'element_family': 'dg-cg',
-     'timestepper_type': 'cranknicolson'}],
+    pytest.mark.not_travis(reason='travis timeout')({'element_family': 'rt-dg',
+                                                     'timestepper_type': 'cranknicolson'}),
+    pytest.mark.not_travis(reason='travis timeout')({'element_family': 'dg-cg',
+                                                     'timestepper_type': 'cranknicolson'})],
     ids=["dg-dg", "rt-dg", "dg-cg"]
 )
 def options(request):

--- a/test/tracerEq/test_consistency.py
+++ b/test/tracerEq/test_consistency.py
@@ -121,8 +121,11 @@ def run_tracer_consistency(element_family='dg-dg', meshtype='regular', do_export
     assert max_abs_overshoot < overshoot_tol, msg
 
 
-@pytest.mark.parametrize('element_family', ['dg-dg', 'rt-dg'])
-@pytest.mark.parametrize('meshtype', ['regular', 'sloped', 'warped'])
+@pytest.mark.parametrize('element_family', ['dg-dg',
+                                            pytest.mark.not_travis(reason='travis timeout')('rt-dg')])
+@pytest.mark.parametrize('meshtype', ['regular',
+                                      'sloped',
+                                      pytest.mark.not_travis(reason='travis timeout')('warped')])
 def test_consistency_dg_regular(element_family, meshtype):
     run_tracer_consistency(element_family=element_family, meshtype=meshtype, do_export=False)
 

--- a/test/tracerEq/test_h-diffusion_mes.py
+++ b/test/tracerEq/test_h-diffusion_mes.py
@@ -187,12 +187,13 @@ def run_convergence(ref_list, saveplot=False, **options):
 # ---------------------------
 
 
-@pytest.fixture(params=[0, 1])
+@pytest.fixture(params=[pytest.mark.not_travis(reason='travis timeout')(0), 1])
 def order(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False], ids=['warped', 'regular'])
+@pytest.fixture(params=[True, False], ids=[pytest.mark.not_travis(reason='travis timeout')('warped'),
+                                           'regular'])
 def warped(request):
     return request.param
 


### PR DESCRIPTION
Travis has decided to timeout after 50 minutes instead of ~2 hours, so all builds are failing now.

I'm marking more tests as `not_travis` to skip them. In cases where there are multiple options to test, only 1 or 2 are being tested. I hope we can rely on drone for complete testing from now on.