### PR TITLE
Detector callback

### DIFF
--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -75,6 +75,7 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, do_export=Fa
     xy = select_and_move_detectors(mesh2d, xy, maximum_distance=lx)
     # thus we should end up with only the first one removed
     assert len(xy)==3
+    np.testing.assert_almost_equal(xy[0][0], lx/nx/3.)
     cb = DetectorsCallback(solver_obj, xy, ['elev_2d', 'uv_2d'])
     solver_obj.add_callback(cb)
 

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -76,8 +76,13 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, do_export=Fa
     # thus we should end up with only the first one removed
     assert len(xy)==3
     np.testing.assert_almost_equal(xy[0][0], lx/nx/3.)
-    cb = DetectorsCallback(solver_obj, xy, ['elev_2d', 'uv_2d'])
-    solver_obj.add_callback(cb)
+    # first set of detectors
+    cb1 = DetectorsCallback(solver_obj, xy, ['elev_2d', 'uv_2d'], name='set1')
+    # same set in reverse order, now with named detectors and only elevations
+    cb2 = DetectorsCallback(solver_obj, xy[::-1], ['elev_2d',], name='set2',
+                            detector_names=['two', 'one', 'zero'])
+    solver_obj.add_callback(cb1)
+    solver_obj.add_callback(cb2)
 
     solver_obj.iterate()
 
@@ -89,12 +94,16 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, do_export=Fa
     assert(rel_err < max_rel_err)
     print_output("PASSED")
 
-    with h5py.File('outputs/diagnostic_detectors.hdf5', 'r') as df:
+    with h5py.File('outputs/diagnostic_set1.hdf5', 'r') as df:
         assert all(df.attrs['field_dims'][:]==[1,2])
         trange = np.arange(n+1)*dt
         np.testing.assert_almost_equal(df['time'][:,0], trange)
         x = lx/4.  # location of detector1
         np.testing.assert_allclose(df['detector1'][:][:,0], np.cos(pi*x/lx)*np.cos(2*pi*trange/period), atol=5e-2, rtol=0.5)
+    with h5py.File('outputs/diagnostic_set2.hdf5', 'r') as df:
+        assert all(df.attrs['field_dims'][:]==[1,])
+        x = lx/4.  # location of detector1
+        np.testing.assert_allclose(df['one'][:][:,0], np.cos(pi*x/lx)*np.cos(2*pi*trange/period), atol=5e-2, rtol=0.5)
 
 
 if __name__ == '__main__':

--- a/thetis/__init__.py
+++ b/thetis/__init__.py
@@ -4,7 +4,7 @@ from thetis.log import *
 import thetis.timeintegrator as timeintegrator  # NOQA
 import thetis.solver as solver  # NOQA
 import thetis.solver2d as solver2d  # NOQA
-from thetis.callback import DiagnosticCallback  # NOQA
+from thetis.callback import DiagnosticCallback, DetectorsCallback  # NOQA
 import thetis.limiter as limiter      # NOQA
 import thetis.interpolation as interpolation      # NOQA
 import thetis.coordsys as coordsys      # NOQA

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -380,18 +380,19 @@ class TracerOvershootCallBack(MinMaxConservationCallback):
 
 class DetectorsCallback(DiagnosticCallback):
     """Callback that writes the specified fields interpolated in the specified detector locations"""
-    name = 'detectors'
-
     def __init__(self, solver_obj,
                  detector_locations,
                  field_names,
+                 name,
                  detector_names=None,
                  **kwargs):
         """
         :arg solver_obj: Thetis solver object
-        :list detector_locations: Locations in which fields are to be interpolated.
-        :list field_names: Fields to be interpolated.
-        :list detector_names: Names for each of the detectors. If not provided automatic names
+        :arg detector_locations: List of x, y locations in which fields are to be interpolated.
+        :arg field_names: List of fields to be interpolated.
+        :arg name: Unique name for this callback and its associated set of detectors. This determines the name
+           of the output h5 file (prefixed with diagnostic_).
+        :arg detector_names: List of names for each of the detectors. If not provided automatic names
            of the form 'detectorNNN' are created where NNN is the (0-padded) detector number.
         :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
         """
