### PR TITLE
SU stabilisation

### DIFF
--- a/test/tracerEq/test_h-advection_mes.py
+++ b/test/tracerEq/test_h-advection_mes.py
@@ -136,7 +136,7 @@ def run_convergence(ref_list, saveplot=False, **options):
         l2_err.append(run(r, **options))
     x_log = numpy.log10(numpy.array(ref_list, dtype=float)**-1)
     y_log = numpy.log10(numpy.array(l2_err))
-    setup_name = 'h-diffusion'
+    setup_name = 'h-advection'
 
     def check_convergence(x_log, y_log, expected_slope, field_str, saveplot):
         slope_rtol = 0.20

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -184,14 +184,13 @@ def polynomial_degree(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
-
 @pytest.fixture(params=['dg', 'cg'])
 def tracer_element_family(request):
     return request.param
 
 
+@pytest.mark.parametrize(('stepper'),
+                         [('CrankNicolson')])
 def test_horizontal_advection(polynomial_degree, stepper, tracer_element_family):
     run_convergence([1, 2, 3], polynomial_degree=polynomial_degree,
                     timestepper_type=stepper, tracer_element_family=tracer_element_family)

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -54,8 +54,6 @@ def run(refinement, **model_options):
     options.use_limiter_for_tracers = True
     options.fields_to_export = ['tracer_2d']
     options.update(model_options)
-    if options.tracer_element_family == 'cg':
-        options.use_limiter_for_tracers = False
     uv_expr = as_vector((u, 0))
     bnd_salt_2d = {'value': Constant(0.0), 'uv': uv_expr}
     bnd_uv_2d = {'uv': uv_expr}

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -50,8 +50,6 @@ def run(refinement, **model_options):
     options.horizontal_diffusivity = Constant(horizontal_diffusivity)
     options.horizontal_viscosity_scale = Constant(horizontal_diffusivity)
     options.update(model_options)
-    if options.tracer_element_family == 'cg':
-        options.use_limiter_for_tracers = False
 
     solverobj.create_equations()
 

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -159,16 +159,15 @@ def run_convergence(ref_list, saveplot=False, **options):
 # standard tests for pytest
 # ---------------------------
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
-
 
 @pytest.fixture(params=['cg', 'dg'])
 def tracer_element_family(request):
     return request.param
 
 
-def test_horizontal_diffusion(stepper):
+@pytest.mark.parametrize(('stepper'),
+                         [('CrankNicolson')])
+def test_horizontal_diffusion(stepper, tracer_element_family):
     run_convergence([1, 2, 3], polynomial_degree=1,
                     timestepper_type=stepper,
                     tracer_element_family=tracer_element_family)

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -50,6 +50,8 @@ def run(refinement, **model_options):
     options.horizontal_diffusivity = Constant(horizontal_diffusivity)
     options.horizontal_viscosity_scale = Constant(horizontal_diffusivity)
     options.update(model_options)
+    if options.tracer_element_family == 'cg':
+        options.use_limiter_for_tracers = False
 
     solverobj.create_equations()
 
@@ -107,6 +109,7 @@ def run(refinement, **model_options):
 def run_convergence(ref_list, saveplot=False, **options):
     """Runs test for a list of refinements and computes error convergence rate"""
     polynomial_degree = options.get('polynomial_degree', 1)
+    family = options.get('tracer_element_family', 'dg')
     l2_err = []
     for r in ref_list:
         l2_err.append(run(r, **options))
@@ -135,10 +138,10 @@ def run_convergence(ref_list, saveplot=False, **options):
                     horizontalalignment='left')
             ax.set_xlabel('log10(dx)')
             ax.set_ylabel('log10(L2 error)')
-            ax.set_title(' '.join([setup_name, field_str, 'degree={:}'.format(polynomial_degree)]))
+            ax.set_title(' '.join([setup_name, field_str, 'degree={:}'.format(polynomial_degree), family]))
             ref_str = 'ref-' + '-'.join([str(r) for r in ref_list])
             degree_str = 'o{:}'.format(polynomial_degree)
-            imgfile = '_'.join(['convergence', setup_name, field_str, ref_str, degree_str])
+            imgfile = '_'.join(['convergence', setup_name, field_str, ref_str, degree_str, family])
             imgfile += '.png'
             imgdir = create_directory('plots')
             imgfile = os.path.join(imgdir, imgfile)
