### PR TITLE
Use 'ksponly' if linear

### DIFF
--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -864,6 +864,7 @@ class FlowSolver(FrozenClass):
         # Avoid additional nonlinear iterations if linear equations are used
         if not self.options.use_nonlinear_equations:
             self.options.timestepper_options.solver_parameters['snes_type'] = 'ksponly'
+            self.options.timestepper_options.solver_parameters_tracer['snes_type'] = 'ksponly'
 
     def assign_initial_conditions(self, elev=None, salt=None, temp=None,
                                   uv_2d=None, uv_3d=None, tke=None, psi=None):

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -861,6 +861,10 @@ class FlowSolver(FrozenClass):
         self._initialized = True
         self._isfrozen = True
 
+        # Avoid additional nonlinear iterations if linear equations are used
+        if not self.options.use_nonlinear_equations:
+            self.options.timestepper_options.solver_parameters['snes_type'] = 'ksponly'
+
     def assign_initial_conditions(self, elev=None, salt=None, temp=None,
                                   uv_2d=None, uv_3d=None, tke=None, psi=None):
         """

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -357,6 +357,10 @@ class FlowSolver2d(FrozenClass):
         print_output('Using time integrator: {:}'.format(self.timestepper.__class__.__name__))
         self._isfrozen = True  # disallow creating new attributes
 
+        # Avoid additional nonlinear iterations if linear equations are used
+        if not self.options.use_nonlinear_equations:
+            self.options.timestepper_options.solver_parameters['snes_type'] = 'ksponly'
+
     def create_exporters(self):
         """
         Creates file exporters

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -360,6 +360,7 @@ class FlowSolver2d(FrozenClass):
         # Avoid additional nonlinear iterations if linear equations are used
         if not self.options.use_nonlinear_equations:
             self.options.timestepper_options.solver_parameters['snes_type'] = 'ksponly'
+            self.options.timestepper_options.solver_parameters_tracer['snes_type'] = 'ksponly'
 
     def create_exporters(self):
         """


### PR DESCRIPTION
Just a minor thing.

I noticed that a nonlinear solver is used even when we set `options.use_nonlinear_equations = False`. By passing the solver parameter `'ksponly'` for `'snes_type'`, we can just use a linear solver.

For the '2D channel with boundary conditions' example, I did notice timing differences when this is used or not. For T=3600s, using the linear equations and averaged over 10 runs:
* Without 'ksponly': average time 1.2136s
* With 'ksponly': average time 1.0493s