@@ -415,6 +416,11 @@ class DetectorsCallback(DiagnosticCallback):
         self._variable_names = detector_names
         self.detector_locations = detector_locations
         self.field_names = field_names
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
 
     @property
     def variable_names(self):

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -405,7 +405,7 @@ class DetectorsCallback(DiagnosticCallback):
         ndetectors = len(detector_locations)
         if detector_names is None:
             fill = len(str(ndetectors))
-            detector_names = ['detector' + str(i).zfill(fill) for i in range(ndetectors)]
+            detector_names = ['detector{:0{fill}d}'.format(i, fill=fill) for i in range(ndetectors)]
         else:
             assert ndetectors == len(detector_names), "Different number of detector locations and names"
         self._variable_names = detector_names

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -289,11 +289,7 @@ class VolumeConservation3DCallback(ScalarConservationCallback):
         """
         def vol3d():
             return comp_volume_3d(self.solver_obj.mesh)
-        super(VolumeConservation3DCallback, self).__init__(vol3d,
-                                                           solver_obj,
-                                                           outputdir=outputdir,
-                                                           export_to_hdf5=export_to_hdf5,
-                                                           append_to_log=append_to_log)
+        super(VolumeConservation3DCallback, self).__init__(vol3d, solver_obj, **kwargs)
 
 
 class VolumeConservation2DCallback(ScalarConservationCallback):
@@ -315,8 +311,7 @@ class TracerMassConservationCallback(ScalarConservationCallback):
     """Checks conservation of total tracer mass"""
     name = 'tracer mass'
 
-    def __init__(self, tracer_name, solver_obj, outputdir=None, export_to_hdf5=False,
-                 append_to_log=True):
+    def __init__(self, tracer_name, solver_obj, **kwargs):
         """
         :arg tracer_name: Name of the tracer. Use canonical field names as in :class:`.FieldDict`.
         :arg solver_obj: Thetis solver object

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -394,12 +394,12 @@ class DetectorsCallback(DiagnosticCallback):
         # printing all detector output to log is probably not a useful default:
         kwargs.setdefault('append_to_log', False)
         field_dims = [solver_obj.fields[field_name].function_space().value_size
-                          for field_name in field_names]
+                      for field_name in field_names]
         attrs = {
-                 # use null-padded ascii strings, dtype='U' not supported in hdf5, see http://docs.h5py.org/en/latest/strings.html
-                 'field_names': np.array(field_names, dtype='S'),
-                 'field_dims': field_dims,
-                }
+            # use null-padded ascii strings, dtype='U' not supported in hdf5, see http://docs.h5py.org/en/latest/strings.html
+            'field_names': np.array(field_names, dtype='S'),
+            'field_dims': field_dims,
+        }
         super().__init__(solver_obj, array_dim=sum(field_dims), attrs=attrs, **kwargs)
 
         ndetectors = len(detector_locations)

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -8,6 +8,8 @@ from abc import ABCMeta, abstractproperty, abstractmethod
 import h5py
 from collections import defaultdict
 from .log import *
+from .firedrake import *
+import numpy as np
 
 
 class CallbackManager(defaultdict):
@@ -63,7 +65,7 @@ class DiagnosticHDF5(object):
     A HDF5 file for storing diagnostic time series arrays.
     """
     def __init__(self, filename, varnames, array_dim=1, attrs=None,
-                 comm=COMM_WORLD, new_file=True):
+                 comm=COMM_WORLD, new_file=True, dtype='d'):
         """
         :arg str filename: Full filename of the HDF5 file.
         :arg varnames: List of variable names that the diagnostic callback
@@ -83,10 +85,10 @@ class DiagnosticHDF5(object):
             # create empty file with correct datasets
             with h5py.File(filename, 'w') as hdf5file:
                 hdf5file.create_dataset('time', (0, 1),
-                                        maxshape=(None, 1))
+                                        maxshape=(None, 1), dtype=dtype)
                 for var in self.varnames:
                     hdf5file.create_dataset(var, (0, array_dim),
-                                            maxshape=(None, array_dim))
+                                            maxshape=(None, array_dim), dtype=dtype)
                 if attrs is not None:
                     hdf5file.attrs.update(attrs)
 