@@ -160,10 +163,17 @@ def run_convergence(ref_list, saveplot=False, **options):
 
 @pytest.mark.parametrize(('stepper'),
                          [('CrankNicolson')])
+
+
+@pytest.fixture(params=['cg', 'dg'])
+def tracer_element_family(request):
+    return request.param
+
+
 def test_horizontal_diffusion(stepper):
     run_convergence([1, 2, 3], polynomial_degree=1,
                     timestepper_type=stepper,
-                    )
+                    tracer_element_family=tracer_element_family)
 # ---------------------------
 # run individual setup for debugging
 # ---------------------------
@@ -172,4 +182,5 @@ def test_horizontal_diffusion(stepper):
 if __name__ == '__main__':
     run_convergence([1, 2, 4, 6, 8], polynomial_degree=1,
                     timestepper_type='CrankNicolson',
+                    tracer_element_family='dg',
                     no_exports=False, saveplot=True)

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -97,8 +97,6 @@ def run(setup, refinement, do_export=True, **options):
     solver_obj.options.fields_to_export = ['tracer_2d', 'uv_2d',]
     solver_obj.options.horizontal_viscosity_scale = Constant(50.0)
     solver_obj.options.update(options)
-    if solver_obj.options.tracer_element_family == 'cg':
-        solver_obj.options.use_limiter_for_tracers = False
     solver_obj.options.solve_tracer = True
     solver_obj.options.timestepper_options.implicitness_theta = 1.0
     solver_obj.create_function_spaces()

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -97,6 +97,8 @@ def run(setup, refinement, do_export=True, **options):
     solver_obj.options.fields_to_export = ['tracer_2d', 'uv_2d',]
     solver_obj.options.horizontal_viscosity_scale = Constant(50.0)
     solver_obj.options.update(options)
+    if solver_obj.options.tracer_element_family == 'cg':
+        solver_obj.options.use_limiter_for_tracers = False
     solver_obj.options.solve_tracer = True
     solver_obj.options.timestepper_options.implicitness_theta = 1.0
     solver_obj.create_function_spaces()
@@ -141,6 +143,7 @@ def run(setup, refinement, do_export=True, **options):
 
 def run_convergence(setup, ref_list, do_export=False, save_plot=False, **options):
     """Runs test for a list of refinements and computes error convergence rate"""
+    family = options.get('tracer_element_family', 'dg')
     l2_err = []
     for r in ref_list:
         l2_err.append(run(setup, r,  do_export=do_export, **options))
@@ -169,10 +172,10 @@ def run_convergence(setup, ref_list, do_export=False, save_plot=False, **options
                     horizontalalignment='left')
             ax.set_xlabel('log10(dx)')
             ax.set_ylabel('log10(L2 error)')
-            ax.set_title('tracer adv-diff MMS DG ')
+            ax.set_title('tracer adv-diff MMS {:s}'.format(family))
             ref_str = 'ref-' + '-'.join([str(r) for r in ref_list])
 
-            imgfile = '_'.join(['convergence', setup_name, field_str, ref_str,])
+            imgfile = '_'.join(['convergence', setup_name, field_str, ref_str, family])
             imgfile += '.png'
             img_dir = create_directory('plots')
             imgfile = os.path.join(img_dir, imgfile)
@@ -205,9 +208,14 @@ def setup(request):
     return request.param
 
 
-def test_convergence(setup, timestepper_type):
-    run_convergence(setup, [1, 2, 3], save_plot=False, timestepper_type=timestepper_type)
+@pytest.fixture(params=['dg', 'cg'])
+def tracer_element_family(request):
+    return request.param
+
+
+def test_convergence(setup, timestepper_type, tracer_element_family):
+    run_convergence(setup, [1, 2, 3], save_plot=False, timestepper_type=timestepper_type, tracer_element_family=tracer_element_family)
 
 
 if __name__ == '__main__':
-    run_convergence(Setup1, [1, 2, 3], save_plot=True, timestepper_type='CrankNicolson')
+    run_convergence(Setup1, [1, 2, 3], save_plot=True, timestepper_type='CrankNicolson', tracer_element_family='dg')

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -538,7 +538,7 @@ class ModelOptions2d(CommonModelOptions):
         help="""Finite element family for tracer transport
 
         2D solver supports 'dg' or 'cg'.""").tag(config=True)
