### PR TITLE
Assembledschur

### DIFF
--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -9,7 +9,7 @@ import math
 
 
 @pytest.mark.parametrize("timesteps,max_rel_err", [
-    (10, 0.02), (20, 5e-3)])
+    (10, 0.02), (20, 5e-3), (40, 1.25e-3)])
 # with nonlin=True and nx=100 this converges for the series
 #  (10,0.02), (20,5e-3), (40, 1.25e-3)
 # with nonlin=False further converge is possible
@@ -19,7 +19,7 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, do_export=Fa
 
     lx = 5e3
     ly = 1e3
-    nx = 50
+    nx = 100
     mesh2d = RectangleMesh(nx, 1, lx, ly)
 
     n = timesteps
@@ -40,58 +40,27 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, do_export=Fa
 
     # --- create solver ---
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
-    solver_obj.options.use_nonlinear_equations = True
+    solver_obj.options.timestep = dt
     solver_obj.options.simulation_export_time = dt
     solver_obj.options.simulation_end_time = t_end
     solver_obj.options.no_exports = not do_export
     solver_obj.options.timestepper_type = timestepper
 
-    if timestepper == 'pressureprojectionpicard':
+    if timestepper == 'CrankNicolson':
+        solver_obj.options.element_family = 'dg-dg'
+        # Crank Nicolson stops being 2nd order if we linearise
+        # (this is not the case for PressureProjectionPicard, as we do 2 Picard iterations)
+        solver_obj.options.timestepper_options.use_semi_implicit_linearization = False
+    elif timestepper == 'PressureProjectionPicard':
         # this approach currently only works well with dg-cg, because in dg-dg
         # the pressure gradient term puts an additional stabilisation term in the velocity block
         # (even without that term  this approach is not as fast, as the stencil for the assembled schur system
         # is a lot bigger for dg-dg than dg-cg)
         solver_obj.options.element_family = 'dg-cg'
-        solver_obj.options.use_linearized_semi_implicit_2d = True
-        # solver options for the linearized wave equation terms
-        solver_obj.options.solver_parameters_sw = {
-            'snes_type': 'ksponly',  # we've linearized, so no snes needed
-            'ksp_type': 'preonly',  # we solve the full schur complement exactly, so no need for outer krylov
-            'mat_type': 'matfree',
-            'pc_type': 'fieldsplit',
-            'pc_fieldsplit_type': 'schur',
-            'pc_fieldsplit_schur_fact_type': 'full',
-            # velocity mass block:
-            'fieldsplit_U_2d_ksp_type': 'gmres',
-            'fieldsplit_U_2d_pc_type': 'python',
-            'fieldsplit_U_2d_pc_python_type': 'firedrake.AssembledPC',
-            'fieldsplit_U_2d_assembled_ksp_type': 'preonly',
-            'fieldsplit_U_2d_assembled_pc_type': 'bjacobi',
-            'fieldsplit_U_2d_assembled_sub_pc_type': 'ilu',
-            # schur system: we tell it to explicitly assemble the schur system
-            # which only works with pressureprojectionicard where the velocity block is just the mass matrix
-            # and if the velocity is DG so that this mass matrix can be inverted explicitly
-            'fieldsplit_1_ksp_type': 'preonly',
-            'fieldsplit_1_pc_type': 'python',
-            'fieldsplit_1_pc_python_type': 'thetis.AssembledSchurPC',
-            # options to solve the assembled schur system
-            'fieldsplit_1_schur_ksp_type': 'preonly',
-            'fieldsplit_1_schur_ksp_max_it': 100,
-            'fieldsplit_1_schur_ksp_converged_reason': True,
-            'fieldsplit_1_schur_pc_type': 'gamg',
-        }
-        solver_obj.options.solver_parameters_sw_momentum = {
-            'snes_monitor': True,
-            'snes_type': 'ksponly',
-            'ksp_type': 'gmres',
-            'ksp_converged_reason': True,
-            'pc_type': 'bjacobi',
-            'pc_bjacobi_type': 'ilu',
-        }
+        solver_obj.options.timestepper_options.use_semi_implicit_linearization = True
+        solver_obj.options.timestepper_options.picard_iterations = 2
     if hasattr(solver_obj.options.timestepper_options, 'use_automatic_timestep'):
         solver_obj.options.timestepper_options.use_automatic_timestep = False