@@ -132,9 +134,11 @@ class DiagnosticCallback(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, solver_obj, outputdir=None, array_dim=1, attrs=None,
+    def __init__(self, solver_obj, array_dim=1, attrs=None,
+                 outputdir=None,
                  export_to_hdf5=True,
-                 append_to_log=True):
+                 append_to_log=True,
+                 hdf5_dtype='d'):
         """
         :arg solver_obj: Thetis solver object
         :kwarg str outputdir: Custom directory where hdf5 files will be stored. By
@@ -145,6 +149,8 @@ class DiagnosticCallback(object):
             format
         :kwarg bool append_to_log: If True, callback output messages will be printed
             in log
+        :kwarg hdf5_dtype: Precision to use in hdf5 output: 'd' for double precision (default),
+            and 'f for single precision
         """
         self.solver_obj = solver_obj
         if outputdir is None:
@@ -155,6 +161,7 @@ class DiagnosticCallback(object):
         self.attrs = attrs
         self.append_to_hdf5 = export_to_hdf5
         self.append_to_log = append_to_log
+        self.hdf5_dtype = hdf5_dtype
         self._create_new_file = True
         self._hdf5_initialized = False
 
@@ -180,7 +187,7 @@ class DiagnosticCallback(object):
                                                array_dim=self.array_dim,
                                                new_file=self._create_new_file,
                                                attrs=self.attrs,
-                                               comm=comm)
+                                               comm=comm, dtype=self.hdf5_dtype)
         self._hdf5_initialized = True
 
     @abstractproperty
@@ -246,25 +253,16 @@ class ScalarConservationCallback(DiagnosticCallback):
     """Base class for callbacks that check conservation of a scalar quantity"""
     variable_names = ['integral', 'relative_difference']
 
-    def __init__(self, scalar_callback, solver_obj, outputdir=None, export_to_hdf5=False,
-                 append_to_log=True):
+    def __init__(self, scalar_callback, solver_obj, **kwargs):
         """
         Creates scalar conservation check callback object
 
         :arg scalar_callback: Python function that takes the solver object as an argument and
             returns a scalar quantity of interest
         :arg solver_obj: Thetis solver object
-        :kwarg str outputdir: Custom directory where hdf5 files will be stored. By
-            default solver's output directory is used.
-        :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
-            format
-        :kwarg bool append_to_log: If True, callback output messages will be printed
-            in log
+        :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
         """
-        super(ScalarConservationCallback, self).__init__(solver_obj,
-                                                         outputdir=outputdir,
-                                                         export_to_hdf5=export_to_hdf5,
-                                                         append_to_log=append_to_log)
+        super(ScalarConservationCallback, self).__init__(solver_obj, **kwargs)
         self.scalar_callback = scalar_callback
         self.initial_value = None
 
@@ -284,16 +282,10 @@ class VolumeConservation3DCallback(ScalarConservationCallback):
     """Checks conservation of 3D volume (volume of 3D mesh)"""
     name = 'volume3d'
 
-    def __init__(self, solver_obj, outputdir=None, export_to_hdf5=False,
-                 append_to_log=True):
+    def __init__(self, solver_obj, **kwargs):
         """
         :arg solver_obj: Thetis solver object
-        :kwarg str outputdir: Custom directory where hdf5 files will be stored. By
-            default solver's output directory is used.
-        :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
-            format
-        :kwarg bool append_to_log: If True, callback output messages will be printed
-            in log
+        :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
         """
         def vol3d():
             return comp_volume_3d(self.solver_obj.mesh)
@@ -308,25 +300,15 @@ class VolumeConservation2DCallback(ScalarConservationCallback):
     """Checks conservation of 2D volume (integral of water elevation field)"""
     name = 'volume2d'
 
-    def __init__(self, solver_obj, outputdir=None, export_to_hdf5=False,
-                 append_to_log=True):
+    def __init__(self, solver_obj, **kwargs):
         """
         :arg solver_obj: Thetis solver object
-        :kwarg str outputdir: Custom directory where hdf5 files will be stored. By
-            default solver's output directory is used.
-        :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
-            format
-        :kwarg bool append_to_log: If True, callback output messages will be printed
-            in log
+        :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
         """
         def vol2d():
             return comp_volume_2d(self.solver_obj.fields.elev_2d,
                                   self.solver_obj.fields.bathymetry_2d)
