### PR TITLE
Tracer advection equation

### DIFF
--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -47,6 +47,9 @@ def run(refinement, **model_options):
     options.output_directory = outputdir
     options.simulation_end_time = t_end
     options.simulation_export_time = t_export
+    solverobj.create_function_spaces()
+    uv_tracer = Function(solverobj.function_spaces.U_2d, name='uv tracer')
+    options.tracer_advective_velocity = uv_tracer
     options.solve_tracer = True
     options.use_limiter_for_tracers = True
     options.fields_to_export = ['tracer_2d']
@@ -93,6 +96,8 @@ def run(refinement, **model_options):
 
     # custom time loop that solves tracer equation only
     ti = solverobj.timestepper.timesteppers.tracer
+
+    uv_tracer.assign(uv_init)
 
     i = 0
     iexport = 1

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -83,6 +83,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                       'diffusivity_h': self.options.horizontal_diffusivity,
                       'source': self.options.tracer_source_2d,
                       'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
+                      'tracer_advective_velocity': self.options.tracer_advective_velocity, 
                       }
             if issubclass(self.tracer_integrator, timeintegrator.CrankNicolson):
                 self.timesteppers.tracer = self.tracer_integrator(

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -65,7 +65,10 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                 semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
                 theta=self.options.timestepper_options.implicitness_theta)
         else:
-            self.timesteppers.swe2d = self.swe_integrator(solver.eq_sw, self.fields.solution_2d, fields, solver.dt, bnd_conditions=solver.bnd_functions['shallow_water'], solver_parameters=self.options.timestepper_options.solver_parameters)
+            self.timesteppers.swe2d = self.swe_integrator(solver.eq_sw, self.fields.solution_2d,
+                                                          fields, solver.dt,
+                                            bnd_conditions=solver.bnd_functions['shallow_water'],
+                            solver_parameters=self.options.timestepper_options.solver_parameters)
 
     def _create_tracer_integrator(self):
         """
@@ -80,7 +83,8 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                       'diffusivity_h': self.options.horizontal_diffusivity,
                       'source': self.options.tracer_source_2d,
                       'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
-                      'tracer_advective_velocity': self.options.tracer_advective_velocity, }
+                      'tracer_advective_velocity': self.options.tracer_advective_velocity,
+                    }
             if issubclass(self.tracer_integrator, timeintegrator.CrankNicolson):
                 self.timesteppers.tracer = self.tracer_integrator(
                     solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt,
@@ -89,7 +93,10 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                     semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
                     theta=self.options.timestepper_options.implicitness_theta)
             else:
-                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt, bnd_conditions=solver.bnd_functions['tracer'], solver_parameters=self.options.timestepper_options.solver_parameters_tracer,)
+                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer,
+                                            solver.fields.tracer_2d, fields, solver.dt,
+                                            bnd_conditions=solver.bnd_functions['tracer'],
+                    solver_parameters=self.options.timestepper_options.solver_parameters_tracer,)
 
     def _create_integrators(self):
         """

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -65,10 +65,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                 semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
                 theta=self.options.timestepper_options.implicitness_theta)
         else:
-            self.timesteppers.swe2d = self.swe_integrator(solver.eq_sw, self.fields.solution_2d,
-                                                          fields, solver.dt,
-                                                          bnd_conditions=solver.bnd_functions['shallow_water'],
-                                                          solver_parameters=self.options.timestepper_options.solver_parameters)
+            self.timesteppers.swe2d = self.swe_integrator(solver.eq_sw, self.fields.solution_2d, fields, solver.dt, bnd_conditions=solver.bnd_functions['shallow_water'], solver_parameters=self.options.timestepper_options.solver_parameters)
 
     def _create_tracer_integrator(self):
         """
@@ -83,8 +80,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                       'diffusivity_h': self.options.horizontal_diffusivity,
                       'source': self.options.tracer_source_2d,
                       'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
-                      'tracer_advective_velocity': self.options.tracer_advective_velocity, 
-                      }
+                      'tracer_advective_velocity': self.options.tracer_advective_velocity, }
             if issubclass(self.tracer_integrator, timeintegrator.CrankNicolson):
                 self.timesteppers.tracer = self.tracer_integrator(
                     solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt,
@@ -93,9 +89,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                     semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
                     theta=self.options.timestepper_options.implicitness_theta)
             else:
-                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt,
-                                                                  bnd_conditions=solver.bnd_functions['tracer'],
-                                                                  solver_parameters=self.options.timestepper_options.solver_parameters_tracer,)
+                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt, bnd_conditions=solver.bnd_functions['tracer'], solver_parameters=self.options.timestepper_options.solver_parameters_tracer,)
 
     def _create_integrators(self):
         """

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -67,8 +67,8 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
         else:
             self.timesteppers.swe2d = self.swe_integrator(solver.eq_sw, self.fields.solution_2d,
                                                           fields, solver.dt,
-                                            bnd_conditions=solver.bnd_functions['shallow_water'],
-                            solver_parameters=self.options.timestepper_options.solver_parameters)
+                                                          bnd_conditions=solver.bnd_functions['shallow_water'],
+                                                          solver_parameters=self.options.timestepper_options.solver_parameters)
 
     def _create_tracer_integrator(self):
         """
@@ -84,19 +84,19 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                       'source': self.options.tracer_source_2d,
                       'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
                       'tracer_advective_velocity': self.options.tracer_advective_velocity,
-                    }
+                      }
             if issubclass(self.tracer_integrator, timeintegrator.CrankNicolson):
-                self.timesteppers.tracer = self.tracer_integrator(
-                    solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt,
-                    bnd_conditions=solver.bnd_functions['tracer'],
-                    solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
-                    semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
-                    theta=self.options.timestepper_options.implicitness_theta)
+                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d,
+                                                                  fields, solver.dt, bnd_conditions=solver.bnd_functions['tracer'],
+                                                                  solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
+                                                                  semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
+                                                                  theta=self.options.timestepper_options.implicitness_theta)
             else:
                 self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer,
-                                            solver.fields.tracer_2d, fields, solver.dt,
-                                            bnd_conditions=solver.bnd_functions['tracer'],
-                    solver_parameters=self.options.timestepper_options.solver_parameters_tracer,)
+                                                                  solver.fields.tracer_2d, fields, solver.dt,
+                                                                  bnd_conditions=solver.bnd_functions['tracer'],
+                                                                  solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
+                                                                  )
 
     def _create_integrators(self):
         """

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -466,8 +466,6 @@ class CommonModelOptions(FrozenConfigurable):
         None, allow_none=True, help="Source term for 2D continuity equation").tag(config=True)
     tracer_source_2d = FiredrakeScalarExpression(
         None, allow_none=True, help="Source term for 2D tracer equation").tag(config=True)