-    use_su_tracer = Bool(
+    use_su_stabilization_tracer = Bool(
         False, help="Use SU stabilisation in tracer advection").tag(config=True)
 
 

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -384,6 +384,8 @@ class CommonModelOptions(FrozenConfigurable):
         Constant(1.0), help="Scaling factor for tracer Lax Friedrichs stability term.").tag(config=True)
     use_limiter_for_tracers = Bool(
         True, help="Apply P1DG limiter for tracer fields").tag(config=True)
+    use_su_tracer = Bool(
+        False, help="Use SU stabilisation in tracer advection").tag(config=True)
 
     check_volume_conservation_2d = Bool(
         False, help="""
@@ -532,6 +534,12 @@ class ModelOptions2d(CommonModelOptions):
 
         Advects tracer in the associated (constant) velocity field.
         """).tag(config=True)
+    tracer_element_family = Enum(
+        ['dg', 'cg'],
+        default_value='dg',
+        help="""Finite element family for tracer transport
+
+        2D solver supports 'dg' or 'cg'.""").tag(config=True)
 
 
 @attach_paired_options("timestepper_type",

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -384,8 +384,6 @@ class CommonModelOptions(FrozenConfigurable):
         Constant(1.0), help="Scaling factor for tracer Lax Friedrichs stability term.").tag(config=True)
     use_limiter_for_tracers = Bool(
         True, help="Apply P1DG limiter for tracer fields").tag(config=True)