-        super(VolumeConservation2DCallback, self).__init__(vol2d,
-                                                           solver_obj,
-                                                           outputdir=outputdir,
-                                                           export_to_hdf5=export_to_hdf5,
-                                                           append_to_log=append_to_log)
+        super(VolumeConservation2DCallback, self).__init__(vol2d, solver_obj, **kwargs)
 
 
 class TracerMassConservationCallback(ScalarConservationCallback):
@@ -338,45 +320,27 @@ class TracerMassConservationCallback(ScalarConservationCallback):
         """
         :arg tracer_name: Name of the tracer. Use canonical field names as in :class:`.FieldDict`.
         :arg solver_obj: Thetis solver object
-        :kwarg str outputdir: Custom directory where hdf5 files will be stored. By
-            default solver's output directory is used.
-        :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
-            format
-        :kwarg bool append_to_log: If True, callback output messages will be printed
-            in log
+        :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
         """
         self.name = tracer_name + ' mass'  # override name for given tracer
 
         def mass():
             return comp_tracer_mass_3d(self.solver_obj.fields[tracer_name])
-        super(TracerMassConservationCallback, self).__init__(mass,
-                                                             solver_obj,
-                                                             outputdir=outputdir,
-                                                             export_to_hdf5=export_to_hdf5,
-                                                             append_to_log=append_to_log)
+        super(TracerMassConservationCallback, self).__init__(mass, solver_obj, **kwargs)
 
 
 class MinMaxConservationCallback(DiagnosticCallback):
     """Base class for callbacks that check conservation of a minimum/maximum"""
     variable_names = ['min_value', 'max_value', 'undershoot', 'overshoot']
 
-    def __init__(self, minmax_callback, solver_obj, outputdir=None, export_to_hdf5=False,
-                 append_to_log=True):
+    def __init__(self, minmax_callback, solver_obj, **kwargs):
         """
         :arg minmax_callback: Python function that takes the solver object as
             an argument and returns a (min, max) value tuple
         :arg solver_obj: Thetis solver object
-        :kwarg str outputdir: Custom directory where hdf5 files will be stored. By
-            default solver's output directory is used.
-        :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
-            format
-        :kwarg bool append_to_log: If True, callback output messages will be printed
-            in log
+        :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
         """
-        super(MinMaxConservationCallback, self).__init__(solver_obj,
-                                                         outputdir=outputdir,
-                                                         export_to_hdf5=export_to_hdf5,
-                                                         append_to_log=append_to_log)
+        super(MinMaxConservationCallback, self).__init__(solver_obj, **kwargs)
         self.minmax_callback = minmax_callback
         self.initial_value = None
 
@@ -397,17 +361,11 @@ class TracerOvershootCallBack(MinMaxConservationCallback):
     """Checks overshoots of the given tracer field."""
     name = 'tracer overshoot'
 
-    def __init__(self, tracer_name, solver_obj, outputdir=None, export_to_hdf5=False,
-                 append_to_log=True):
+    def __init__(self, tracer_name, solver_obj, **kwargs):
         """
         :arg tracer_name: Name of the tracer. Use canonical field names as in :class:`.FieldDict`.
         :arg solver_obj: Thetis solver object
-        :kwarg str outputdir: Custom directory where hdf5 files will be stored. By
-            default solver's output directory is used.
-        :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
-            format
-        :kwarg bool append_to_log: If True, callback output messages will be printed
-            in log
+        :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
         """
         self.name = tracer_name + ' overshoot'
 
@@ -417,8 +375,61 @@ class TracerOvershootCallBack(MinMaxConservationCallback):
             tracer_min = self.solver_obj.comm.allreduce(tracer_min, op=MPI.MIN)
             tracer_max = self.solver_obj.comm.allreduce(tracer_max, op=MPI.MAX)
             return tracer_min, tracer_max
