### PR TITLE
Fixes for non-deterministic iteration order

### DIFF
--- a/thetis/equation.py
+++ b/thetis/equation.py
@@ -4,6 +4,7 @@ Implements Equation and Term classes.
 """
 from __future__ import absolute_import
 from .utility import *
+from collections import OrderedDict
 
 
 class Term(object):
@@ -61,7 +62,7 @@ class Equation(object):
     """
     Implements an equation, made out of terms.
     """
-    SUPPORTED_LABELS = ['source', 'explicit', 'implicit', 'nonlinear']
+    SUPPORTED_LABELS = frozenset(['source', 'explicit', 'implicit', 'nonlinear'])
     """
     Valid labels for terms, indicating how they should be treated in the time
     integrator.
@@ -83,7 +84,7 @@ class Equation(object):
         """
         :arg function_space: the :class:`FunctionSpace` the solution belongs to
         """
-        self.terms = {}
+        self.terms = OrderedDict()
         self.labels = {}
         self.function_space = function_space
         self.mesh = self.function_space.mesh()
@@ -140,12 +141,12 @@ class Equation(object):
             if label == 'all':
                 labels = self.SUPPORTED_LABELS
             else:
-                labels = [label]
+                labels = frozenset([label])
         else:
-            labels = list(label)
-        for key in self.terms:
+            labels = frozenset(label)
+        for key, value in self.terms.items():
             if self.labels[key] in labels:
-                yield self.terms[key]
+                yield value
 
     def residual(self, label, solution, solution_old, fields, fields_old, bnd_conditions):
         """

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -4,6 +4,7 @@ Routines for handling file exports.
 from __future__ import absolute_import
 from .utility import *
 from firedrake.output import is_cg
+from collections import OrderedDict
 import itertools
 
 
@@ -238,7 +239,7 @@ class ExportManager(object):
         self.coords_dg_2d = None
         self.coords_dg_3d = None
         # for each field create an exporter
-        self.exporters = {}
+        self.exporters = OrderedDict()
         for key in fields_to_export:
             shortname = self.field_metadata[key]['shortname']
             fn = self.field_metadata[key]['filename']

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -957,20 +957,19 @@ class ShallowWaterMomentumEquation(BaseShallowWaterEquation):
     2D depth averaged momentum equation :eq:`swe_momentum` in non-conservative
     form.
     """