-    solver_obj.options.timestep = dt
-    solver_obj.options.shallow_water_theta = 0.5
 
     # boundary conditions
     solver_obj.bnd_functions['shallow_water'] = {}

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -44,15 +44,54 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, do_export=Fa
     solver_obj.options.simulation_export_time = dt
     solver_obj.options.simulation_end_time = t_end
     solver_obj.options.no_exports = not do_export
-    solver_obj.options.element_family = 'dg-dg'
     solver_obj.options.timestepper_type = timestepper
-    if timestepper == 'CrankNicolson':
-        # when linearising the equations, CrankNicolson (theta=0.5) stops being 2nd order
-        # (for PressureProjectionPicard we restore 2nd order because of the 2 iterations)
-        solver_obj.options.timestepper_options.use_semi_implicit_linearization = False
+
+    if timestepper == 'pressureprojectionpicard':
+        # this approach currently only works well with dg-cg, because in dg-dg
+        # the pressure gradient term puts an additional stabilisation term in the velocity block
+        # (even without that term  this approach is not as fast, as the stencil for the assembled schur system
+        # is a lot bigger for dg-dg than dg-cg)
+        solver_obj.options.element_family = 'dg-cg'
+        solver_obj.options.use_linearized_semi_implicit_2d = True
+        # solver options for the linearized wave equation terms
+        solver_obj.options.solver_parameters_sw = {
+            'snes_type': 'ksponly',  # we've linearized, so no snes needed
+            'ksp_type': 'preonly',  # we solve the full schur complement exactly, so no need for outer krylov
+            'mat_type': 'matfree',
+            'pc_type': 'fieldsplit',
+            'pc_fieldsplit_type': 'schur',
+            'pc_fieldsplit_schur_fact_type': 'full',
+            # velocity mass block:
+            'fieldsplit_U_2d_ksp_type': 'gmres',
+            'fieldsplit_U_2d_pc_type': 'python',
+            'fieldsplit_U_2d_pc_python_type': 'firedrake.AssembledPC',
+            'fieldsplit_U_2d_assembled_ksp_type': 'preonly',
+            'fieldsplit_U_2d_assembled_pc_type': 'bjacobi',
+            'fieldsplit_U_2d_assembled_sub_pc_type': 'ilu',
+            # schur system: we tell it to explicitly assemble the schur system
+            # which only works with pressureprojectionicard where the velocity block is just the mass matrix
+            # and if the velocity is DG so that this mass matrix can be inverted explicitly
+            'fieldsplit_1_ksp_type': 'preonly',
+            'fieldsplit_1_pc_type': 'python',
+            'fieldsplit_1_pc_python_type': 'thetis.AssembledSchurPC',
+            # options to solve the assembled schur system
+            'fieldsplit_1_schur_ksp_type': 'preonly',
+            'fieldsplit_1_schur_ksp_max_it': 100,
+            'fieldsplit_1_schur_ksp_converged_reason': True,
+            'fieldsplit_1_schur_pc_type': 'gamg',
+        }
+        solver_obj.options.solver_parameters_sw_momentum = {
+            'snes_monitor': True,
+            'snes_type': 'ksponly',
+            'ksp_type': 'gmres',
+            'ksp_converged_reason': True,
+            'pc_type': 'bjacobi',
+            'pc_bjacobi_type': 'ilu',
+        }
     if hasattr(solver_obj.options.timestepper_options, 'use_automatic_timestep'):
         solver_obj.options.timestepper_options.use_automatic_timestep = False
     solver_obj.options.timestep = dt
+    solver_obj.options.shallow_water_theta = 0.5
 
     # boundary conditions
     solver_obj.bnd_functions['shallow_water'] = {}

