### PR TITLE
Fix DIRK22 gamma parameter

### DIFF
--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -24,19 +24,22 @@ def run(refinement, **model_options):
     mesh2d = RectangleMesh(nx, ny, lx, ly)
 
     # set time steps
-    # stable explicit time step for diffusion
-    dz = depth/n_layers
-    alpha = 1.0/200.0  # TODO theoretical alpha...
-    dt = alpha * dz**2/vertical_viscosity
+    if implicit:
+        dt = 100.
+    else:
+        # stable explicit time step for diffusion
+        dz = depth/n_layers
+        alpha = 1.0/200.0
+        dt = alpha * dz**2/vertical_viscosity
     # simulation run time
-    t_end = 3600.0/2
+    t_end = 1900.
     # initial time
     t_init = 100.0  # NOTE start from t > 0 for smoother init cond
     # eliminate reminder
     ndt = np.ceil((t_end-t_init)/dt)
     dt = (t_end-t_init)/ndt
     dt_2d = dt/2
-    t_export = (t_end-t_init)/20.0
+    t_export = (t_end-t_init)/6
 
     # outputs
     outputdir = 'outputs'

--- a/test/tracerEq/test_v-diffusion_mes.py
+++ b/test/tracerEq/test_v-diffusion_mes.py
@@ -25,19 +25,22 @@ def run(refinement, **model_options):
     mesh2d = RectangleMesh(nx, ny, lx, ly)
 
     # set time steps
-    # stable explicit time step for diffusion
-    dz = depth/n_layers
-    alpha = 1.0/200.0  # TODO theoretical alpha...
-    dt = alpha * dz**2/vertical_diffusivity
+    if implicit:
+        dt = 100.
+    else:
+        # stable explicit time step for diffusion
+        dz = depth/n_layers
+        alpha = 1.0/200.0
+        dt = alpha * dz**2/vertical_diffusivity
     # simulation run time
-    t_end = 3600.0/2
+    t_end = 1900.
     # initial time
     t_init = 100.0  # NOTE start from t > 0 for smoother init cond
     # eliminate reminder
     ndt = np.ceil((t_end-t_init)/dt)
     dt = (t_end-t_init)/ndt
     dt_2d = dt/2
-    t_export = (t_end-t_init)/20.0
+    t_export = (t_end-t_init)/6
 
     # outputs
     outputdir = 'outputs'

--- a/thetis/rungekutta.py
+++ b/thetis/rungekutta.py
@@ -204,7 +204,7 @@ class DIRK22Abstract(AbstractRKScheme):
                 &       1/2 &     1/2
         \end{array}
 
-    with :math:`\gamma = (2 + \sqrt{2})/2`.
+    with :math:`\gamma = (2 - \sqrt{2})/2`.
 
     From DIRK(2,3,2) IMEX scheme in Ascher et al. (1997)
 
@@ -212,7 +212,7 @@ class DIRK22Abstract(AbstractRKScheme):
     time-dependent partial differential equations. Applied Numerical
     Mathematics, 25:151-167. http://dx.doi.org/10.1137/0732037
     """
-    gamma = (2.0 + np.sqrt(2.0))/2.0
+    gamma = (2.0 - np.sqrt(2.0))/2.0
     a = [[gamma, 0],
          [1-gamma, gamma]]
     b = [1-gamma, gamma]


### PR DESCRIPTION
Fixes gamma parameter in DIRK22 time stepper.

2nd order 2-stage DIRK, `rungekutta.DIRK22`, should have `gamma = (2 - \sqrt{2})/2`. Current implementation has `(2 + \sqrt{2})/2`. Both values result in a 2nd order scheme, but the minus one is the preferred one.