### PR TITLE
Fix 2d solver for elev=0 boundary condition

### DIFF
--- a/test/callback/test_diagnostic_hdf5_output.py
+++ b/test/callback/test_diagnostic_hdf5_output.py
@@ -176,7 +176,7 @@ def test_callbacks(tmp_outputdir):
         value = h5file['value'][:]
         correct_value = np.zeros((11, 4))
         for row in range(11):
-            t = correct_time[row]
+            t = correct_time[row, 0]
             correct_value[row, :] = np.linspace(t, 2*t + 1, 4)
         assert np.allclose(time, correct_time)
         assert np.allclose(value, correct_value)

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -283,7 +283,7 @@ class ShallowWaterTerm(Term):
         if self.options.use_nonlinear_equations:
             total_h = self.bathymetry + eta
             if hasattr(self.options, 'use_wetting_and_drying') and self.options.use_wetting_and_drying:
-                total_h += self.wd_bathymetry_displacement(eta)
+                total_h = self.bathymetry + eta + self.wd_bathymetry_displacement(eta)
         else:
             total_h = self.bathymetry
         return total_h


### PR DESCRIPTION
Fixes issue #150, where setting elev=0 (a float) on a boundary will cause bathymetry being altered if wetting-drying is enabled.