--- a/thetis/__init__.py
+++ b/thetis/__init__.py
@@ -7,6 +7,7 @@ import thetis.solver2d as solver2d  # NOQA
 from thetis.callback import DiagnosticCallback  # NOQA
 import thetis.limiter as limiter      # NOQA
 from thetis._version import get_versions
+from thetis.assembledschur import AssembledSchurPC  # NOQA
 __version__ = get_versions()['version']
 del get_versions
 

--- a/thetis/assembledschur.py
+++ b/thetis/assembledschur.py
@@ -12,7 +12,6 @@ class AssembledSchurPC(PCBase):
         v and u are the test and trial of the 00 block. This gives the exact
         inverse of the mass matrix for a DG discretisation."""
     def initialize(self, pc):
-        print "Initializing AssembledSchurPC"
         _, P = pc.getOperators()
         ctx = P.getPythonContext()
         a = ctx.appctx['a']
@@ -24,40 +23,42 @@ class AssembledSchurPC(PCBase):
         v = TestFunction(V)
         u = TrialFunction(V)
         mass = dot(v, u)*dx
-        self.A00 = assemble(mass).M.handle
-        self.A00_inv = assemble(mass, inverse=True).M.handle
-        self.A00_inv.convert(PETSc.Mat.Type.AIJ)
+        self.A00_inv = assemble(mass, inverse=True, mat_type='aij').M.handle
         self.A10_A00_inv = None
         self.schur = None
         self.schur_plus = None
 
         fs = dict(formmanipulation.split_form(a))
-        self.a01 = fs[(0, 1)]
-        self.a10 = fs[(1, 0)]
-        self.a11 = fs[(1, 1)]
+        self.a01 = fs[(0,1)]
+        self.a10 = fs[(1,0)]
+        self.a11 = fs[(1,1)]
+        self.A01 = None
+        self.A10 = None
+        self.A11 = None
         self.ksp = PETSc.KSP().create()
         self.ksp.setOptionsPrefix(options_prefix + 'schur_')
         self.ksp.setFromOptions()
         self.update(pc)
 
     def update(self, pc):
-        print "Updating AssembledSchurPC"
-        self.A01 = assemble(self.a01).M.handle
-        self.A10 = assemble(self.a10).M.handle
-        self.A11 = assemble(self.a11).M.handle
+        self.A01 = assemble(self.a01, tensor=self.A01)
+        self.A10 = assemble(self.a10, tensor=self.A10)
+        self.A11 = assemble(self.a11, tensor=self.A11)
+        A01 = self.A01.M.handle
+        A10 = self.A10.M.handle
+        A11 = self.A11.M.handle
 
-        self.A10_A00_inv = self.A10.matMult(self.A00_inv, self.A10_A00_inv, 2.0)
-        self.schur = self.A10_A00_inv.matMult(self.A01, self.schur, 2.0)
+        self.A10_A00_inv = A10.matMult(self.A00_inv, self.A10_A00_inv, 2.0)
+        self.schur = self.A10_A00_inv.matMult(A01, self.schur, 2.0)
         if self.schur_plus is None:
-            self.schur_plus = self.schur.duplicate(copy=True)
+          self.schur_plus = self.schur.duplicate(copy=True)
+          self.schur_plus.aypx(-1.0, A11, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
         else:
-            self.schur_plus = self.schur.copy(self.schur_plus, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
-        self.schur_plus.aypx(-1.0, self.A11, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
+          self.schur_plus = self.schur.copy(self.schur_plus, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
+          self.schur_plus.aypx(-1.0, A11, PETSc.Mat.Structure.SAME_NONZERO_PATTERN)
         self.ksp.setOperators(self.schur_plus)
 
     def apply(self, pc, X, Y):
-        print "Applying AssembledSchurPC"
-
         self.ksp.solve(X, Y)
         r = self.ksp.getConvergedReason()
         if r < 0:

--- a/thetis/assembledschur.py
+++ b/thetis/assembledschur.py
@@ -1,6 +1,7 @@
 from firedrake import *
 from petsc4py import PETSc
 
+
 class AssembledSchurPC(PCBase):
     """Preconditioner for the Schur complement, where the preconditioner
     matrix is assembled by explicitly matrix multiplying A10*Minv*A10. Here:
