### PR TITLE
Fix restarts with a different dt

### DIFF
--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -1126,7 +1126,7 @@ class FlowSolver(FrozenClass):
                 self.exporters['vtk'].export_bathymetry(self.fields.bathymetry_2d)
 
         initial_simulation_time = self.simulation_time
-        iteration = 0
+        internal_iteration = 0
 
         while self.simulation_time <= self.options.simulation_end_time - t_epsilon:
 
@@ -1135,8 +1135,8 @@ class FlowSolver(FrozenClass):
 
              # Move to next time step
             self.iteration += 1
-            iteration += 1
-            self.simulation_time = initial_simulation_time + iteration*self.dt
+            internal_iteration += 1
+            self.simulation_time = initial_simulation_time + internal_iteration*self.dt
 
             self.callbacks.evaluate(mode='timestep')
 

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -1133,7 +1133,7 @@ class FlowSolver(FrozenClass):
             self.timestepper.advance(self.simulation_time,
                                      update_forcings, update_forcings3d)
 
-             # Move to next time step
+            # Move to next time step
             self.iteration += 1
             internal_iteration += 1
             self.simulation_time = initial_simulation_time + internal_iteration*self.dt

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -1125,14 +1125,18 @@ class FlowSolver(FrozenClass):
             if 'vtk' in self.exporters:
                 self.exporters['vtk'].export_bathymetry(self.fields.bathymetry_2d)
 
+        initial_simulation_time = self.simulation_time
+        iteration = 0
+
         while self.simulation_time <= self.options.simulation_end_time - t_epsilon:
 
             self.timestepper.advance(self.simulation_time,
                                      update_forcings, update_forcings3d)
 
-            # Move to next time step
-            self.simulation_time += self.dt
+             # Move to next time step
             self.iteration += 1
+            iteration += 1
+            self.simulation_time = initial_simulation_time + iteration*self.dt
 
             self.callbacks.evaluate(mode='timestep')
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -577,7 +577,7 @@ class FlowSolver2d(FrozenClass):
 
             # Move to next time step
             self.iteration += 1
-            self.simulation_time = self.iteration*self.dt
+            self.simulation_time += self.dt
 
             self.callbacks.evaluate(mode='timestep')
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -571,13 +571,17 @@ class FlowSolver2d(FrozenClass):
             if 'vtk' in self.exporters:
                 self.exporters['vtk'].export_bathymetry(self.fields.bathymetry_2d)
 
+        initial_simulation_time = self.simulation_time
+        iteration = 0
+
         while self.simulation_time <= self.options.simulation_end_time + t_epsilon:
 
             self.timestepper.advance(self.simulation_time, update_forcings)
 
             # Move to next time step
             self.iteration += 1
-            self.simulation_time += self.dt
+            iteration += 1
+            self.simulation_time = initial_simulation_time + iteration*self.dt
 
             self.callbacks.evaluate(mode='timestep')
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -572,7 +572,7 @@ class FlowSolver2d(FrozenClass):
                 self.exporters['vtk'].export_bathymetry(self.fields.bathymetry_2d)
 
         initial_simulation_time = self.simulation_time
-        iteration = 0
+        internal_iteration = 0
 
         while self.simulation_time <= self.options.simulation_end_time + t_epsilon:
 
@@ -580,8 +580,8 @@ class FlowSolver2d(FrozenClass):
 
             # Move to next time step
             self.iteration += 1
-            iteration += 1
-            self.simulation_time = initial_simulation_time + iteration*self.dt
+            internal_iteration += 1
+            self.simulation_time = initial_simulation_time + internal_iteration*self.dt
 
             self.callbacks.evaluate(mode='timestep')
 


### PR DESCRIPTION
Restarts with a different dt can be useful: if the code crashed after a while due to too large dt and one wants to restart from a previous checkpoint, or in adaptive simulations where the size of the elements is not explicitly controlled. This is not currently supported by Thetis, however, it *seems*  the small change proposed in this PR fixes the issue.

It was tested in an adaptation context, with many restarts, and does not seem to break anything.

Tests pass, however there seems to be a difference in the output with master which I cannot explain:
the following is my branch:
```
=========================================================================== warnings summary ===========================================================================
None
  Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.

test/solver3d/test_baroclinic_mms.py::test_baroclinic_mms
  /Users/barral/code/firedrake_thetis_allinvenv/src/thetis/thetis/solver.py:279: RuntimeWarning: divide by zero encountered in double_scalars
    dt = (min_dx)**2/nu
  /Users/barral/code/firedrake_thetis_allinvenv/src/thetis/thetis/solver.py:279: RuntimeWarning: divide by zero encountered in double_scalars
    dt = (min_dx)**2/nu
  /Users/barral/code/firedrake_thetis_allinvenv/src/thetis/thetis/solver.py:279: RuntimeWarning: divide by zero encountered in double_scalars
    dt = (min_dx)**2/nu

-- Docs: http://doc.pytest.org/en/latest/warnings.html
============================================== 337 passed, 4 skipped, 4 xfailed, 2 xpassed, 4 warnings in 2223.02 seconds ==============================================
```

the following is master:
```
========================================================================== warnings summary ===========================================================================
None
  Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.

test/solver3d/test_baroclinic_mms.py::test_baroclinic_mms
  /Users/barral/code/firedrake_thetis_allinvenv/src/thetis/thetis/solver.py:279: RuntimeWarning: divide by zero encountered in double_scalars
    dt = (min_dx)**2/nu

-- Docs: http://doc.pytest.org/en/latest/warnings.html
============================================== 337 passed, 4 skipped, 4 xfailed, 2 xpassed, 2 warnings in 893.38 seconds ==============================================
```

Is it related ? (not at first sight...)