### PR TITLE
This PR frees a MPI user-defined operation, and OMG you won't believe what happens next

### DIFF
--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -49,7 +49,7 @@ solver_obj.options.solver_parameters_sw = {
     'mat_type': 'aij',
     'ksp_type': 'preonly',
     'pc_type': 'lu',
-    'pc_factor_mat_solver_package': 'mumps',
+    'pc_factor_mat_solver_type': 'mumps',
     'snes_monitor': False,
     'snes_type': 'newtonls',
 }

--- a/test/swe2d/test_steady_state_channel.py
+++ b/test/swe2d/test_steady_state_channel.py
@@ -31,7 +31,7 @@ def test_steady_state_channel(do_export=False):
     solver_obj.options.timestepper_options.solver_parameters = {
         'ksp_type': 'preonly',
         'pc_type': 'lu',
-        'pc_factor_mat_solver_package': 'mumps',
+        'pc_factor_mat_solver_type': 'mumps',
         'snes_monitor': False,
         'snes_type': 'newtonls',
     }

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -61,7 +61,7 @@ def test_steady_state_channel_mms(options):
         solver_obj.options.timestepper_options.solver_parameters = {
             'ksp_type': 'preonly',
             'pc_type': 'lu',
-            'pc_factor_mat_solver_package': 'mumps',
+            'pc_factor_mat_solver_type': 'mumps',
             'snes_monitor': False,
             'snes_type': 'newtonls',
         }

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -77,7 +77,7 @@ def setup_steady():
         'mat_type': 'aij',
         'ksp_type': 'preonly',
         'pc_type': 'lu',
-        'pc_factor_mat_solver_package': 'mumps',
+        'pc_factor_mat_solver_type': 'mumps',
         'snes_monitor': False,
         'snes_type': 'newtonls',
     }
@@ -94,7 +94,7 @@ def setup_unsteady():
         'mat_type': 'aij',
         'ksp_type': 'preonly',
         'pc_type': 'lu',
-        'pc_factor_mat_solver_package': 'mumps',
+        'pc_factor_mat_solver_type': 'mumps',
         'snes_monitor': False,
         'snes_type': 'newtonls',
     }

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1657,6 +1657,8 @@ def select_and_move_detectors(mesh, detector_locations, detector_names=None,
         accepted_locations.append(location)
         accepted_names.append(name)
 
+    min_lexsort_op.Free()
+
     if detector_names is None:
         return accepted_locations
     else:


### PR DESCRIPTION
Not freeing this operation results in MPI crashing with error "cannot create too many user-defined reduction operations" when multiple restarts are done (in adaptive simulations for instance). Hence the proposed fix.