-    tracer_advective_velocity = FiredrakeVectorExpression(
-        None, allow_none=True, help="Velocity to used in tracer advection equation.").tag(config=True)
     horizontal_diffusivity = FiredrakeCoefficient(
         None, allow_none=True, help="Horizontal diffusivity for tracers").tag(config=True)
 
@@ -514,7 +512,8 @@ class ModelOptions2d(CommonModelOptions):
 
         Prints deviation from the initial mass to stdout.
         """).tag(config=True)
-
+    tracer_advective_velocity = FiredrakeVectorExpression(
+                                                          None, allow_none=True, help="Custom function to be used for the velocity variable in tracer advection equation").tag(config=True)
     check_tracer_overshoot = Bool(
         False, help="""
         Compute tracer overshoots at every export

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -512,8 +512,8 @@ class ModelOptions2d(CommonModelOptions):
 
         Prints deviation from the initial mass to stdout.
         """).tag(config=True)
-    tracer_advective_velocity = FiredrakeVectorExpression(
-                                                          None, allow_none=True, help="Custom function to be used for the velocity variable in tracer advection equation").tag(config=True)
+    tracer_advective_velocity = FiredrakeVectorExpression(None, allow_none=True,
+                                                          help="Custom function to be used for the velocity variable in tracer advection equation").tag(config=True)
     check_tracer_overshoot = Bool(
         False, help="""
         Compute tracer overshoots at every export

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -466,6 +466,8 @@ class CommonModelOptions(FrozenConfigurable):
         None, allow_none=True, help="Source term for 2D continuity equation").tag(config=True)
     tracer_source_2d = FiredrakeScalarExpression(
         None, allow_none=True, help="Source term for 2D tracer equation").tag(config=True)
+    tracer_advective_velocity = FiredrakeVectorExpression(
+        None, allow_none=True, help="Velocity to used in tracer advection equation.").tag(config=True)
     horizontal_diffusivity = FiredrakeCoefficient(
         None, allow_none=True, help="Horizontal diffusivity for tracers").tag(config=True)
 

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -114,7 +114,7 @@ class HorizontalAdvectionTerm(TracerTerm):
         if fields_old.get('uv_2d') is None:
             return 0
         elev = fields_old['elev_2d']
-        uv = fields_old['tracer_advective_velocity']
+        uv = fields_old.get('tracer_advective_velocity')
         if uv is None:
             uv = fields_old['uv_2d']
 

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -114,7 +114,9 @@ class HorizontalAdvectionTerm(TracerTerm):
         if fields_old.get('uv_2d') is None:
             return 0
         elev = fields_old['elev_2d']
-        uv = fields_old['uv_2d']
+        uv = fields_old['tracer_advective_velocity']
+        if uv is None:
+            uv = fields_old['uv_2d']
 
         uv_p1 = fields_old.get('uv_p1')
         uv_mag = fields_old.get('uv_mag')


### PR DESCRIPTION
Due to the coupled nature of Thetis, we cannot calculate the depth-averaged product **u**c required by the sediment concentration equation, but only the product of the depth-averaged **u** (from the hydrodynamic component) and the depth-averaged **c** (from the sediment transport component).

This addition allows us to add a correction factor to the tracer advection equation to account for this error. More details about this correction factor can be found in:

_Huybrechts, N., Villaret, C., & Hervouet, J. M. (2010, September). Comparison between 2D and 3D modelling of sediment transport: application to the dune evolution. In River Flow (pp. 887-893)._