### PR TITLE
Solve tracer equation in P1 space

### DIFF
--- a/thetis/options.py
+++ b/thetis/options.py
@@ -524,7 +524,7 @@ class ModelOptions2d(CommonModelOptions):
 
     tracer_family = Unicode('dg', help="""
         Specify whether tracer should be continuous or discontinous
-        
+
         Choose from 'dg' and 'cg'.
         """).tag(config=True)
 

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -522,6 +522,12 @@ class ModelOptions2d(CommonModelOptions):
         Prints overshoot values that exceed the initial range to stdout.
         """).tag(config=True)
 
+    tracer_family = Unicode('dg', help="""
+        Specify whether tracer should be continuous or discontinous
+        
+        Choose from 'dg' and 'cg'.
+        """).tag(config=True)
+
 
 @attach_paired_options("timestepper_type",
                        PairedEnum([('LeapFrog', ExplicitTimestepperOptions3d),

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -216,8 +216,17 @@ class FlowSolver2d(FrozenClass):
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d])
 
-        self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='Q_2d')
-
+        if self.options.tracer_family == 'dg':
+            self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='Q_2d')
+        elif self.options.tracer_family == 'cg':
+            self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'CG', 1, name='Q_2d')
+            try:
+                assert(self.options.use_limiter_for_tracers == False)
+            except:
+                print("WARNING: Limiter for tracers turned off")
+                self.options.use_limiter_for_tracers = False
+        else:
+            raise Exception('Unsupported tracer finite element family {:}'.format(self.options.tracer_family))
         self._isfrozen = True
 
     def create_equations(self):

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -223,7 +223,7 @@ class FlowSolver2d(FrozenClass):
             try:
                 assert(self.options.use_limiter_for_tracers == False)
             except:
-                print("WARNING: Limiter for tracers turned off")
+                print("NOTE: Limiter for tracers turned off since tracer is CG")
                 self.options.use_limiter_for_tracers = False
         else:
             raise Exception('Unsupported tracer finite element family {:}'.format(self.options.tracer_family))

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -220,11 +220,9 @@ class FlowSolver2d(FrozenClass):
             self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='Q_2d')
         elif self.options.tracer_family == 'cg':
             self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'CG', 1, name='Q_2d')
-            try:
-                assert(self.options.use_limiter_for_tracers == False)
-            except:
+            if self.options.use_limiter_for_tracers:
                 print("NOTE: Limiter for tracers turned off since tracer is CG")
-                self.options.use_limiter_for_tracers = False
+            self.options.use_limiter_for_tracers = False
         else:
             raise Exception('Unsupported tracer finite element family {:}'.format(self.options.tracer_family))
         self._isfrozen = True

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -93,7 +93,7 @@ class TracerTerm(Term):
         return c_ext, uv_ext, elev_ext
 
 
-class HorizontalAdvectionTerm(TracerTerm):
+class HorizontalAdvectionTerm(TracerTerm):  # TODO: Implement SUPG advection scheme
     r"""
     Advection of tracer term, :math:`\bar{\textbf{u}} \cdot \nabla T`
 


### PR DESCRIPTION
This PR includes an option for choosing to solve tracer transport in P1 space, using `solver_obj.options.tracer_family = 'cg'`.

In the current DG setup, problems can arise in the presence of both high diffusivity and element anisotropy (e.g. under anisotropic mesh adaptivity).