@@ -31,9 +32,9 @@ class AssembledSchurPC(PCBase):
         self.schur_plus = None
 
         fs = dict(formmanipulation.split_form(a))
-        self.a01 = fs[(0,1)]
-        self.a10 = fs[(1,0)]
-        self.a11 = fs[(1,1)]
+        self.a01 = fs[(0, 1)]
+        self.a10 = fs[(1, 0)]
+        self.a11 = fs[(1, 1)]
         self.ksp = PETSc.KSP().create()
         self.ksp.setOptionsPrefix(options_prefix + 'schur_')
         self.ksp.setFromOptions()
@@ -48,9 +49,9 @@ class AssembledSchurPC(PCBase):
         self.A10_A00_inv = self.A10.matMult(self.A00_inv, self.A10_A00_inv, 2.0)
         self.schur = self.A10_A00_inv.matMult(self.A01, self.schur, 2.0)
         if self.schur_plus is None:
-          self.schur_plus = self.schur.duplicate(copy=True)
+            self.schur_plus = self.schur.duplicate(copy=True)
         else:
-          self.schur_plus = self.schur.copy(self.schur_plus, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
+            self.schur_plus = self.schur.copy(self.schur_plus, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
         self.schur_plus.aypx(-1.0, self.A11, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
         self.ksp.setOperators(self.schur_plus)
 

--- a/thetis/assembledschur.py
+++ b/thetis/assembledschur.py
@@ -29,9 +29,9 @@ class AssembledSchurPC(PCBase):
         self.schur_plus = None
 
         fs = dict(formmanipulation.split_form(a))
-        self.a01 = fs[(0,1)]
-        self.a10 = fs[(1,0)]
-        self.a11 = fs[(1,1)]
+        self.a01 = fs[(0, 1)]
+        self.a10 = fs[(1, 0)]
+        self.a11 = fs[(1, 1)]
         self.A01 = None
         self.A10 = None
         self.A11 = None
@@ -51,11 +51,11 @@ class AssembledSchurPC(PCBase):
         self.A10_A00_inv = A10.matMult(self.A00_inv, self.A10_A00_inv, 2.0)
         self.schur = self.A10_A00_inv.matMult(A01, self.schur, 2.0)
         if self.schur_plus is None:
-          self.schur_plus = self.schur.duplicate(copy=True)
-          self.schur_plus.aypx(-1.0, A11, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
+            self.schur_plus = self.schur.duplicate(copy=True)
+            self.schur_plus.aypx(-1.0, A11, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
         else:
-          self.schur_plus = self.schur.copy(self.schur_plus, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
-          self.schur_plus.aypx(-1.0, A11, PETSc.Mat.Structure.SAME_NONZERO_PATTERN)
+            self.schur_plus = self.schur.copy(self.schur_plus, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
+            self.schur_plus.aypx(-1.0, A11, PETSc.Mat.Structure.SAME_NONZERO_PATTERN)
         self.ksp.setOperators(self.schur_plus)
 
     def apply(self, pc, X, Y):

--- a/thetis/assembledschur.py
+++ b/thetis/assembledschur.py
@@ -1,5 +1,5 @@
 from firedrake import *
-from firedrake.petsc import PETSc
+from petsc4py import PETSc
 
 class AssembledSchurPC(PCBase):
     """Preconditioner for the Schur complement, where the preconditioner

--- a/thetis/assembledschur.py
+++ b/thetis/assembledschur.py
@@ -71,6 +71,7 @@ class AssembledSchurPC(PCBase):
         if viewer.getType() != PETSc.Viewer.Type.ASCII:
             return
         viewer.pushASCIITab()
+        viewer.printfASCII("Solves assembled Schur system D - C M.inv C^T\n")
         self.ksp.view(viewer)
         viewer.popASCIITab()
 

--- a/thetis/assembledschur.py
+++ b/thetis/assembledschur.py
@@ -1,0 +1,76 @@
+from firedrake import *
+from firedrake.petsc import PETSc
+
+class AssembledSchurPC(PCBase):
+    """Preconditioner for the Schur complement, where the preconditioner
+    matrix is assembled by explicitly matrix multiplying A10*Minv*A10. Here:
+    A01, A10 are the assembled sub-blocks of the saddle point system. The form
+        of this system needs to be supplied in the appctx to the solver as appctx['a']
+    Minv is the inverse of the mass-matrix which is assembled as
+        assemble(v*u*dx, inverse=True), i.e. the element-wise inverse, where
+        v and u are the test and trial of the 00 block. This gives the exact
+        inverse of the mass matrix for a DG discretisation."""
+    def initialize(self, pc):
+        print "Initializing AssembledSchurPC"
+        _, P = pc.getOperators()
+        ctx = P.getPythonContext()
+        a = ctx.appctx['a']
+        options_prefix = pc.getOptionsPrefix()
+
+        test, trial = a.arguments()
+        W = test.function_space()
+        V, Q = W.split()
+        v = TestFunction(V)
+        u = TrialFunction(V)
+        mass = dot(v, u)*dx
+        self.A00 = assemble(mass).M.handle
+        self.A00_inv = assemble(mass, inverse=True).M.handle
+        self.A00_inv.convert(PETSc.Mat.Type.AIJ)
+        self.A10_A00_inv = None
+        self.schur = None
+        self.schur_plus = None
+
+        fs = dict(formmanipulation.split_form(a))
+        self.a01 = fs[(0,1)]
+        self.a10 = fs[(1,0)]
+        self.a11 = fs[(1,1)]
+        self.ksp = PETSc.KSP().create()
+        self.ksp.setOptionsPrefix(options_prefix + 'schur_')
+        self.ksp.setFromOptions()
+        self.update(pc)
+
+    def update(self, pc):
+        print "Updating AssembledSchurPC"
+        self.A01 = assemble(self.a01).M.handle
+        self.A10 = assemble(self.a10).M.handle
+        self.A11 = assemble(self.a11).M.handle
+
+        self.A10_A00_inv = self.A10.matMult(self.A00_inv, self.A10_A00_inv, 2.0)
+        self.schur = self.A10_A00_inv.matMult(self.A01, self.schur, 2.0)
+        if self.schur_plus is None:
+          self.schur_plus = self.schur.duplicate(copy=True)
+        else:
+          self.schur_plus = self.schur.copy(self.schur_plus, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
+        self.schur_plus.aypx(-1.0, self.A11, PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN)
+        self.ksp.setOperators(self.schur_plus)
+
+    def apply(self, pc, X, Y):
+        print "Applying AssembledSchurPC"
+
+        self.ksp.solve(X, Y)
+        r = self.ksp.getConvergedReason()
+        if r < 0:
+            raise RuntimeError("LinearSolver failed to converge after %d iterations with reason: %s", self.ksp.getIterationNumber(), solving_utils.KSPReasons[r])
+
+    def view(self, pc, viewer=None):
+        super(AssembledSchurPC, self).view(pc, viewer)
+        if viewer is None:
+            return
+        if viewer.getType() != PETSc.Viewer.Type.ASCII:
+            return
+        viewer.pushASCIITab()
+        self.ksp.view(viewer)
+        viewer.popASCIITab()
+
+    def applyTranspose(self, pc, X, Y):
+        raise NotImplemented("applyTranspose not implemented for AssembledSchurPC")

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -322,7 +322,8 @@ class FlowSolver2d(FrozenClass):
                                                                        solver_parameters=self.options.timestepper_options.solver_parameters_pressure,
                                                                        solver_parameters_mom=self.options.timestepper_options.solver_parameters_momentum,
                                                                        semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
-                                                                       theta=self.options.timestepper_options.implicitness_theta)
+                                                                       theta=self.options.timestepper_options.implicitness_theta,
+                                                                       iterations=self.options.timestepper_options.picard_iterations)
 
         elif self.options.timestepper_type == 'SSPIMEX':
             # TODO meaningful solver params

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -408,8 +408,10 @@ class PressureProjectionPicard(TimeIntegrator):
         for it in range(self.iterations):
             if self.iterations > 1:
                 self.solution_lagged.assign(self.solution)
-            self.solver_mom.solve()
-            self.solver.solve()
+            with timed_stage("Momentum solve"):
+                self.solver_mom.solve()
+            with timed_stage("Pressure solve"):
+                self.solver.solve()
 
         # shift time
         for k in self.fields_old:

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -319,6 +319,20 @@ class PressureProjectionPicard(TimeIntegrator):
         uv_lagged, eta_lagged = self.solution_lagged.split()
         uv_old, eta_old = self.solution_old.split()
 
+        if (solver_parameters['ksp_type'] == 'preonly'
+                and 'fieldsplit_H_2d' in solver_parameters
+                and solver_parameters['fieldsplit_H_2d']['ksp_type'] == 'preonly'
+                and solver_parameters['fieldsplit_H_2d']['pc_python_type'] == 'thetis.AssembledSchurPC'
+                and element_continuity(eta_old.function_space().ufl_element()).horizontal != 'cg'):
+            # the default settings use AssembledSchurPC which assumes that the velocity block is only a dg mass matrix
+            # Under these assumptions this preconditioner assembles the exact Schur complement. If this is not true, we either need
+            # iterations with the unassembled Schur complement (fieldsplit_H_2d_ksp_type), or alternatively iterations outside
+            # the fieldsplit to deal with the fact that we haven't solved the Schur complement exactly.
+            # Currently only the dg-cg element pair, gives a pure DG  mass matrix velocity block: for dg-dg the pressure gradient adds a
+            # Riemann term in the velocity block, for rt-dg the velocity block cannot be explicitly inverted either.
+            raise Exception("The timestepper PressureProjectionPicard is only recommended in combination with the "
+                            "dg-cg element_family. If you want to use it in combination with dg-dg or rt-dg you need to adjust the solver_parameters_pressure option.")
+
         # create functions to hold the values of previous time step
         self.fields_old = {}
         for k in self.fields:

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -388,6 +388,7 @@ class PressureProjectionPicard(TimeIntegrator):
             self.solver_parameters['mat_type'] = 'aij'
         prob = NonlinearVariationalProblem(self.F, self.solution)
         self.solver = NonlinearVariationalSolver(prob,
+                                                 appctx={'a': derivative(self.F, self.solution)},
                                                  solver_parameters=self.solver_parameters,
                                                  options_prefix=self.name)
 


### PR DESCRIPTION
Add a AssembledSchurPC preconditioner that can be used to solve the schur system with the 'pressureprojectionpicard' timestepper. This gives very good performance with the dg-cg element pair for the depth-averaged equations.

The AssembledSchurPC provides a preconditioner for the schur system of the velocity-pressure system [[K,G],[C, P]] by explicitly assembling (an approximation to) it, assuming the velocity is DG and the velocity block K is just a mass matrix M. This is true for the pressureprojectionpicard time integration with dg-cg as the other terms in the momentum equation are solved in a separate step. dg-cg has the particular advantage that the stencil of C M^-1 G is compact (it's the same as that of the standard Laplacian in pressure space). For dg-dg it becomes a lot bigger. Also currently, even with pressureprojectionpicard the velocity block K of the dg-dg discretisation contains an additional term which stems from the stabilisation of the pressure gradient. In cases where M != K the AssembledSchurPC could still be used as an approximate preconditioner.

This is perhaps a little specific, and maybe it should live somewhere else in the long run - but it is something that we use in all large-scale tidal runs at AMCG so it would be very useful to have it available out of the box.

