### PR TITLE
3D solver: use backward Euler in implicit vertical problem

### DIFF
--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -603,7 +603,7 @@ class CoupledTwoStageRK(CoupledTimeIntegrator):
     """
     integrator_2d = rungekutta.ESDIRKTrapezoid
     integrator_3d = timeintegrator.SSPRK22ALE
-    integrator_vert_3d = rungekutta.DIRK22
+    integrator_vert_3d = rungekutta.BackwardEuler
 
     def __init__(self, solver):
         super(CoupledTwoStageRK, self).__init__(solver)

--- a/thetis/field_defs.py
+++ b/thetis/field_defs.py
@@ -229,7 +229,7 @@ field_metadata['psi_3d'] = {
 field_metadata['eps_3d'] = {
     'name': 'TKE dissipation rate',
     'shortname': 'TKE dissipation rate',
-    'unit': 'm2 s-2',
+    'unit': 'm2 s-3',
     'filename': 'TurbEps3d',
 }
 field_metadata['len_3d'] = {


### PR DESCRIPTION
As we update baroclinic/turbulence terms only at the end of the time
step, using a 2nd order two-stage (DIRK22) scheme does not bring any benefit
in turbulence problems, but does increase the cost by 2x.