-        super(TracerOvershootCallBack, self).__init__(minmax,
-                                                      solver_obj,
-                                                      outputdir=outputdir,
-                                                      export_to_hdf5=export_to_hdf5,
-                                                      append_to_log=append_to_log)
+        super(TracerOvershootCallBack, self).__init__(minmax, solver_obj, **kwargs)
+
+
+class DetectorsCallback(DiagnosticCallback):
+    """Callback that writes the specified fields interpolated in the specified detector locations"""
+    name = 'detectors'
+
+    def __init__(self, solver_obj,
+                 detector_locations,
+                 field_names,
+                 detector_names=None,
+                 **kwargs):
+        """
+        :arg solver_obj: Thetis solver object
+        :list detector_locations: Locations in which fields are to be interpolated.
+        :list field_names: Fields to be interpolated.
+        :list detector_names: Names for each of the detectors. If not provided automatic names
+           of the form 'detectorNNN' are created where NNN is the (0-padded) detector number.
+        :arg **kwargs: any additional keyword arguments, see DiagnosticCallback
+        """
+        # printing all detector output to log is probably not a useful default:
+        kwargs.setdefault('append_to_log', False)
+        field_dims = [solver_obj.fields[field_name].function_space().value_size
+                          for field_name in field_names]
+        attrs = {
+                 # use null-padded ascii strings, dtype='U' not supported in hdf5, see http://docs.h5py.org/en/latest/strings.html
+                 'field_names': np.array(field_names, dtype='S'),
+                 'field_dims': field_dims,
+                }
+        super().__init__(solver_obj, array_dim=sum(field_dims), attrs=attrs, **kwargs)
+
+        ndetectors = len(detector_locations)
+        if detector_names is None:
+            fill = len(str(ndetectors))
+            detector_names = ['detector' + str(i).zfill(fill) for i in range(ndetectors)]
+        else:
+            assert ndetectors == len(detector_names), "Different number of detector locations and names"
+        self._variable_names = detector_names
+        self.detector_locations = detector_locations
+        self.field_names = field_names
+
+    @property
+    def variable_names(self):
+        return self._variable_names
+
+    def _evaluate_field(self, field_name):
+        return self.solver_obj.fields[field_name](self.detector_locations)
+
+    def __call__(self):
+        """Evaluate all current fields in all detector locations
+
+        Returns a ndetectors x ndims array, where ndims is the sum of the dimension of the fields."""
+        ndetectors = len(self.detector_locations)
+        field_vals = []
+        for field_name in self.field_names:
+            field_vals.append(np.reshape(self._evaluate_field(field_name), (ndetectors, -1)))
+
+        return np.hstack(field_vals)

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1619,6 +1619,8 @@ def select_and_move_detectors(mesh, detector_locations, detector_names=None,
     accepted_names = []
     if detector_names is None:
         names = [None] * len(detector_locations)
+    else:
+        names = detector_names
     for location, name in zip(detector_locations, names):
         try:
             v(location)

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1607,10 +1607,10 @@ def select_and_move_detectors(mesh, detector_locations, detector_names=None,
 
     # comparison operator that sorts on first entry first, etc.
     def min_lexsort(x, y, datatype):
-        for xi, yi in zip(x,y):
-            if xi<yi:
+        for xi, yi in zip(x, y):
+            if xi < yi:
                 return x
-            elif yi<xi:
+            elif yi < xi:
                 return y
         # all entries the same:
         return x

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1581,7 +1581,19 @@ def compute_boundary_length(mesh2d):
 
 def select_and_move_detectors(mesh, detector_locations, detector_names=None,
                               maximum_distance=0.):
-    """Select those detectors that are within the domain and/or move them to the nearest cell centre within the domain."""
+    """Select those detectors that are within the domain and/or move them to
+    the nearest cell centre within the domain
+
+    :arg mesh: Defines the domain in which detectors are to be located
+    :arg detector_locations: List of x, y locations
+    :arg detector_names: List of detector names (optional). If provided, a list
+       of selected locations and a list of selected detector names are returned,
+       otherwise only a list of selected locations is returned
+    :arg maximum_distance: Detectors whose initial locations is outside the domain,
+      but for which the nearest cell centre is within the specified distance, are
+      moved to this location. By default a maximum distance of 0.0 is used, i.e
+      no detectors are moved.
+    """
     # auxilary function to test whether we can interpolate it in the given locations
     V = FunctionSpace(mesh, "CG", 1)
     v = Function(V)


### PR DESCRIPTION
Add a callback to write out interpolated fields at detector locations. Based on DiagnosticCallback, writes to diagnostic_detectors.h5 file.

Also includes a helper function that can select those detector locations
that are actually within the domain, and potentially move them inside
(if within some maximum distance) in the nearest cell centre.

Change default precision from dtype='f' (single precision) to dtype='d'
(double precision). All DiagnosticCallback derived callback classes can
pass a new hdf5_dtype keyword arg to override.