### PR TITLE
Fix slope limiter at lateral boundary

### DIFF
--- a/thetis/limiter.py
+++ b/thetis/limiter.py
@@ -86,19 +86,44 @@ class VertexBasedP1DGLimiter(VertexBasedLimiter):
         """
         # Call general-purpose bound computation.
         super(VertexBasedP1DGLimiter, self).compute_bounds(field)
-        # NOTE This does not limit solution at lateral boundaries at all
-        # NOTE Omit for now
-        # # Add nodal values from lateral boundaries
-        # par_loop("""
-        #     for (int i=0; i<qmax.dofs; i++) {
-        #         qmax[i][0] = fmax(qmax[i][0], field[i][0]);
-        #         qmin[i][0] = fmin(qmin[i][0], field[i][0]);
-        #     }""",
-        #          ds,
-        #          {'qmax': (self.max_field, RW),
-        #           'qmin': (self.min_field, RW),
-        #           'field': (field, READ)})
 
+        # Add the average of lateral boundary facets to min/max fields
+        # NOTE this just computes the arithmetic mean of nodal values on the facet,
+        # which in general is not equivalent to the mean of the field over the bnd facet.
+        # This is OK for P1DG triangles, but not exact for the extruded case (quad facets)
+        from finat.finiteelementbase import entity_support_dofs
+
+        if self.is_2d:
+            entity_dim = 1  # get 1D facets
+        else:
+            entity_dim = (1, 1)  # get vertical facets
+        boundary_dofs = entity_support_dofs(self.P1DG.finat_element, entity_dim)
+        local_facet_nodes = np.array([boundary_dofs[e] for e in sorted(boundary_dofs.keys())])
+        n_bnd_nodes = local_facet_nodes.shape[1]
+        local_facet_idx = op2.Global(local_facet_nodes.shape, local_facet_nodes, dtype=np.int32, name='local_facet_idx')
+        code = """
+            void my_kernel(double **qmax, double **qmin, double **field, unsigned int *facet, unsigned int *local_facet_idx)
+            {
+                double face_mean = 0.0;
+                for (int i = 0; i < %(nnodes)d; i++) {
+                    unsigned int idx = local_facet_idx[facet[0]*%(nnodes)d + i];
+                    face_mean += field[idx][0];
+                }
+                face_mean /= %(nnodes)d;
+                for (int i = 0; i < %(nnodes)d; i++) {
+                    unsigned int idx = local_facet_idx[facet[0]*%(nnodes)d + i];
+                    qmax[idx][0] = fmax(qmax[idx][0], face_mean);
+                    qmin[idx][0] = fmin(qmin[idx][0], face_mean);
+                }
+            }"""
+        bnd_kernel = op2.Kernel(code % {'nnodes': n_bnd_nodes}, 'my_kernel')
+        op2.par_loop(bnd_kernel,
+                     self.P1DG.mesh().exterior_facets.set,
+                     self.max_field.dat(op2.RW, self.max_field.exterior_facet_node_map()),
+                     self.min_field.dat(op2.RW, self.min_field.exterior_facet_node_map()),
+                     field.dat(op2.RW, field.exterior_facet_node_map()),
+                     self.P1DG.mesh().exterior_facets.local_facet_dat(op2.READ),
+                     local_facet_idx(op2.READ))
         if not self.is_2d:
             # Add nodal values from surface/bottom boundaries
             # NOTE calling firedrake par_loop with measure=ds_t raises an error
@@ -107,10 +132,10 @@ class VertexBasedP1DGLimiter(VertexBasedLimiter):
             bottom_idx = op2.Global(len(bottom_nodes), bottom_nodes, dtype=np.int32, name='node_idx')
             top_idx = op2.Global(len(top_nodes), top_nodes, dtype=np.int32, name='node_idx')
             code = """
-                void my_kernel(double **qmax, double **qmin, double **centroids, int *idx) {
+                void my_kernel(double **qmax, double **qmin, double **field, int *idx) {
                     double face_mean = 0;
                     for (int i=0; i<%(nnodes)d; i++) {
-                        face_mean += centroids[idx[i]][0];
+                        face_mean += field[idx[i]][0];
                     }
                     face_mean /= %(nnodes)d;
                     for (int i=0; i<%(nnodes)d; i++) {


### PR DESCRIPTION
This (partially) fixes lateral boundary issues discussed in #23  and #29.

To avoid limiting too much at the boundaries, we add the mean value of the field at the lateral boundary facets to the min/max fields. This works in cases where the solution is a linear function that does not attain min/max at a corner. In this case the limiter does not alter the linear function at all. If min/max occurs at the corner, then the corner element will still be limited.

This sits on top of #88.