-    def __init__(self, eta_test, eta_space, u_space,
+    def __init__(self, u_test, u_space, eta_space,
                  bathymetry,
                  options):
         """
-        :arg eta_test: test function of the elevation function space
-        :arg eta_space: elevation function space
+        :arg u_test: test function of the velocity function space
         :arg u_space: velocity function space
-        :arg function_space: Mixed function space where the solution belongs
+        :arg eta_space: elevation function space
         :arg bathymetry: bathymetry of the domain
         :type bathymetry: :class:`Function` or :class:`Constant`
         :arg options: :class:`.AttrDict` object containing all circulation model options
         """
         super(ShallowWaterMomentumEquation, self).__init__(u_space, bathymetry, options)
-        self.add_momentum_terms(eta_test, u_space, eta_space,
+        self.add_momentum_terms(u_test, u_space, eta_space,
                                 bathymetry, options)
 
     def residual(self, label, solution, solution_old, fields, fields_old, bnd_conditions):

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -17,6 +17,7 @@ from .field_defs import field_metadata
 from .options import ModelOptions3d
 from . import callback
 from .log import *
+from collections import OrderedDict
 
 
 class FlowSolver(FrozenClass):
@@ -711,7 +712,7 @@ class FlowSolver(FrozenClass):
 
         # ----- File exporters
         # create export_managers and store in a list
-        self.exporters = {}
+        self.exporters = OrderedDict()
         if not self.options.no_exports:
             e = exporter.ExportManager(self.options.output_directory,
                                        self.options.fields_to_export,
@@ -911,8 +912,8 @@ class FlowSolver(FrozenClass):
         # set uv to total uv instead of deviation from depth average
         # TODO find a cleaner way of doing this ...
         self.fields.uv_3d += self.fields.uv_dav_3d
-        for key in self.exporters:
-            self.exporters[key].export()
+        for e in self.exporters.values():
+            e.export()
         # restore uv_3d
         self.fields.uv_3d -= self.fields.uv_dav_3d
 
@@ -994,8 +995,8 @@ class FlowSolver(FrozenClass):
         else:
             offset = 1
         self.next_export_t += self.options.simulation_export_time
-        for k in self.exporters:
-            self.exporters[k].set_next_export_ix(self.i_export + offset)
+        for e in self.exporters.values():
+            e.set_next_export_ix(self.i_export + offset)
 
     def print_state(self, cputime):
         """

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -312,7 +312,7 @@ class FlowSolver2d(FrozenClass):
 
             u_test = TestFunction(self.function_spaces.U_2d)
             self.eq_mom = shallowwater_eq.ShallowWaterMomentumEquation(
-                u_test, self.function_spaces.H_2d, self.function_spaces.U_2d,
+                u_test, self.function_spaces.U_2d, self.function_spaces.H_2d,
                 self.fields.bathymetry_2d,
                 options=self.options
             )

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -14,6 +14,7 @@ from .field_defs import field_metadata
 from .options import ModelOptions2d
 from . import callback
 from .log import *
+from collections import OrderedDict
 
 
 class FlowSolver2d(FrozenClass):
@@ -357,7 +358,7 @@ class FlowSolver2d(FrozenClass):
         uv_2d, elev_2d = self.fields.solution_2d.split()
         self.fields.uv_2d = uv_2d
         self.fields.elev_2d = elev_2d
-        self.exporters = {}
+        self.exporters = OrderedDict()
         if not self.options.no_exports:
             e = exporter.ExportManager(self.options.output_directory,
                                        self.options.fields_to_export,
@@ -428,8 +429,8 @@ class FlowSolver2d(FrozenClass):
         Also evaluates all callbacks set to 'export' interval.
         """
         self.callbacks.evaluate(mode='export')
-        for key in self.exporters:
-            self.exporters[key].export()
+        for e in self.exporters.values():
+            e.export()
 
     def load_state(self, i_export, outputdir=None, t=None, iteration=None):
         """
@@ -485,8 +486,8 @@ class FlowSolver2d(FrozenClass):
         else:
             offset = 1
         self.next_export_t += self.options.simulation_export_time
-        for k in self.exporters:
-            self.exporters[k].set_next_export_ix(self.i_export + offset)
+        for e in self.exporters.values():
+            e.set_next_export_ix(self.i_export + offset)
 
     def print_state(self, cputime):
         """

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -382,11 +382,13 @@ class PressureProjectionPicard(TimeIntegrator):
             )
         )
         # subtract G eta_lagged: G is the implicit term in the mom. eqn.
-        for term in self.equation_mom.select_terms('implicit'):
-            self.F += -self.dt_const*(
-                - theta_const*term.residual(self.uv_star, eta_lagged, uv_star_nl, eta_lagged, self.fields, self.fields, bnd_conditions)
-                - (1-theta_const)*term.residual(uv_old, eta_old, uv_old, eta_old, self.fields_old, self.fields_old, bnd_conditions)
-            )
+        for key in self.equation_mom.terms:
+            if self.equation_mom.labels[key] == 'implicit':
+                term = self.equation.terms[key]
+                self.F += -self.dt_const*(
+                    - theta_const*term.residual(self.uv_star, eta_lagged, uv_star_nl, eta_lagged, self.fields, self.fields, bnd_conditions)
+                    - (1-theta_const)*term.residual(uv_old, eta_old, uv_old, eta_old, self.fields_old, self.fields_old, bnd_conditions)
+                )
 
         self.update_solver()
 

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -94,7 +94,7 @@ class ForwardEuler(TimeIntegrator):
 
         # create functions to hold the values of previous time step
         self.fields_old = {}
-        for k in self.fields:
+        for k in sorted(self.fields):
             if self.fields[k] is not None:
                 if isinstance(self.fields[k], FiredrakeFunction):
                     self.fields_old[k] = Function(
@@ -120,7 +120,7 @@ class ForwardEuler(TimeIntegrator):
         """Assigns initial conditions to all required fields."""
         self.solution_old.assign(solution)
         # assign values to old functions
-        for k in self.fields_old:
+        for k in sorted(self.fields_old):
             self.fields_old[k].assign(self.fields[k])
 
     def advance(self, t, update_forcings=None):
@@ -131,7 +131,7 @@ class ForwardEuler(TimeIntegrator):
         self.solution_old.assign(self.solution)
         self.solver.solve()
         # shift time
-        for k in self.fields_old:
+        for k in sorted(self.fields_old):
             self.fields_old[k].assign(self.fields[k])
 
 
@@ -162,7 +162,7 @@ class CrankNicolson(TimeIntegrator):
         # create functions to hold the values of previous time step
         # TODO is this necessary? is self.fields sufficient?
         self.fields_old = {}
-        for k in self.fields:
+        for k in sorted(self.fields):
             if self.fields[k] is not None:
                 if isinstance(self.fields[k], FiredrakeFunction):
                     self.fields_old[k] = Function(
@@ -207,7 +207,7 @@ class CrankNicolson(TimeIntegrator):
         """Assigns initial conditions to all required fields."""
         self.solution_old.assign(solution)
         # assign values to old functions
-        for k in self.fields_old:
+        for k in sorted(self.fields_old):
             self.fields_old[k].assign(self.fields[k])
 
     def advance(self, t, update_forcings=None):
@@ -217,7 +217,7 @@ class CrankNicolson(TimeIntegrator):
         self.solution_old.assign(self.solution)
         self.solver.solve()
         # shift time
-        for k in self.fields_old:
+        for k in sorted(self.fields_old):
             self.fields_old[k].assign(self.fields[k])
 
 
@@ -335,7 +335,7 @@ class PressureProjectionPicard(TimeIntegrator):
 
         # create functions to hold the values of previous time step
         self.fields_old = {}
-        for k in self.fields:
+        for k in sorted(self.fields):
             if self.fields[k] is not None:
                 if isinstance(self.fields[k], Function):
                     self.fields_old[k] = Function(
@@ -382,12 +382,11 @@ class PressureProjectionPicard(TimeIntegrator):
             )
         )
         # subtract G eta_lagged: G is the implicit term in the mom. eqn.
-        for key in self.equation_mom.terms:
-            if self.equation_mom.labels[key] == 'implicit':
-                self.F += -self.dt_const*(
-                    - theta_const*self.equation.terms[key].residual(self.uv_star, eta_lagged, uv_star_nl, eta_lagged, self.fields, self.fields, bnd_conditions)
-                    - (1-theta_const)*self.equation.terms[key].residual(uv_old, eta_old, uv_old, eta_old, self.fields_old, self.fields_old, bnd_conditions)
-                )
+        for term in self.equation_mom.select_terms('implicit'):
+            self.F += -self.dt_const*(
+                - theta_const*term.residual(self.uv_star, eta_lagged, uv_star_nl, eta_lagged, self.fields, self.fields, bnd_conditions)
+                - (1-theta_const)*term.residual(uv_old, eta_old, uv_old, eta_old, self.fields_old, self.fields_old, bnd_conditions)
+            )
 
         self.update_solver()
 
@@ -411,7 +410,7 @@ class PressureProjectionPicard(TimeIntegrator):
         self.solution_old.assign(solution)
         self.solution_lagged.assign(solution)
         # assign values to old functions
-        for k in self.fields_old:
+        for k in sorted(self.fields_old):
             self.fields_old[k].assign(self.fields[k])
 
     def advance(self, t, updateForcings=None):
@@ -429,7 +428,7 @@ class PressureProjectionPicard(TimeIntegrator):
                 self.solver.solve()
 
         # shift time
-        for k in self.fields_old:
+        for k in sorted(self.fields_old):
             self.fields_old[k].assign(self.fields[k])
 
 

--- a/thetis/turbulence.py
+++ b/thetis/turbulence.py
@@ -353,10 +353,9 @@ class ShearFrequencySolver(object):
         self.minval = minval
         self.relaxation = relaxation
 
-        self.var_solvers = {}
+        self.var_solvers = []
         for i_comp in range(2):
-            solver = VerticalGradSolver(uv[i_comp], mu_tmp)
-            self.var_solvers[i_comp] = solver
+            self.var_solvers.append(VerticalGradSolver(uv[i_comp], mu_tmp))
 
     def solve(self, init_solve=False):
         """
@@ -369,8 +368,8 @@ class ShearFrequencySolver(object):
         with timed_stage('shear_freq_solv'):
             mu_comp = [self.mu, self.mv]
             self.m2.assign(0.0)
-            for i_comp in range(2):
-                self.var_solvers[i_comp].solve()
+            for i_comp, solver in enumerate(self.var_solvers):
+                solver.solve()
                 gamma = self.relaxation if not init_solve else 1.0
                 mu_comp[i_comp].assign(gamma*self.mu_tmp +
                                        (1.0 - gamma)*mu_comp[i_comp])
@@ -409,8 +408,6 @@ class BuoyFrequencySolver(object):
             self.n2 = n2
             self.n2_tmp = n2_tmp
             self.relaxation = relaxation
-
-            self.var_solvers = {}
 
             g = physical_constants['g_grav']
             rho0 = physical_constants['rho0']


### PR DESCRIPTION
We have to be careful that we iterate over dict-like objects in a
consistent order.  Arrange for that either by using OrderedDict or
iterating over sorted keys.