-    use_su_tracer = Bool(
-        False, help="Use SU stabilisation in tracer advection").tag(config=True)
 
     check_volume_conservation_2d = Bool(
         False, help="""
@@ -540,6 +538,8 @@ class ModelOptions2d(CommonModelOptions):
         help="""Finite element family for tracer transport
 
         2D solver supports 'dg' or 'cg'.""").tag(config=True)
+    use_su_tracer = Bool(
+        False, help="Use SU stabilisation in tracer advection").tag(config=True)
 
 
 @attach_paired_options("timestepper_type",

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -248,8 +248,8 @@ class FlowSolver2d(FrozenClass):
             self.options.use_limiter_for_tracers &= self.options.tracer_element_family == 'dg'
             self.options.use_lax_friedrichs_tracer &= self.options.tracer_element_family == 'dg'
             self.options.use_su_stabilization_tracer &= self.options.tracer_element_family == 'cg'
-            #if self.options.tracer_element_family == 'cg':  # TODO: Temporary measure until SUPG is implemented
-            #    self.options.use_su_stabilization_tracer = True
+            if self.options.tracer_element_family == 'cg':
+                self.options.use_su_stabilization_tracer = True
 
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -248,7 +248,7 @@ class FlowSolver2d(FrozenClass):
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                           use_su=self.options.use_su_tracer)
+                                                           use_su=self.options.use_su_stabilization_tracer)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:
@@ -552,6 +552,10 @@ class FlowSolver2d(FrozenClass):
             self.initialize()
 
         self.options.use_limiter_for_tracers &= self.options.polynomial_degree > 0
+        self.options.use_limiter_for_tracers &= self.options.tracer_element_family == 'dg'
+        self.options.use_lax_friedrichs_tracer &= self.options.tracer_element_family == 'dg'
+        self.options.use_su_stabilization_tracer &= self.options.tracer_element_family == 'cg'
+        self.options.tracer_element_family == 'cg' &= self.options.use_su_stabilization_tracer  # TODO: Temporary measure until SUPG is implemented
 
         t_epsilon = 1.0e-5
         cputimestamp = time_mod.clock()

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -245,6 +245,12 @@ class FlowSolver2d(FrozenClass):
         )
         self.eq_sw.bnd_functions = self.bnd_functions['shallow_water']
         if self.options.solve_tracer:
+            self.options.use_limiter_for_tracers &= self.options.tracer_element_family == 'dg'
+            self.options.use_lax_friedrichs_tracer &= self.options.tracer_element_family == 'dg'
+            self.options.use_su_stabilization_tracer &= self.options.tracer_element_family == 'cg'
+            #if self.options.tracer_element_family == 'cg':  # TODO: Temporary measure until SUPG is implemented
+            #    self.options.use_su_stabilization_tracer = True
+
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -552,10 +558,6 @@ class FlowSolver2d(FrozenClass):
             self.initialize()
 
         self.options.use_limiter_for_tracers &= self.options.polynomial_degree > 0
-        self.options.use_limiter_for_tracers &= self.options.tracer_element_family == 'dg'
-        self.options.use_lax_friedrichs_tracer &= self.options.tracer_element_family == 'dg'
-        self.options.use_su_stabilization_tracer &= self.options.tracer_element_family == 'cg'
-        self.options.tracer_element_family == 'cg' &= self.options.use_su_stabilization_tracer  # TODO: Temporary measure until SUPG is implemented
 
         t_epsilon = 1.0e-5
         cputimestamp = time_mod.clock()

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -216,7 +216,12 @@ class FlowSolver2d(FrozenClass):
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d])
 
-        self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='Q_2d')
+        if self.options.tracer_element_family == 'dg':
+            self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='Q_2d')
+        elif self.options.tracer_element_family == 'cg':
+            self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'CG', 1, name='Q_2d')
+        else:
+            raise Exception('Unsupported finite element family {:}'.format(self.options.tracer_element_family))
 
         self._isfrozen = True
 
@@ -242,7 +247,8 @@ class FlowSolver2d(FrozenClass):
         if self.options.solve_tracer:
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
-                                                           use_lax_friedrichs=self.options.use_lax_friedrichs_tracer)
+                                                           use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
+                                                           use_su=self.options.use_su_tracer)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -170,7 +170,7 @@ class HorizontalAdvectionTerm(TracerTerm):
             # Here CellSize is the measure of element size used.
             # TODO: In the presence of anisotropic elements, it may be important to also consider
             # shape and orientation.
-            tau = 0.5*self.cellsize/sqrt(inner(uv,uv))
+            tau = 0.5*self.cellsize/sqrt(inner(uv, uv))
 
             # Add stabilisation term
             f += tau*inner(uv, grad(self.test))*dot(uv, grad(solution))*dx

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -110,6 +110,12 @@ class HorizontalAdvectionTerm(TracerTerm):
     :math:`\textbf{n}` is the unit normal of
     the element interfaces, and :math:`\text{jump}` and :math:`\text{avg}` denote the
     jump and average operators across the interface.
+
+    For the continuous Galerkin method we use
+
+    .. math::
+        \int_\Omega \bar{\textbf{u}} \cdot \boldsymbol{\psi} \cdot \nabla T  dx
+        = - \int_\Omega \nabla_h \cdot (\bar{\textbf{u}} \boldsymbol{\psi}) \cdot T dx.
     """
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         if fields_old.get('uv_2d') is None:
@@ -217,6 +223,10 @@ class HorizontalDiffusionTerm(TracerTerm):
     interior penalty Galerkin methods. Journal of Computational and Applied
     Mathematics, 206(2):843-872. http://dx.doi.org/10.1016/j.cam.2006.08.029
 
+    For the continuous Galerkin method we use
+    .. math::
+        -\int_\Omega \nabla_h \cdot (\mu_h \nabla_h T) \phi dx
+        = \int_\Omega \mu_h (\nabla_h \phi) \cdot (\nabla_h T) dx.
     """
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         if fields_old.get('diffusivity_h') is None:

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -164,10 +164,26 @@ class HorizontalAdvectionTerm(TracerTerm):
                         c_up = c_in*s + c_ext*(1-s)
                         f += c_up*(uv_av[0]*self.normal[0]
                                    + uv_av[1]*self.normal[1])*self.test*ds_bnd
+        else:
+            if bnd_conditions is not None:
+                for bnd_marker in self.boundary_markers:
+                    funcs = bnd_conditions.get(bnd_marker)
+                    ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
+                    c_in = solution
+                    if funcs is None:
+                        f += c_in * (uv[0]*self.normal[0]
+                                     + uv[1]*self.normal[1])*self.test*ds_bnd
+                    else:
+                        c_ext, uv_ext, eta_ext = self.get_bnd_functions(c_in, uv, elev, bnd_marker, bnd_conditions)
+                        s = 0.5*(sign(uv[0]*self.normal[0]
+                                      + uv[1]*self.normal[1]) + 1.0)
+                        c_up = c_in*s + c_ext*(1-s)
+                        f += c_up*(uv[0]*self.normal[0]
+                                   + uv[1]*self.normal[1])*self.test*ds_bnd
 
         if self.use_su:
 
-            # Here CellSize is the measure of element size used.
+            # Here CellSize is the measure of element size used in the stabilisation parameter.
             # TODO: In the presence of anisotropic elements, it may be important to also consider
             # shape and orientation.
             tau = 0.5*self.cellsize/sqrt(inner(uv, uv))

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -192,7 +192,13 @@ class HorizontalAdvectionTerm(TracerTerm):
             # Here CellSize is the measure of element size used in the stabilisation parameter.
             # TODO: In the presence of anisotropic elements, it may be important to also consider
             # shape and orientation.
-            tau = 0.5*self.cellsize/sqrt(inner(uv, uv))
+            unorm = sqrt(inner(uv, uv))
+            diffusivity_h = fields_old['diffusivity_h']
+            if diffusivity_h is not None:
+                Pe = unorm*self.cellsize/(2*diffusivity_h)
+                tau = min_value(0.5*self.cellsize/unorm, Pe/3)
+            else:
+                tau = 0.5*self.cellsize/unorm
 
             # Add stabilisation term
             f += tau*inner(uv, grad(self.test))*dot(uv, grad(solution))*dx

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -193,9 +193,8 @@ class HorizontalAdvectionTerm(TracerTerm):
             # TODO: In the presence of anisotropic elements, it may be important to also consider
             # shape and orientation.
             unorm = sqrt(inner(uv, uv))
-            diffusivity_h = fields_old['diffusivity_h']
-            if diffusivity_h is not None:
-                Pe = unorm*self.cellsize/(2*diffusivity_h)
+            if fields_old.get('diffusivity_h') is not None:
+                Pe = 0.5*unorm*self.cellsize/fields_old['diffusivity_h']
                 tau = min_value(0.5*self.cellsize/unorm, Pe/3)
             else:
                 tau = 0.5*self.cellsize/unorm

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -170,7 +170,7 @@ class HorizontalAdvectionTerm(TracerTerm):
             # Here CellSize is the measure of element size used.
             # TODO: In the presence of anisotropic elements, it may be important to also consider
             # shape and orientation.
-            tau = 0.5*self.cellsize/norm(uv)
+            tau = 0.5*self.cellsize/sqrt(inner(uv,uv))
 
             # Add stabilisation term
             f += tau*inner(uv, grad(self.test))*dot(uv, grad(solution))*dx


### PR DESCRIPTION
I was working on stabilisation for CG tracers a couple of months ago but got sidetracked. This PR allows P1 tracers and simple SU stabilisation (with the same stabilisation coefficient as in the FEniCS demo https://github.com/FEniCS/dolfin/blob/master/demo/undocumented/advection-diffusion/python/demo_advection-diffusion.py).

Consider the following script.
```
from thetis import *

mesh = RectangleMesh(60, 10, 60, 10)
x, y = SpatialCoordinate(mesh)
P1 = FunctionSpace(mesh, "CG", 1)
P1_vec = VectorFunctionSpace(mesh, "CG", 1)

u0 = interpolate(as_vector((1., 0.)), P1_vec)
zero = Function(P1)
b = Function(P1).assign(1.)
x0 = 10.
y0 = 5.
r = 0.5
bell = conditional(
    ge((1 + cos(pi*min_value(sqrt(pow(x-x0, 2) + pow(y-y0, 2)) / r, 1.))), 0.),
    (1 + cos(pi*min_value(sqrt(pow(x-x0, 2) + pow(y-y0, 2)) / r, 1.))),
    0.)
source = interpolate(0. + bell, P1)

solver_obj = solver2d.FlowSolver2d(mesh, b)
options = solver_obj.options
options.timestep = 0.1
options.simulation_export_time = options.timestep*10
options.simulation_end_time = 50.
options.timestepper_type = 'CrankNicolson'
options.fields_to_export = ['tracer_2d']
options.solve_tracer = True
options.tracer_only = True
options.use_limiter_for_tracers = False
options.use_su_tracer = True
options.tracer_element_family = 'cg'
options.horizontal_diffusivity = Constant(0.1)
options.tracer_source_2d = source
solver_obj.assign_initial_conditions(elev=zero, uv=u0, tracer=zero)
solver_obj.bnd_functions['tracer'][1] = {'value': Constant(0.)}  # inflow condition
solver_obj.iterate()
```

At timestep 30, the tracer concentration is
![su_t30](https://user-images.githubusercontent.com/22053413/55556775-3e560a80-56e0-11e9-8b2d-28af280b85ef.png)
whereas with `options.use_su_tracer = False` we have
![no_stab_t30](https://user-images.githubusercontent.com/22053413/55556802-4f068080-56e0-11e9-890d-d3fede145faf.png)


SUPG implementation to follow, if this looks okay.