### PR TITLE
Use equispaced elements in 3D model

### DIFF
--- a/examples/balzano/balzano.py
+++ b/examples/balzano/balzano.py
@@ -42,7 +42,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry: uniform slope with gradient 1/2760
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry = Function(P1_2d, name='Bathymetry')
 x = SpatialCoordinate(mesh2d)
 bathymetry.interpolate(x[0] / 2760.0)

--- a/examples/balzano/balzano.py
+++ b/examples/balzano/balzano.py
@@ -42,7 +42,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry: uniform slope with gradient 1/2760
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry = Function(P1_2d, name='Bathymetry')
 x = SpatialCoordinate(mesh2d)
 bathymetry.interpolate(x[0] / 2760.0)

--- a/examples/baroclinic_channel/baroclinic_channel.py
+++ b/examples/baroclinic_channel/baroclinic_channel.py
@@ -56,7 +56,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/baroclinic_channel/baroclinic_channel.py
+++ b/examples/baroclinic_channel/baroclinic_channel.py
@@ -56,7 +56,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/baroclinic_eddies/baroclinic_eddies.py
+++ b/examples/baroclinic_eddies/baroclinic_eddies.py
@@ -101,7 +101,7 @@ def run_problem(reso_dx=10.0, poly_order=1, element_family='dg-dg',
     outputdir = 'outputs_' + options_str
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/examples/baroclinic_eddies/baroclinic_eddies.py
+++ b/examples/baroclinic_eddies/baroclinic_eddies.py
@@ -101,7 +101,7 @@ def run_problem(reso_dx=10.0, poly_order=1, element_family='dg-dg',
     outputdir = 'outputs_' + options_str
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/examples/bottomFriction/steadyChannel.py
+++ b/examples/bottomFriction/steadyChannel.py
@@ -54,7 +54,7 @@ def bottom_friction_test(layers=25, gls_closure='k-omega',
         t_end = 5*t_export
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry2d = Function(p1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/examples/bottomFriction/steadyChannel.py
+++ b/examples/bottomFriction/steadyChannel.py
@@ -54,7 +54,7 @@ def bottom_friction_test(layers=25, gls_closure='k-omega',
         t_end = 5*t_export
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry2d = Function(p1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/examples/channel2d/channel2d.py
+++ b/examples/channel2d/channel2d.py
@@ -32,7 +32,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 # assign bathymetry to a linear function
 x, y = SpatialCoordinate(mesh2d)

--- a/examples/channel2d/channel2d.py
+++ b/examples/channel2d/channel2d.py
@@ -32,7 +32,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 # assign bathymetry to a linear function
 x, y = SpatialCoordinate(mesh2d)

--- a/examples/channel3d/channel3d.py
+++ b/examples/channel3d/channel3d.py
@@ -27,7 +27,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
 depth_max = 20.0

--- a/examples/channel3d/channel3d.py
+++ b/examples/channel3d/channel3d.py
@@ -27,7 +27,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
 depth_max = 20.0

--- a/examples/channel3d/channel3d_closed.py
+++ b/examples/channel3d/channel3d_closed.py
@@ -31,7 +31,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
 depth_max = 20.0

--- a/examples/channel3d/channel3d_closed.py
+++ b/examples/channel3d/channel3d_closed.py
@@ -31,7 +31,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
 depth_max = 20.0

--- a/examples/columbia_plume/atm_forcing.py
+++ b/examples/columbia_plume/atm_forcing.py
@@ -45,8 +45,8 @@ def test():
     """
     mesh2d = Mesh('mesh_cre-plume_03_normal.msh')
     comm = mesh2d.comm
-    p1 = get_functionspace_2d(mesh2d, 'CG', 1)
-    p1v = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
+    p1 = get_functionspace(mesh2d, 'CG', 1)
+    p1v = get_functionspace(mesh2d, 'CG', 1, vector=True)
     windstress_2d = Function(p1v, name='wind stress')
     atmpressure_2d = Function(p1, name='atm pressure')
 

--- a/examples/columbia_plume/atm_forcing.py
+++ b/examples/columbia_plume/atm_forcing.py
@@ -11,6 +11,7 @@ from thetis.log import *
 import datetime
 import netCDF4
 from thetis.forcing import *
+from thetis.utility import get_functionspace
 
 # define model coordinate system
 COORDSYS = coordsys.UTM_ZONE10

--- a/examples/columbia_plume/atm_forcing.py
+++ b/examples/columbia_plume/atm_forcing.py
@@ -45,8 +45,8 @@ def test():
     """
     mesh2d = Mesh('mesh_cre-plume_03_normal.msh')
     comm = mesh2d.comm
-    p1 = FunctionSpace(mesh2d, 'CG', 1)
-    p1v = VectorFunctionSpace(mesh2d, 'CG', 1)
+    p1 = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1v = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
     windstress_2d = Function(p1v, name='wind stress')
     atmpressure_2d = Function(p1, name='atm pressure')
 

--- a/examples/columbia_plume/bathymetry.py
+++ b/examples/columbia_plume/bathymetry.py
@@ -3,6 +3,7 @@ import os
 import scipy.interpolate
 from netCDF4 import Dataset
 from firedrake import *
+from thetis.utility import get_functionspace
 
 
 def interpolate_onto(interp_func, output_func, coords, min_val):

--- a/examples/columbia_plume/bathymetry.py
+++ b/examples/columbia_plume/bathymetry.py
@@ -39,13 +39,13 @@ def get_bathymetry(bathymetry_file, mesh2d, minimum_depth=5.0, project=False):
     bath[~np.isfinite(bath)] = minimum_depth
     interpolator = scipy.interpolate.RegularGridInterpolator((x, y), bath.T)
 
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry2d = Function(P1_2d, name='bathymetry')
 
     if project:
         # interpolate on a high order mesh
-        P3_2d = FunctionSpace(mesh2d, 'CG', 3)
-        P3_2d_v = VectorFunctionSpace(mesh2d, 'CG', 3)
+        P3_2d = get_functionspace_2d(mesh2d, 'CG', 3)
+        P3_2d_v = get_functionspace_2d(mesh2d, 'CG', 3, vector=True)
         bathymetry2d_ho = Function(P3_2d, name='bathymetry')
         coords_ho = Function(P3_2d_v).interpolate(SpatialCoordinate(mesh2d))
         interpolate_onto(interpolator, bathymetry2d_ho, coords_ho, minimum_depth)

--- a/examples/columbia_plume/bathymetry.py
+++ b/examples/columbia_plume/bathymetry.py
@@ -39,13 +39,13 @@ def get_bathymetry(bathymetry_file, mesh2d, minimum_depth=5.0, project=False):
     bath[~np.isfinite(bath)] = minimum_depth
     interpolator = scipy.interpolate.RegularGridInterpolator((x, y), bath.T)
 
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry2d = Function(P1_2d, name='bathymetry')
 
     if project:
         # interpolate on a high order mesh
-        P3_2d = get_functionspace_2d(mesh2d, 'CG', 3)
-        P3_2d_v = get_functionspace_2d(mesh2d, 'CG', 3, vector=True)
+        P3_2d = get_functionspace(mesh2d, 'CG', 3)
+        P3_2d_v = get_functionspace(mesh2d, 'CG', 3, vector=True)
         bathymetry2d_ho = Function(P3_2d, name='bathymetry')
         coords_ho = Function(P3_2d_v).interpolate(SpatialCoordinate(mesh2d))
         interpolate_onto(interpolator, bathymetry2d_ho, coords_ho, minimum_depth)

--- a/examples/columbia_plume/cre-plume.py
+++ b/examples/columbia_plume/cre-plume.py
@@ -90,10 +90,6 @@ if reso_str == 'coarse':
     south_bnd_id = 6
     river_bnd_id = 5
 
-nnodes = comm.allreduce(mesh2d.topology.num_vertices(), MPI.SUM)
-ntriangles = comm.allreduce(mesh2d.topology.num_cells(), MPI.SUM)
-nprisms = ntriangles*nlayers
-
 sim_tz = timezone.FixedTimeZone(-8, 'PST')
 init_date = datetime.datetime(2006, 5, 1, tzinfo=sim_tz)
 end_date = datetime.datetime(2006, 7, 2, tzinfo=sim_tz)

--- a/examples/columbia_plume/ncom_forcing.py
+++ b/examples/columbia_plume/ncom_forcing.py
@@ -92,8 +92,8 @@ def test_interpolator():
     }
     mesh = extrude_mesh_sigma(mesh2d, nlayers, bathymetry_2d,
                               **extrude_options)
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
-    p1 = get_functionspace_3d(mesh, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
+    p1 = get_functionspace(mesh, 'CG', 1)
 
     # make functions
     salt = Function(p1, name='salinity')

--- a/examples/columbia_plume/ncom_forcing.py
+++ b/examples/columbia_plume/ncom_forcing.py
@@ -5,6 +5,7 @@ from thetis import *
 from atm_forcing import to_latlon, COORDSYS
 from thetis.timezone import *
 from thetis.forcing import *
+from thetis.utility import get_functionspace
 
 
 def test_time_search():

--- a/examples/columbia_plume/ncom_forcing.py
+++ b/examples/columbia_plume/ncom_forcing.py
@@ -92,8 +92,8 @@ def test_interpolator():
     }
     mesh = extrude_mesh_sigma(mesh2d, nlayers, bathymetry_2d,
                               **extrude_options)
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
-    p1 = FunctionSpace(mesh, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1 = get_functionspace_3d(mesh, 'CG', 1)
 
     # make functions
     salt = Function(p1, name='salinity')

--- a/examples/columbia_plume/roms_forcing.py
+++ b/examples/columbia_plume/roms_forcing.py
@@ -93,7 +93,7 @@ def test_interpolator():
     }
     mesh = extrude_mesh_sigma(mesh2d, nlayers, bathymetry_2d,
                               **extrude_options)
-    p1 = FunctionSpace(mesh, 'CG', 1)
+    p1 = get_functionspace_3d(mesh, 'CG', 1)
 
     # make functions
     salt = Function(p1, name='salinity')

--- a/examples/columbia_plume/roms_forcing.py
+++ b/examples/columbia_plume/roms_forcing.py
@@ -93,7 +93,7 @@ def test_interpolator():
     }
     mesh = extrude_mesh_sigma(mesh2d, nlayers, bathymetry_2d,
                               **extrude_options)
-    p1 = get_functionspace_3d(mesh, 'CG', 1)
+    p1 = get_functionspace(mesh, 'CG', 1)
 
     # make functions
     salt = Function(p1, name='salinity')

--- a/examples/columbia_plume/test_bathy_smoothing.py
+++ b/examples/columbia_plume/test_bathy_smoothing.py
@@ -42,7 +42,7 @@ out.write(new_bathymetry_2d)
 def compute_hcc(bathymetry_2d, nlayers):
     mesh = extrude_mesh_sigma(mesh2d, nlayers, bathymetry_2d)
 
-    P1DG = get_functionspace_3d(mesh, 'DG', 1)
+    P1DG = get_functionspace(mesh, 'DG', 1)
     f_hcc = Function(P1DG, name='hcc_metric_3d')
     xyz = SpatialCoordinate(mesh)
 

--- a/examples/columbia_plume/test_bathy_smoothing.py
+++ b/examples/columbia_plume/test_bathy_smoothing.py
@@ -14,10 +14,6 @@ nlayers = 15
 mesh2d = Mesh('mesh_cre-plume_03_normal.msh')
 print_output('Loaded mesh ' + mesh2d.name)
 
-nnodes = comm.allreduce(mesh2d.topology.num_vertices(), MPI.SUM)
-ntriangles = comm.allreduce(mesh2d.topology.num_cells(), MPI.SUM)
-nprisms = ntriangles*nlayers
-
 dt = 7.0
 t_end = 10*24*3600.
 t_export = 900.

--- a/examples/columbia_plume/test_bathy_smoothing.py
+++ b/examples/columbia_plume/test_bathy_smoothing.py
@@ -42,7 +42,7 @@ out.write(new_bathymetry_2d)
 def compute_hcc(bathymetry_2d, nlayers):
     mesh = extrude_mesh_sigma(mesh2d, nlayers, bathymetry_2d)
 
-    P1DG = FunctionSpace(mesh, 'DG', 1)
+    P1DG = get_functionspace_3d(mesh, 'DG', 1)
     f_hcc = Function(P1DG, name='hcc_metric_3d')
     xyz = SpatialCoordinate(mesh)
 

--- a/examples/columbia_plume/tidal_forcing.py
+++ b/examples/columbia_plume/tidal_forcing.py
@@ -6,8 +6,8 @@ from thetis.forcing import *
 
 def test():
     mesh2d = Mesh('mesh_cre-plume_03_normal.msh')
-    p1 = get_functionspace_2d(mesh2d, 'CG', 1)
-    p1v = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
+    p1 = get_functionspace(mesh2d, 'CG', 1)
+    p1v = get_functionspace(mesh2d, 'CG', 1, vector=True)
     elev_field = Function(p1, name='elevation')
     uv_field = Function(p1v, name='transport')
 

--- a/examples/columbia_plume/tidal_forcing.py
+++ b/examples/columbia_plume/tidal_forcing.py
@@ -2,6 +2,7 @@ from thetis import *
 from atm_forcing import to_latlon, COORDSYS
 from thetis.timezone import *
 from thetis.forcing import *
+from thetis.utility import get_functionspace
 
 
 def test():

--- a/examples/columbia_plume/tidal_forcing.py
+++ b/examples/columbia_plume/tidal_forcing.py
@@ -6,8 +6,8 @@ from thetis.forcing import *
 
 def test():
     mesh2d = Mesh('mesh_cre-plume_03_normal.msh')
-    p1 = FunctionSpace(mesh2d, 'CG', 1)
-    p1v = VectorFunctionSpace(mesh2d, 'CG', 1)
+    p1 = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1v = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
     elev_field = Function(p1, name='elevation')
     uv_field = Function(p1v, name='transport')
 

--- a/examples/dome/dome.py
+++ b/examples/dome/dome.py
@@ -46,7 +46,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
 delta_x = delta_x_dict[reso_str]
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 xy = SpatialCoordinate(mesh2d)
 lin_bath_expr = (setup.depth_lim[1] - setup.depth_lim[0])/(setup.y_slope[1] - setup.y_slope[0])*(xy[1] - setup.y_slope[0]) + setup.depth_lim[0]

--- a/examples/dome/dome.py
+++ b/examples/dome/dome.py
@@ -46,7 +46,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
 delta_x = delta_x_dict[reso_str]
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 xy = SpatialCoordinate(mesh2d)
 lin_bath_expr = (setup.depth_lim[1] - setup.depth_lim[0])/(setup.y_slope[1] - setup.y_slope[0])*(xy[1] - setup.y_slope[0]) + setup.depth_lim[0]

--- a/examples/freshwaterCylinder/freshwaterCylinder.py
+++ b/examples/freshwaterCylinder/freshwaterCylinder.py
@@ -177,7 +177,7 @@ salt_center = 33.75
 salt_outside = 34.85
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/freshwaterCylinder/freshwaterCylinder.py
+++ b/examples/freshwaterCylinder/freshwaterCylinder.py
@@ -177,7 +177,7 @@ salt_center = 33.75
 salt_outside = 34.85
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/geostrophicGyre/geoGyre2d.py
+++ b/examples/geostrophicGyre/geoGyre2d.py
@@ -25,8 +25,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
-P1v_2d = VectorFunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/geostrophicGyre/geoGyre2d.py
+++ b/examples/geostrophicGyre/geoGyre2d.py
@@ -25,8 +25,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
-P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/idealizedEstuary/warnerEstuary.py
+++ b/examples/idealizedEstuary/warnerEstuary.py
@@ -50,7 +50,7 @@ salt_river = 0.0
 temp_const = 10.0
 
 # bathymetry
-p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(p1_2d, name='Bathymetry')
 x, y = SpatialCoordinate(mesh2d)
 bathymetry_2d.interpolate(depth_ocean - (depth_ocean - depth_river)*x/lx)

--- a/examples/idealizedEstuary/warnerEstuary.py
+++ b/examples/idealizedEstuary/warnerEstuary.py
@@ -50,7 +50,7 @@ salt_river = 0.0
 temp_const = 10.0
 
 # bathymetry
-p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+p1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(p1_2d, name='Bathymetry')
 x, y = SpatialCoordinate(mesh2d)
 bathymetry_2d.interpolate(depth_ocean - (depth_ocean - depth_river)*x/lx)

--- a/examples/katophillips/katophillips.py
+++ b/examples/katophillips/katophillips.py
@@ -64,7 +64,7 @@ def katophillips_test(layers=25, gls_closure='k-omega',
         t_end = 5*t_export
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry2d = Function(P1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/examples/katophillips/katophillips.py
+++ b/examples/katophillips/katophillips.py
@@ -64,7 +64,7 @@ def katophillips_test(layers=25, gls_closure='k-omega',
         t_end = 5*t_export
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry2d = Function(P1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/examples/lockExchange/diagnostics.py
+++ b/examples/lockExchange/diagnostics.py
@@ -42,7 +42,7 @@ class FrontLocationCalculator(DiagnosticCallback):
                                                   boundary='bottom',
                                                   elem_facet='bottom')
         # project to higher order cg for interpolation
-        fs_ho = get_functionspace_2d(mesh2d, 'CG', 2)
+        fs_ho = get_functionspace(mesh2d, 'CG', 2)
         self.rho_ho = Function(fs_ho, name='Density 2d ho')
         self.ho_projector = Projector(self.rho_2d, self.rho_ho)
         self._initialized = True

--- a/examples/lockExchange/diagnostics.py
+++ b/examples/lockExchange/diagnostics.py
@@ -42,7 +42,7 @@ class FrontLocationCalculator(DiagnosticCallback):
                                                   boundary='bottom',
                                                   elem_facet='bottom')
         # project to higher order cg for interpolation
-        fs_ho = FunctionSpace(mesh2d, 'CG', 2)
+        fs_ho = get_functionspace_2d(mesh2d, 'CG', 2)
         self.rho_ho = Function(fs_ho, name='Density 2d ho')
         self.ho_projector = Projector(self.rho_2d, self.rho_ho)
         self._initialized = True

--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -190,11 +190,6 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
     print_output('Lax-Friedrichs factor trc: {:}'.format(laxfriedrichs_trc))
     print_output('Exporting to {:}'.format(outputdir))
 
-    esize = solver_obj.fields.h_elem_size_2d
-    min_elem_size = comm.allreduce(np.min(esize.dat.data), op=MPI.MIN)
-    max_elem_size = comm.allreduce(np.max(esize.dat.data), op=MPI.MAX)
-    print_output('Elem size: {:} {:}'.format(min_elem_size, max_elem_size))
-
     temp_init3d = Function(solver_obj.function_spaces.H, name='initial temperature')
     x, y, z = SpatialCoordinate(solver_obj.mesh)
     # vertical barrier

--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -115,7 +115,7 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
     outputdir = 'outputs_' + options_str
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -115,7 +115,7 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
     outputdir = 'outputs_' + options_str
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/examples/overflow/overflow.py
+++ b/examples/overflow/overflow.py
@@ -42,7 +42,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 hmin = 500.0
 hmax = 2000.0

--- a/examples/overflow/overflow.py
+++ b/examples/overflow/overflow.py
@@ -42,7 +42,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 hmin = 500.0
 hmax = 2000.0

--- a/examples/rhineROFI/rhineROFI.py
+++ b/examples/rhineROFI/rhineROFI.py
@@ -101,7 +101,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 x, y = SpatialCoordinate(mesh2d)
 bathymetry_2d.interpolate(conditional(le(x, 0.0),

--- a/examples/rhineROFI/rhineROFI.py
+++ b/examples/rhineROFI/rhineROFI.py
@@ -101,7 +101,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 x, y = SpatialCoordinate(mesh2d)
 bathymetry_2d.interpolate(conditional(le(x, 0.0),

--- a/examples/rhineROFI/rhineROFI2d.py
+++ b/examples/rhineROFI/rhineROFI2d.py
@@ -55,7 +55,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 x, y = SpatialCoordinate(mesh2d)
 bathymetry_2d.interpolate(conditional(x > 0.0,

--- a/examples/rhineROFI/rhineROFI2d.py
+++ b/examples/rhineROFI/rhineROFI2d.py
@@ -55,7 +55,7 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 1*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 x, y = SpatialCoordinate(mesh2d)
 bathymetry_2d.interpolate(conditional(x > 0.0,

--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -25,8 +25,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
-P1v_2d = VectorFunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -25,8 +25,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
-P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/stommel2d/stommel2d_picard.py
+++ b/examples/stommel2d/stommel2d_picard.py
@@ -29,8 +29,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
-P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/stommel2d/stommel2d_picard.py
+++ b/examples/stommel2d/stommel2d_picard.py
@@ -29,8 +29,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
-P1v_2d = VectorFunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/stommel3d/stommel3d.py
+++ b/examples/stommel3d/stommel3d.py
@@ -27,8 +27,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
-P1v_2d = VectorFunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/stommel3d/stommel3d.py
+++ b/examples/stommel3d/stommel3d.py
@@ -27,8 +27,8 @@ if os.getenv('THETIS_REGRESSION_TEST') is not None:
     t_end = 5*t_export
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
-P1v_2d = get_functionspace_2d(mesh2d, 'CG', 1, vector=True)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
+P1v_2d = get_functionspace(mesh2d, 'CG', 1, vector=True)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/tidal_barrage/lagoon2d.py
+++ b/examples/tidal_barrage/lagoon2d.py
@@ -34,7 +34,7 @@ period = 12.42 * 3600
 omega = (2 * pi) / period
 
 # Bathymetry and viscosity field
-P1_2d = FunctionSpace(mesh2d, 'DG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'DG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 viscosity_2d = Function(P1_2d, name='viscosity')
 

--- a/examples/tidal_barrage/lagoon2d.py
+++ b/examples/tidal_barrage/lagoon2d.py
@@ -34,7 +34,7 @@ period = 12.42 * 3600
 omega = (2 * pi) / period
 
 # Bathymetry and viscosity field
-P1_2d = get_functionspace_2d(mesh2d, 'DG', 1)
+P1_2d = get_functionspace(mesh2d, 'DG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 viscosity_2d = Function(P1_2d, name='viscosity')
 

--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -66,7 +66,7 @@ options.quadratic_drag_coefficient = Constant(0.0025)
 left_tag = 1
 right_tag = 2
 coasts_tag = 3
-tidal_elev = Function(get_functionspace_2d(mesh2d, "CG", 1), name='tidal_elev')
+tidal_elev = Function(get_functionspace(mesh2d, "CG", 1), name='tidal_elev')
 tidal_elev_bc = {'elev': tidal_elev}
 # noslip currently doesn't work (vector Constants are broken in firedrake_adjoint)
 freeslip_bc = {'un': Constant(0.0)}
@@ -88,7 +88,7 @@ def update_forcings(t):
 
 
 # a density function (to be optimised below) that specifies the number of turbines per unit area
-turbine_density = Function(get_functionspace_2d(mesh2d, "CG", 1), name='turbine_density')
+turbine_density = Function(get_functionspace(mesh2d, "CG", 1), name='turbine_density')
 # associate subdomain_id 2 (as in dx(2)) with a tidal turbine farm
 # (implemented via a drag term) with specified turbine density
 # Turbine characteristic can be specified via:
@@ -115,7 +115,7 @@ turbine_density.assign(0.0)
 # These nonzero values outside the farm itself do not contribute in any of the
 # computations. For visualisation purposes we therefore project to a DG field
 # restricted to the farm.
-farm_density = Function(get_functionspace_2d(mesh2d, "DG", 1), name='farm_density')
+farm_density = Function(get_functionspace(mesh2d, "DG", 1), name='farm_density')
 projector = SubdomainProjector(turbine_density, farm_density, 2)
 projector.project()
 

--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -66,7 +66,7 @@ options.quadratic_drag_coefficient = Constant(0.0025)
 left_tag = 1
 right_tag = 2
 coasts_tag = 3
-tidal_elev = Function(FunctionSpace(mesh2d, "CG", 1), name='tidal_elev')
+tidal_elev = Function(get_functionspace_2d(mesh2d, "CG", 1), name='tidal_elev')
 tidal_elev_bc = {'elev': tidal_elev}
 # noslip currently doesn't work (vector Constants are broken in firedrake_adjoint)
 freeslip_bc = {'un': Constant(0.0)}
@@ -88,7 +88,7 @@ def update_forcings(t):
 
 
 # a density function (to be optimised below) that specifies the number of turbines per unit area
-turbine_density = Function(FunctionSpace(mesh2d, "CG", 1), name='turbine_density')
+turbine_density = Function(get_functionspace_2d(mesh2d, "CG", 1), name='turbine_density')
 # associate subdomain_id 2 (as in dx(2)) with a tidal turbine farm
 # (implemented via a drag term) with specified turbine density
 # Turbine characteristic can be specified via:
@@ -115,7 +115,7 @@ turbine_density.assign(0.0)
 # These nonzero values outside the farm itself do not contribute in any of the
 # computations. For visualisation purposes we therefore project to a DG field
 # restricted to the farm.
-farm_density = Function(FunctionSpace(mesh2d, "DG", 1), name='farm_density')
+farm_density = Function(get_functionspace_2d(mesh2d, "DG", 1), name='farm_density')
 projector = SubdomainProjector(turbine_density, farm_density, 2)
 projector.project()
 

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -37,7 +37,7 @@ outputdir = 'outputs' + suffix
 print_output('Exporting to ' + outputdir)
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -37,7 +37,7 @@ outputdir = 'outputs' + suffix
 print_output('Exporting to ' + outputdir)
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/waveEq2d/channel2d_waveEq.py
+++ b/examples/waveEq2d/channel2d_waveEq.py
@@ -26,7 +26,7 @@ u_mag = Constant(0.5)
 outputdir = 'outputs_wave_eq_2d'
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/waveEq2d/channel2d_waveEq.py
+++ b/examples/waveEq2d/channel2d_waveEq.py
@@ -26,7 +26,7 @@ u_mag = Constant(0.5)
 outputdir = 'outputs_wave_eq_2d'
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/waveEq3d/channel3d_waveEq.py
+++ b/examples/waveEq3d/channel3d_waveEq.py
@@ -28,7 +28,7 @@ outputdir = 'outputs'
 print_output('Exporting to ' + outputdir)
 
 # bathymetry
-P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/examples/waveEq3d/channel3d_waveEq.py
+++ b/examples/waveEq3d/channel3d_waveEq.py
@@ -28,7 +28,7 @@ outputdir = 'outputs'
 print_output('Exporting to ' + outputdir)
 
 # bathymetry
-P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+P1_2d = get_functionspace(mesh2d, 'CG', 1)
 bathymetry_2d = Function(P1_2d, name='Bathymetry')
 bathymetry_2d.assign(depth)
 

--- a/test/barotropicChannel/test_closed_channel.py
+++ b/test/barotropicChannel/test_closed_channel.py
@@ -26,7 +26,7 @@ def test_closed_channel(**user_options):
     t_export = 900.0
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     depth_max = 20.0

--- a/test/barotropicChannel/test_closed_channel.py
+++ b/test/barotropicChannel/test_closed_channel.py
@@ -26,7 +26,7 @@ def test_closed_channel(**user_options):
     t_export = 900.0
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     depth_max = 20.0

--- a/test/bottomFriction/test_bottom_friction.py
+++ b/test/bottomFriction/test_bottom_friction.py
@@ -52,7 +52,7 @@ def run_bottom_friction(parabolic_visosity=False,
     u_mag = 1.0
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry2d = Function(p1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/test/bottomFriction/test_bottom_friction.py
+++ b/test/bottomFriction/test_bottom_friction.py
@@ -52,7 +52,7 @@ def run_bottom_friction(parabolic_visosity=False,
     u_mag = 1.0
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry2d = Function(p1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/test/callback/test_diagnostic_hdf5_output.py
+++ b/test/callback/test_diagnostic_hdf5_output.py
@@ -30,7 +30,7 @@ def test_callbacks(tmp_outputdir):
     print_output('Exporting to ' + outputdir)
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/callback/test_diagnostic_hdf5_output.py
+++ b/test/callback/test_diagnostic_hdf5_output.py
@@ -30,7 +30,7 @@ def test_callbacks(tmp_outputdir):
     print_output('Exporting to ' + outputdir)
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/continuity3d/test_continuity_mes.py
+++ b/test/continuity3d/test_continuity_mes.py
@@ -90,7 +90,7 @@ def run(setup, refinement, order, do_export=True):
     mesh2d = RectangleMesh(nx, ny, lx, ly)
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     x_2d, y_2d = SpatialCoordinate(mesh2d)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(setup_obj.bath(x_2d, y_2d, lx, ly))

--- a/test/continuity3d/test_continuity_mes.py
+++ b/test/continuity3d/test_continuity_mes.py
@@ -90,7 +90,7 @@ def run(setup, refinement, order, do_export=True):
     mesh2d = RectangleMesh(nx, ny, lx, ly)
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     x_2d, y_2d = SpatialCoordinate(mesh2d)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(setup_obj.bath(x_2d, y_2d, lx, ly))

--- a/test/firedrake/test_divergence_2d.py
+++ b/test/firedrake/test_divergence_2d.py
@@ -2,6 +2,7 @@
 Tests convergence of div(uv) in 2D
 """
 from firedrake import *
+from thetis.utility import get_functionspace_2d
 import numpy
 from scipy import stats
 import os
@@ -15,11 +16,11 @@ def compute(refinement=1, order=1, do_export=False):
     mesh = UnitSquareMesh(n, n)
 
     family = 'DG'
-    p0dg = FunctionSpace(mesh, family, order-1)
-    p1dg = FunctionSpace(mesh, family, order)
-    p1dg_v = VectorFunctionSpace(mesh, family, order)
-    p1dg_ho = FunctionSpace(mesh, family, order + 2)
-    p1dg_v_ho = VectorFunctionSpace(mesh, family, order + 2)
+    p0dg = get_functionspace_2d(mesh, family, order-1)
+    p1dg = get_functionspace_2d(mesh, family, order)
+    p1dg_v = get_functionspace_2d(mesh, family, order, vector=True)
+    p1dg_ho = get_functionspace_2d(mesh, family, order + 2)
+    p1dg_v_ho = get_functionspace_2d(mesh, family, order + 2, vector=True)
 
     lx = 1.0
     x, y = SpatialCoordinate(mesh)

--- a/test/firedrake/test_divergence_2d.py
+++ b/test/firedrake/test_divergence_2d.py
@@ -2,7 +2,7 @@
 Tests convergence of div(uv) in 2D
 """
 from firedrake import *
-from thetis.utility import get_functionspace_2d
+from thetis.utility import get_functionspace
 import numpy
 from scipy import stats
 import os
@@ -16,11 +16,11 @@ def compute(refinement=1, order=1, do_export=False):
     mesh = UnitSquareMesh(n, n)
 
     family = 'DG'
-    p0dg = get_functionspace_2d(mesh, family, order-1)
-    p1dg = get_functionspace_2d(mesh, family, order)
-    p1dg_v = get_functionspace_2d(mesh, family, order, vector=True)
-    p1dg_ho = get_functionspace_2d(mesh, family, order + 2)
-    p1dg_v_ho = get_functionspace_2d(mesh, family, order + 2, vector=True)
+    p0dg = get_functionspace(mesh, family, order-1)
+    p1dg = get_functionspace(mesh, family, order)
+    p1dg_v = get_functionspace(mesh, family, order, vector=True)
+    p1dg_ho = get_functionspace(mesh, family, order + 2)
+    p1dg_v_ho = get_functionspace(mesh, family, order + 2, vector=True)
 
     lx = 1.0
     x, y = SpatialCoordinate(mesh)

--- a/test/firedrake/test_implicit_diffusion.py
+++ b/test/firedrake/test_implicit_diffusion.py
@@ -5,7 +5,7 @@ Tests implicit vertical diffusion on a DG vector field
 Intended to be executed with pytest.
 """
 from firedrake import *
-from thetis.utility import get_functionspace_3d
+from thetis.utility import get_functionspace
 import numpy as np
 
 op2.init(log_level=WARNING)
@@ -42,7 +42,7 @@ def test_implicit_diffusion(do_export=False, do_assert=True):
     # define function spaces
     fam = 'DG'
     deg = 1
-    fs = get_functionspace_3d(mesh, fam, deg)
+    fs = get_functionspace(mesh, fam, deg)
 
     solution = Function(fs, name='tracer')
     solution_new = Function(fs, name='new tracer')

--- a/test/firedrake/test_implicit_diffusion.py
+++ b/test/firedrake/test_implicit_diffusion.py
@@ -5,6 +5,7 @@ Tests implicit vertical diffusion on a DG vector field
 Intended to be executed with pytest.
 """
 from firedrake import *
+from thetis.utility import get_functionspace_3d
 import numpy as np
 
 op2.init(log_level=WARNING)
@@ -41,7 +42,7 @@ def test_implicit_diffusion(do_export=False, do_assert=True):
     # define function spaces
     fam = 'DG'
     deg = 1
-    fs = FunctionSpace(mesh, fam, degree=deg, vfamily=fam, vdegree=deg)
+    fs = get_functionspace_3d(mesh, fam, deg)
 
     solution = Function(fs, name='tracer')
     solution_new = Function(fs, name='new tracer')

--- a/test/firedrake/test_implicit_friction.py
+++ b/test/firedrake/test_implicit_friction.py
@@ -5,7 +5,7 @@ Tests implicit bottom friction formulation
 Intended to be executed with pytest.
 """
 from firedrake import *
-from thetis.utility import get_functionspace_3d
+from thetis.utility import get_functionspace
 import numpy as np
 import time as time_mod
 
@@ -36,8 +36,8 @@ def test_implicit_friction(do_export=False, do_assert=True):
 
     # ----- define function spaces
     deg = 1
-    p1dg = get_functionspace_3d(mesh, 'DG', 1)
-    p1dgv = get_functionspace_3d(mesh, 'DG', 1, vector=True)
+    p1dg = get_functionspace(mesh, 'DG', 1)
+    p1dgv = get_functionspace(mesh, 'DG', 1, vector=True)
     u_h_elt = FiniteElement('RT', triangle, deg + 1, variant='equispaced')
     u_v_elt = FiniteElement('DG', interval, deg, variant='equispaced')
     u_elt = HDiv(TensorProductElement(u_h_elt, u_v_elt))

--- a/test/firedrake/test_implicit_friction.py
+++ b/test/firedrake/test_implicit_friction.py
@@ -5,6 +5,7 @@ Tests implicit bottom friction formulation
 Intended to be executed with pytest.
 """
 from firedrake import *
+from thetis.utility import get_functionspace_3d
 import numpy as np
 import time as time_mod
 
@@ -35,14 +36,14 @@ def test_implicit_friction(do_export=False, do_assert=True):
 
     # ----- define function spaces
     deg = 1
-    p1dg = FunctionSpace(mesh, 'DG', degree=1, vfamily='DG', vdegree=1)
-    p1dgv = VectorFunctionSpace(mesh, 'DG', degree=1, vfamily='DG', vdegree=1)
-    u_h_elt = FiniteElement('RT', triangle, deg + 1)
-    u_v_elt = FiniteElement('DG', interval, deg)
+    p1dg = get_functionspace_3d(mesh, 'DG', 1)
+    p1dgv = get_functionspace_3d(mesh, 'DG', 1, vector=True)
+    u_h_elt = FiniteElement('RT', triangle, deg + 1, variant='equispaced')
+    u_v_elt = FiniteElement('DG', interval, deg, variant='equispaced')
     u_elt = HDiv(TensorProductElement(u_h_elt, u_v_elt))
     # for vertical velocity component
-    w_h_elt = FiniteElement('DG', triangle, deg)
-    w_v_elt = FiniteElement('CG', interval, deg + 1)
+    w_h_elt = FiniteElement('DG', triangle, deg, variant='equispaced')
+    w_v_elt = FiniteElement('CG', interval, deg + 1, variant='equispaced')
     w_elt = HDiv(TensorProductElement(w_h_elt, w_v_elt))
     # in deformed mesh horiz. velocity must actually live in U + W
     uw_elt = EnrichedElement(u_elt, w_elt)

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -34,7 +34,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
     x_2d, y_2d = SpatialCoordinate(mesh2d)
@@ -80,7 +80,7 @@ def run(refinement, **model_options):
     uv_ana = Function(solverobj.function_spaces.U, name='uv analytical')
     uv_ana_p1 = Function(solverobj.function_spaces.P1v, name='uv analytical')
 
-    p1dg_v_ho = get_functionspace_3d(solverobj.mesh,
+    p1dg_v_ho = get_functionspace(solverobj.mesh,
         'DG', options.polynomial_degree + 2, vector=True)
     uv_ana_ho = Function(p1dg_v_ho, name='uv analytical')
     uv_ana.project(ana_uv_expr)

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -34,7 +34,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
     x_2d, y_2d = SpatialCoordinate(mesh2d)
@@ -80,8 +80,8 @@ def run(refinement, **model_options):
     uv_ana = Function(solverobj.function_spaces.U, name='uv analytical')
     uv_ana_p1 = Function(solverobj.function_spaces.P1v, name='uv analytical')
 
-    p1dg_v_ho = VectorFunctionSpace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
-                                    vfamily='DG', vdegree=options.polynomial_degree + 2)
+    p1dg_v_ho = get_functionspace_3d(solverobj.mesh,
+        'DG', options.polynomial_degree + 2, vector=True)
     uv_ana_ho = Function(p1dg_v_ho, name='uv analytical')
     uv_ana.project(ana_uv_expr)
 

--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -45,7 +45,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 
@@ -85,7 +85,7 @@ def run(refinement, **model_options):
     uv_ana = Function(solverobj.function_spaces.U, name='uv analytical')
     uv_ana_p1 = Function(solverobj.function_spaces.P1v, name='uv analytical')
 
-    p1dg_v_ho = get_functionspace_3d(solverobj.mesh,
+    p1dg_v_ho = get_functionspace(solverobj.mesh,
         'DG', options.polynomial_degree + 2, vector=True)
     uv_ana_ho = Function(p1dg_v_ho, name='uv analytical')
     uv_ana.project(ana_uv_expr)

--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -45,7 +45,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 
@@ -85,8 +85,8 @@ def run(refinement, **model_options):
     uv_ana = Function(solverobj.function_spaces.U, name='uv analytical')
     uv_ana_p1 = Function(solverobj.function_spaces.P1v, name='uv analytical')
 
-    p1dg_v_ho = VectorFunctionSpace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
-                                    vfamily='DG', vdegree=options.polynomial_degree + 2)
+    p1dg_v_ho = get_functionspace_3d(solverobj.mesh,
+        'DG', options.polynomial_degree + 2, vector=True)
     uv_ana_ho = Function(p1dg_v_ho, name='uv analytical')
     uv_ana.project(ana_uv_expr)
 

--- a/test/operations/test_hcc_metric.py
+++ b/test/operations/test_hcc_metric.py
@@ -22,7 +22,7 @@ def compute_hcc_metric(nelem, nlayers, slope, deform='uniform'):
             mesh.coordinates.dat.data[:, 2] +
             slope*mesh.coordinates.dat.data[:, 0]*mesh.coordinates.dat.data[:, 2])
 
-    P1DG = utility.get_functionspace_3d(mesh, 'DG', 1)
+    P1DG = utility.get_functionspace(mesh, 'DG', 1)
     f_hcc = Function(P1DG, name='hcc_metric_3d')
 
     # emulate solver object

--- a/test/operations/test_hcc_metric.py
+++ b/test/operations/test_hcc_metric.py
@@ -22,7 +22,7 @@ def compute_hcc_metric(nelem, nlayers, slope, deform='uniform'):
             mesh.coordinates.dat.data[:, 2] +
             slope*mesh.coordinates.dat.data[:, 0]*mesh.coordinates.dat.data[:, 2])
 
-    P1DG = FunctionSpace(mesh, 'DG', 1)
+    P1DG = utility.get_functionspace_3d(mesh, 'DG', 1)
     f_hcc = Function(P1DG, name='hcc_metric_3d')
 
     # emulate solver object

--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -11,7 +11,7 @@ def mesh2d():
 
 @pytest.fixture(scope="module")
 def mesh(mesh2d):
-    fs = FunctionSpace(mesh2d, 'CG', 1)
+    fs = utility.get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(fs).assign(1.0)
     n_layers = 10
     return utility.extrude_mesh_sigma(mesh2d, n_layers, bathymetry_2d)
@@ -32,27 +32,26 @@ def spaces(request):
 @pytest.fixture
 def p1_2d(mesh2d, spaces):
     (name, order), (vname, vorder) = spaces
-    return FunctionSpace(mesh2d, name, order)
+    return utility.get_functionspace_2d(mesh2d, name, order)
 
 
 @pytest.fixture
 def p1(mesh, spaces):
     (name, order), (vname, vorder) = spaces
-    return FunctionSpace(mesh, name, order,
-                         vfamily=vname, vdegree=vorder)
+    return utility.get_functionspace_3d(mesh, name, order, vname, vorder)
 
 
 @pytest.fixture
 def u_2d(mesh2d, spaces):
     (name, order), (vname, vorder) = spaces
-    return VectorFunctionSpace(mesh2d, name, order)
+    return utility.get_functionspace_2d(mesh2d, name, order, vector=True)
 
 
 @pytest.fixture
 def u(mesh, spaces):
     (name, order), (vname, vorder) = spaces
-    return VectorFunctionSpace(mesh, name, order,
-                               vfamily=vname, vdegree=vorder)
+    return utility.get_functionspace_3d(mesh, name, order, vname, vorder,
+                                        vector=True)
 
 
 @pytest.fixture

--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -11,7 +11,7 @@ def mesh2d():
 
 @pytest.fixture(scope="module")
 def mesh(mesh2d):
-    fs = utility.get_functionspace_2d(mesh2d, 'CG', 1)
+    fs = utility.get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(fs).assign(1.0)
     n_layers = 10
     return utility.extrude_mesh_sigma(mesh2d, n_layers, bathymetry_2d)
@@ -32,25 +32,25 @@ def spaces(request):
 @pytest.fixture
 def p1_2d(mesh2d, spaces):
     (name, order), (vname, vorder) = spaces
-    return utility.get_functionspace_2d(mesh2d, name, order)
+    return utility.get_functionspace(mesh2d, name, order)
 
 
 @pytest.fixture
 def p1(mesh, spaces):
     (name, order), (vname, vorder) = spaces
-    return utility.get_functionspace_3d(mesh, name, order, vname, vorder)
+    return utility.get_functionspace(mesh, name, order, vname, vorder)
 
 
 @pytest.fixture
 def u_2d(mesh2d, spaces):
     (name, order), (vname, vorder) = spaces
-    return utility.get_functionspace_2d(mesh2d, name, order, vector=True)
+    return utility.get_functionspace(mesh2d, name, order, vector=True)
 
 
 @pytest.fixture
 def u(mesh, spaces):
     (name, order), (vname, vorder) = spaces
-    return utility.get_functionspace_3d(mesh, name, order, vname, vorder,
+    return utility.get_functionspace(mesh, name, order, vname, vorder,
                                         vector=True)
 
 

--- a/test/pressure_grad/test_baroc_head_mes.py
+++ b/test/pressure_grad/test_baroc_head_mes.py
@@ -33,7 +33,7 @@ def compute_l2_error(refinement=1, fs_type='P1DGxP1DG', no_exports=True):
     layers = 3*refinement
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     xy = SpatialCoordinate(mesh2d)
@@ -44,14 +44,14 @@ def compute_l2_error(refinement=1, fs_type='P1DGxP1DG', no_exports=True):
     mesh = extrude_mesh_sigma(mesh2d, layers, bathymetry_2d)
 
     # make function spaces and fields
-    p1 = get_functionspace_3d(mesh, 'CG', 1)
-    p1dg = get_functionspace_3d(mesh, 'DG', 1)
+    p1 = get_functionspace(mesh, 'CG', 1)
+    p1dg = get_functionspace(mesh, 'DG', 1)
     if fs_type == 'P2DGxP2':
-        fs_bhead = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_bhead = get_functionspace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
     elif fs_type == 'P1DGxP2':
-        fs_bhead = get_functionspace_3d(mesh, 'DG', 1, vfamily='CG', vdegree=2)
+        fs_bhead = get_functionspace(mesh, 'DG', 1, vfamily='CG', vdegree=2)
     elif fs_type == 'P1DGxP1DG':
-        fs_bhead = get_functionspace_3d(mesh, 'DG', 1, vfamily='DG', vdegree=1)
+        fs_bhead = get_functionspace(mesh, 'DG', 1, vfamily='DG', vdegree=1)
     else:
         raise Exception('Unsupported function space type {:}'.format(fs_type))
 

--- a/test/pressure_grad/test_baroc_head_mes.py
+++ b/test/pressure_grad/test_baroc_head_mes.py
@@ -33,7 +33,7 @@ def compute_l2_error(refinement=1, fs_type='P1DGxP1DG', no_exports=True):
     layers = 3*refinement
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     xy = SpatialCoordinate(mesh2d)
@@ -44,14 +44,14 @@ def compute_l2_error(refinement=1, fs_type='P1DGxP1DG', no_exports=True):
     mesh = extrude_mesh_sigma(mesh2d, layers, bathymetry_2d)
 
     # make function spaces and fields
-    p1 = FunctionSpace(mesh, 'CG', 1)
-    p1dg = FunctionSpace(mesh, 'DG', 1)
+    p1 = get_functionspace_3d(mesh, 'CG', 1)
+    p1dg = get_functionspace_3d(mesh, 'DG', 1)
     if fs_type == 'P2DGxP2':
-        fs_bhead = FunctionSpace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_bhead = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
     elif fs_type == 'P1DGxP2':
-        fs_bhead = FunctionSpace(mesh, 'DG', 1, vfamily='CG', vdegree=2)
+        fs_bhead = get_functionspace_3d(mesh, 'DG', 1, vfamily='CG', vdegree=2)
     elif fs_type == 'P1DGxP1DG':
-        fs_bhead = FunctionSpace(mesh, 'DG', 1, vfamily='DG', vdegree=1)
+        fs_bhead = get_functionspace_3d(mesh, 'DG', 1, vfamily='DG', vdegree=1)
     else:
         raise Exception('Unsupported function space type {:}'.format(fs_type))
 

--- a/test/pressure_grad/test_int_pg_mes.py
+++ b/test/pressure_grad/test_int_pg_mes.py
@@ -34,7 +34,7 @@ def compute_l2_error(refinement=1, quadratic=False, no_exports=True):
     layers = 3*refinement
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     xy = SpatialCoordinate(mesh2d)
@@ -48,15 +48,15 @@ def compute_l2_error(refinement=1, quadratic=False, no_exports=True):
     mesh.boundary_len = bnd_len
 
     # make function spaces and fields
-    p1 = FunctionSpace(mesh, 'CG', 1)
+    p1 = get_functionspace_3d(mesh, 'CG', 1)
     if quadratic:
         # NOTE for 3rd order convergence both the scalar and grad must be p2
-        fs_pg = VectorFunctionSpace(mesh, 'DG', 2, vfamily='CG', vdegree=2, dim=2)
-        fs_scalar = FunctionSpace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace_3d(mesh, 'DG', 2, 'CG', 2, vector=True, dim=2)
+        fs_scalar = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
     else:
         # the default function spaces in Thetis
-        fs_pg = VectorFunctionSpace(mesh, 'DG', 1, vfamily='CG', vdegree=2, dim=2)
-        fs_scalar = FunctionSpace(mesh, 'DG', 1, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace_3d(mesh, 'DG', 1, 'CG', 2, vector=True, dim=2)
+        fs_scalar = get_functionspace_3d(mesh, 'DG', 1, vfamily='CG', vdegree=2)
 
     density_3d = Function(fs_scalar, name='density')
     baroc_head_3d = Function(fs_scalar, name='baroclinic head')

--- a/test/pressure_grad/test_int_pg_mes.py
+++ b/test/pressure_grad/test_int_pg_mes.py
@@ -34,7 +34,7 @@ def compute_l2_error(refinement=1, quadratic=False, no_exports=True):
     layers = 3*refinement
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     xy = SpatialCoordinate(mesh2d)
@@ -48,15 +48,15 @@ def compute_l2_error(refinement=1, quadratic=False, no_exports=True):
     mesh.boundary_len = bnd_len
 
     # make function spaces and fields
-    p1 = get_functionspace_3d(mesh, 'CG', 1)
+    p1 = get_functionspace(mesh, 'CG', 1)
     if quadratic:
         # NOTE for 3rd order convergence both the scalar and grad must be p2
-        fs_pg = get_functionspace_3d(mesh, 'DG', 2, 'CG', 2, vector=True, dim=2)
-        fs_scalar = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace(mesh, 'DG', 2, 'CG', 2, vector=True, dim=2)
+        fs_scalar = get_functionspace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
     else:
         # the default function spaces in Thetis
-        fs_pg = get_functionspace_3d(mesh, 'DG', 1, 'CG', 2, vector=True, dim=2)
-        fs_scalar = get_functionspace_3d(mesh, 'DG', 1, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace(mesh, 'DG', 1, 'CG', 2, vector=True, dim=2)
+        fs_scalar = get_functionspace(mesh, 'DG', 1, vfamily='CG', vdegree=2)
 
     density_3d = Function(fs_scalar, name='density')
     baroc_head_3d = Function(fs_scalar, name='baroclinic head')

--- a/test/pressure_grad/test_int_pg_zero.py
+++ b/test/pressure_grad/test_int_pg_zero.py
@@ -35,7 +35,7 @@ def compute_pg_error(**kwargs):
     salt_const = 33.0
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     xy = SpatialCoordinate(mesh2d)

--- a/test/pressure_grad/test_int_pg_zero.py
+++ b/test/pressure_grad/test_int_pg_zero.py
@@ -35,7 +35,7 @@ def compute_pg_error(**kwargs):
     salt_const = 33.0
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     xy = SpatialCoordinate(mesh2d)

--- a/test/pressure_grad/test_pg-stack_mes.py
+++ b/test/pressure_grad/test_pg-stack_mes.py
@@ -37,7 +37,7 @@ def compute_l2_error(refinement=1, quadratic_pressure=False, quadratic_density=F
     layers = 3*refinement
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     elev_warp_fact = 0.3
@@ -53,22 +53,22 @@ def compute_l2_error(refinement=1, quadratic_pressure=False, quadratic_density=F
     mesh.boundary_len = bnd_len
 
     # make function spaces and fields
-    p1 = get_functionspace_3d(mesh, 'CG', 1)
-    p1dg = get_functionspace_3d(mesh, 'DG', 1)
+    p1 = get_functionspace(mesh, 'CG', 1)
+    p1dg = get_functionspace(mesh, 'DG', 1)
 
     if quadratic_density:
-        fs_density = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_density = get_functionspace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
     else:
         fs_density = p1dg
 
     if quadratic_pressure:
         # NOTE for 3rd order convergence both the scalar and grad must be p2
-        fs_bhead = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
-        fs_pg = get_functionspace_3d(mesh, 'DG', 2, 'CG', 2, vector=True, dim=2)
+        fs_bhead = get_functionspace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace(mesh, 'DG', 2, 'CG', 2, vector=True, dim=2)
     else:
         # the default function spaces in Thetis
-        fs_bhead = get_functionspace_3d(mesh, 'DG', 1, vfamily='CG', vdegree=2)
-        fs_pg = get_functionspace_3d(mesh, 'DG', 1, 'CG', 2, vector=True, dim=2)
+        fs_bhead = get_functionspace(mesh, 'DG', 1, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace(mesh, 'DG', 1, 'CG', 2, vector=True, dim=2)
 
     temp_3d = Function(p1dg, name='temperature')
     density_3d = Function(fs_density, name='density')

--- a/test/pressure_grad/test_pg-stack_mes.py
+++ b/test/pressure_grad/test_pg-stack_mes.py
@@ -37,7 +37,7 @@ def compute_l2_error(refinement=1, quadratic_pressure=False, quadratic_density=F
     layers = 3*refinement
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     elev_warp_fact = 0.3
@@ -53,22 +53,22 @@ def compute_l2_error(refinement=1, quadratic_pressure=False, quadratic_density=F
     mesh.boundary_len = bnd_len
 
     # make function spaces and fields
-    p1 = FunctionSpace(mesh, 'CG', 1)
-    p1dg = FunctionSpace(mesh, 'DG', 1)
+    p1 = get_functionspace_3d(mesh, 'CG', 1)
+    p1dg = get_functionspace_3d(mesh, 'DG', 1)
 
     if quadratic_density:
-        fs_density = FunctionSpace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_density = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
     else:
         fs_density = p1dg
 
     if quadratic_pressure:
         # NOTE for 3rd order convergence both the scalar and grad must be p2
-        fs_bhead = FunctionSpace(mesh, 'DG', 2, vfamily='CG', vdegree=2)
-        fs_pg = VectorFunctionSpace(mesh, 'DG', 2, vfamily='CG', vdegree=2, dim=2)
+        fs_bhead = get_functionspace_3d(mesh, 'DG', 2, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace_3d(mesh, 'DG', 2, 'CG', 2, vector=True, dim=2)
     else:
         # the default function spaces in Thetis
-        fs_bhead = FunctionSpace(mesh, 'DG', 1, vfamily='CG', vdegree=2)
-        fs_pg = VectorFunctionSpace(mesh, 'DG', 1, vfamily='CG', vdegree=2, dim=2)
+        fs_bhead = get_functionspace_3d(mesh, 'DG', 1, vfamily='CG', vdegree=2)
+        fs_pg = get_functionspace_3d(mesh, 'DG', 1, 'CG', 2, vector=True, dim=2)
 
     temp_3d = Function(p1dg, name='temperature')
     density_3d = Function(fs_density, name='density')

--- a/test/slopelimiter/test_slopelimiter.py
+++ b/test/slopelimiter/test_slopelimiter.py
@@ -21,10 +21,10 @@ def vertex_limiter_test(dim=3, type='linear', direction='x', export=False):
         # slanted prisms
         xyz = mesh.coordinates
         xyz.dat.data[:, 2] *= 1.0 + 0.25 - 0.5*xyz.dat.data[:, 0]
-        p1dg = get_functionspace_3d(mesh, 'DP', 1, vfamily='DP', vdegree=1)
+        p1dg = get_functionspace(mesh, 'DP', 1, vfamily='DP', vdegree=1)
         x, y, z = SpatialCoordinate(mesh)
     else:
-        p1dg = get_functionspace_2d(mesh2d, 'DP', 1)
+        p1dg = get_functionspace(mesh2d, 'DP', 1)
         x, y = SpatialCoordinate(mesh2d)
         z = Constant(0)
 

--- a/test/slopelimiter/test_slopelimiter.py
+++ b/test/slopelimiter/test_slopelimiter.py
@@ -21,10 +21,10 @@ def vertex_limiter_test(dim=3, type='linear', direction='x', export=False):
         # slanted prisms
         xyz = mesh.coordinates
         xyz.dat.data[:, 2] *= 1.0 + 0.25 - 0.5*xyz.dat.data[:, 0]
-        p1dg = FunctionSpace(mesh, 'DP', 1, vfamily='DP', vdegree=1)
+        p1dg = get_functionspace_3d(mesh, 'DP', 1, vfamily='DP', vdegree=1)
         x, y, z = SpatialCoordinate(mesh)
     else:
-        p1dg = FunctionSpace(mesh2d, 'DP', 1)
+        p1dg = get_functionspace_2d(mesh2d, 'DP', 1)
         x, y = SpatialCoordinate(mesh2d)
         z = Constant(0)
 

--- a/test/solver3d/test_baroclinic_mms.py
+++ b/test/solver3d/test_baroclinic_mms.py
@@ -229,7 +229,7 @@ def run(setup, refinement, polynomial_degree, do_export=True, **options):
     mesh2d = RectangleMesh(nx, ny, lx, ly)
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(bath_expr)
 

--- a/test/solver3d/test_baroclinic_mms.py
+++ b/test/solver3d/test_baroclinic_mms.py
@@ -229,7 +229,7 @@ def run(setup, refinement, polynomial_degree, do_export=True, **options):
     mesh2d = RectangleMesh(nx, ny, lx, ly)
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(bath_expr)
 

--- a/test/solver3d/test_barotropic_mes.py
+++ b/test/solver3d/test_barotropic_mes.py
@@ -32,7 +32,7 @@ def run(refinement=1, ncycles=2, **kwargs):
     print_output('Number of layers {:}'.format(n_layers))
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/solver3d/test_barotropic_mes.py
+++ b/test/solver3d/test_barotropic_mes.py
@@ -32,7 +32,7 @@ def run(refinement=1, ncycles=2, **kwargs):
     print_output('Number of layers {:}'.format(n_layers))
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/swe2d/test_atmospheric_pressure.py
+++ b/test/swe2d/test_atmospheric_pressure.py
@@ -55,7 +55,7 @@ def test_pressure_forcing(element_family, timestepper):
         eta_expr = A*cos(pi*x[0]/lx)*cos(pi*x[1]/ly)
 
         # bathymetry
-        P1 = FunctionSpace(mesh2d, "DG", 1)
+        P1 = get_functionspace_2d(mesh2d, "DG", 1)
         bathymetry = Function(P1, name='bathymetry')
         bathymetry.interpolate(Constant(5.0))
 

--- a/test/swe2d/test_atmospheric_pressure.py
+++ b/test/swe2d/test_atmospheric_pressure.py
@@ -55,7 +55,7 @@ def test_pressure_forcing(element_family, timestepper):
         eta_expr = A*cos(pi*x[0]/lx)*cos(pi*x[1]/ly)
 
         # bathymetry
-        P1 = get_functionspace_2d(mesh2d, "DG", 1)
+        P1 = get_functionspace(mesh2d, "DG", 1)
         bathymetry = Function(P1, name='bathymetry')
         bathymetry.interpolate(Constant(5.0))
 

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -35,7 +35,7 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, tmpdir, do_e
     elev_init = cos(pi*x[0]/lx)
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name="bathymetry")
     bathymetry_2d.assign(depth)
 

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -35,7 +35,7 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, tmpdir, do_e
     elev_init = cos(pi*x[0]/lx)
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name="bathymetry")
     bathymetry_2d.assign(depth)
 

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -133,7 +133,7 @@ def run(setup, refinement, order, do_export=True, options=None,
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(sdict['bath_expr'])
     if bathymetry_2d.dat.data.min() < 0.0:

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -133,7 +133,7 @@ def run(setup, refinement, order, do_export=True, options=None,
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(sdict['bath_expr'])
     if bathymetry_2d.dat.data.min() < 0.0:

--- a/test/swe2d/test_steady_state_channel.py
+++ b/test/swe2d/test_steady_state_channel.py
@@ -10,7 +10,7 @@ def test_steady_state_channel(do_export=False):
     mesh2d = RectangleMesh(10, 1, lx, ly)
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name="bathymetry")
     bathymetry_2d.assign(100.0)
 

--- a/test/swe2d/test_steady_state_channel.py
+++ b/test/swe2d/test_steady_state_channel.py
@@ -10,7 +10,7 @@ def test_steady_state_channel(do_export=False):
     mesh2d = RectangleMesh(10, 1, lx, ly)
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name="bathymetry")
     bathymetry_2d.assign(100.0)
 

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -42,11 +42,11 @@ def test_steady_state_channel_mms(options):
         eta_bcval = Constant(eta0)
 
         # bathymetry
-        p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+        p1_2d = get_functionspace(mesh2d, 'CG', 1)
         bathymetry_2d = Function(p1_2d, name="bathymetry")
         bathymetry_2d.assign(H0)
 
-        source_space = get_functionspace_2d(mesh2d, 'DG', order+2, vector=True)
+        source_space = get_functionspace(mesh2d, 'DG', order+2, vector=True)
         source_func = project(source_expr*xhat, source_space, name="Source")
 
         # --- create solver ---

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -42,11 +42,11 @@ def test_steady_state_channel_mms(options):
         eta_bcval = Constant(eta0)
 
         # bathymetry
-        p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+        p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
         bathymetry_2d = Function(p1_2d, name="bathymetry")
         bathymetry_2d.assign(H0)
 
-        source_space = VectorFunctionSpace(mesh2d, 'DG', order+2)
+        source_space = get_functionspace_2d(mesh2d, 'DG', order+2, vector=True)
         source_func = project(source_expr*xhat, source_space, name="Source")
 
         # --- create solver ---

--- a/test/swe2d/test_thacker.py
+++ b/test/swe2d/test_thacker.py
@@ -50,7 +50,7 @@ def test_thacker(stepper, n, dt, alpha, max_err):
     X0 = Y0 = l_mesh/2  # Domain offset
 
     # bathymetry
-    bathymetry = Function(FunctionSpace(mesh2d, "CG", 1), name='bathymetry')
+    bathymetry = Function(get_functionspace_2d(mesh2d, "CG", 1), name='bathymetry')
     x, y = SpatialCoordinate(mesh2d)
     bath_expr = D0*(1-((x-X0)**2+(y-Y0)**2)/L**2)
     bathymetry.interpolate(bath_expr)

--- a/test/swe2d/test_thacker.py
+++ b/test/swe2d/test_thacker.py
@@ -50,7 +50,7 @@ def test_thacker(stepper, n, dt, alpha, max_err):
     X0 = Y0 = l_mesh/2  # Domain offset
 
     # bathymetry
-    bathymetry = Function(get_functionspace_2d(mesh2d, "CG", 1), name='bathymetry')
+    bathymetry = Function(get_functionspace(mesh2d, "CG", 1), name='bathymetry')
     x, y = SpatialCoordinate(mesh2d)
     bath_expr = D0*(1-((x-X0)**2+(y-Y0)**2)/L**2)
     bathymetry.interpolate(bath_expr)

--- a/test/time_integration/test_convergence_ode.py
+++ b/test/time_integration/test_convergence_ode.py
@@ -102,7 +102,7 @@ def run(timeintegrator_class, refinement=1):
     bnd_len = compute_boundary_length(mesh)
     mesh.boundary_len = bnd_len
 
-    p1 = get_functionspace_2d(mesh, 'CG', 1)
+    p1 = get_functionspace(mesh, 'CG', 1)
     fs = MixedFunctionSpace([p1, p1])
 
     alpha = 2*np.pi

--- a/test/time_integration/test_convergence_ode.py
+++ b/test/time_integration/test_convergence_ode.py
@@ -102,7 +102,7 @@ def run(timeintegrator_class, refinement=1):
     bnd_len = compute_boundary_length(mesh)
     mesh.boundary_len = bnd_len
 
-    p1 = FunctionSpace(mesh, 'CG', 1)
+    p1 = get_functionspace_2d(mesh, 'CG', 1)
     fs = MixedFunctionSpace([p1, p1])
 
     alpha = 2*np.pi

--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -37,7 +37,7 @@ def fourier_series_solution(mesh, lx, diff_flux, **model_options):
     time = model_options['simulation_end_time']
 
     # Initial condition and source term for two homogeneous Neumann problems
-    P1 = get_functionspace_2d(mesh, 'CG', 1)
+    P1 = get_functionspace(mesh, 'CG', 1)
     ic = Function(P1).interpolate(diff_flux*0.5*(lx - x)*(lx - x)/lx)
     source = Constant(-nu*diff_flux/lx, domain=mesh)
 
@@ -99,7 +99,7 @@ def run(refinement, **model_options):
     model_options['simulation_end_time'] = t_end
 
     # Bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathy_2d = Function(P1_2d, name='Bathymetry')
     bathy_2d.assign(depth)
 

--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -37,7 +37,7 @@ def fourier_series_solution(mesh, lx, diff_flux, **model_options):
     time = model_options['simulation_end_time']
 
     # Initial condition and source term for two homogeneous Neumann problems
-    P1 = FunctionSpace(mesh, 'CG', 1)
+    P1 = get_functionspace_2d(mesh, 'CG', 1)
     ic = Function(P1).interpolate(diff_flux*0.5*(lx - x)*(lx - x)/lx)
     source = Constant(-nu*diff_flux/lx, domain=mesh)
 
@@ -99,7 +99,7 @@ def run(refinement, **model_options):
     model_options['simulation_end_time'] = t_end
 
     # Bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathy_2d = Function(P1_2d, name='Bathymetry')
     bathy_2d.assign(depth)
 

--- a/test/tracerEq/test_consistency.py
+++ b/test/tracerEq/test_consistency.py
@@ -45,7 +45,7 @@ def run_tracer_consistency(**model_options):
     outputdir = 'outputs' + suffix
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
     x_2d, y_2d = SpatialCoordinate(mesh2d)

--- a/test/tracerEq/test_consistency.py
+++ b/test/tracerEq/test_consistency.py
@@ -45,7 +45,7 @@ def run_tracer_consistency(**model_options):
     outputdir = 'outputs' + suffix
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
     x_2d, y_2d = SpatialCoordinate(mesh2d)

--- a/test/tracerEq/test_consistency_2d.py
+++ b/test/tracerEq/test_consistency_2d.py
@@ -29,7 +29,7 @@ def run_tracer_consistency(constant_c = True, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     x_2d, y_2d = SpatialCoordinate(mesh2d)
     # non-trivial bathymetry, to properly test 2d tracer conservation

--- a/test/tracerEq/test_consistency_2d.py
+++ b/test/tracerEq/test_consistency_2d.py
@@ -29,7 +29,7 @@ def run_tracer_consistency(constant_c = True, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     x_2d, y_2d = SpatialCoordinate(mesh2d)
     # non-trivial bathymetry, to properly test 2d tracer conservation

--- a/test/tracerEq/test_h-advection_mes.py
+++ b/test/tracerEq/test_h-advection_mes.py
@@ -33,7 +33,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 
@@ -80,7 +80,7 @@ def run(refinement, **model_options):
     salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
     salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
 
-    p1dg_ho = get_functionspace_3d(solverobj.mesh, 'DG', options.polynomial_degree + 2,
+    p1dg_ho = get_functionspace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
                             vfamily='DG', vdegree=options.polynomial_degree + 2)
     salt_ana_ho = Function(p1dg_ho, name='salt analytical')
 

--- a/test/tracerEq/test_h-advection_mes.py
+++ b/test/tracerEq/test_h-advection_mes.py
@@ -33,7 +33,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 
@@ -80,7 +80,7 @@ def run(refinement, **model_options):
     salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
     salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
 
-    p1dg_ho = FunctionSpace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
+    p1dg_ho = get_functionspace_3d(solverobj.mesh, 'DG', options.polynomial_degree + 2,
                             vfamily='DG', vdegree=options.polynomial_degree + 2)
     salt_ana_ho = Function(p1dg_ho, name='salt analytical')
 

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -32,7 +32,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -32,7 +32,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/tracerEq/test_h-diffusion_mes.py
+++ b/test/tracerEq/test_h-diffusion_mes.py
@@ -49,7 +49,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
     x_2d, y_2d = SpatialCoordinate(mesh2d)
@@ -91,7 +91,7 @@ def run(refinement, **model_options):
     salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
     salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
 
-    p1dg_ho = FunctionSpace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
+    p1dg_ho = get_functionspace_3d(solverobj.mesh, 'DG', options.polynomial_degree + 2,
                             vfamily='DG', vdegree=options.polynomial_degree + 2)
     salt_ana_ho = Function(p1dg_ho, name='salt analytical')
 

--- a/test/tracerEq/test_h-diffusion_mes.py
+++ b/test/tracerEq/test_h-diffusion_mes.py
@@ -49,7 +49,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
     x_2d, y_2d = SpatialCoordinate(mesh2d)
@@ -91,7 +91,7 @@ def run(refinement, **model_options):
     salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
     salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
 
-    p1dg_ho = get_functionspace_3d(solverobj.mesh, 'DG', options.polynomial_degree + 2,
+    p1dg_ho = get_functionspace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
                             vfamily='DG', vdegree=options.polynomial_degree + 2)
     salt_ana_ho = Function(p1dg_ho, name='salt analytical')
 

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -32,7 +32,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -32,7 +32,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 

--- a/test/tracerEq/test_steady_adv-diff_mms.py
+++ b/test/tracerEq/test_steady_adv-diff_mms.py
@@ -175,7 +175,7 @@ def run(setup, refinement, order, do_export=True, **options):
 
     # bathymetry
     x_2d, y_2d = SpatialCoordinate(mesh2d)
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(setup_obj.bath(x_2d, y_2d, lx, ly))
 

--- a/test/tracerEq/test_steady_adv-diff_mms.py
+++ b/test/tracerEq/test_steady_adv-diff_mms.py
@@ -175,7 +175,7 @@ def run(setup, refinement, order, do_export=True, **options):
 
     # bathymetry
     x_2d, y_2d = SpatialCoordinate(mesh2d)
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(setup_obj.bath(x_2d, y_2d, lx, ly))
 

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -84,7 +84,7 @@ def run(setup, refinement, do_export=True, **options):
 
     # bathymetry
     x_2d, y_2d = SpatialCoordinate(mesh2d)
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(setup_obj.bath(x_2d, y_2d, lx, ly))
 

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -84,7 +84,7 @@ def run(setup, refinement, do_export=True, **options):
 
     # bathymetry
     x_2d, y_2d = SpatialCoordinate(mesh2d)
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.project(setup_obj.bath(x_2d, y_2d, lx, ly))
 

--- a/test/tracerEq/test_v-diffusion_mes.py
+++ b/test/tracerEq/test_v-diffusion_mes.py
@@ -46,7 +46,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 
@@ -84,7 +84,7 @@ def run(refinement, **model_options):
     salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
     salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
 
-    p1dg_ho = get_functionspace_3d(solverobj.mesh, 'DG', options.polynomial_degree + 2,
+    p1dg_ho = get_functionspace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
                             vfamily='DG', vdegree=options.polynomial_degree + 2)
     salt_ana_ho = Function(p1dg_ho, name='salt analytical')
 

--- a/test/tracerEq/test_v-diffusion_mes.py
+++ b/test/tracerEq/test_v-diffusion_mes.py
@@ -46,7 +46,7 @@ def run(refinement, **model_options):
     outputdir = 'outputs'
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(p1_2d, name='Bathymetry')
     bathymetry_2d.assign(depth)
 
@@ -84,7 +84,7 @@ def run(refinement, **model_options):
     salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
     salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
 
-    p1dg_ho = FunctionSpace(solverobj.mesh, 'DG', options.polynomial_degree + 2,
+    p1dg_ho = get_functionspace_3d(solverobj.mesh, 'DG', options.polynomial_degree + 2,
                             vfamily='DG', vdegree=options.polynomial_degree + 2)
     salt_ana_ho = Function(p1dg_ho, name='salt analytical')
 

--- a/test/turbulence/test_katophillips.py
+++ b/test/turbulence/test_katophillips.py
@@ -47,7 +47,7 @@ def run_katophillips(**model_options):
     u_mag = 1.0
 
     # bathymetry
-    p1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry2d = Function(p1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/test/turbulence/test_katophillips.py
+++ b/test/turbulence/test_katophillips.py
@@ -47,7 +47,7 @@ def run_katophillips(**model_options):
     u_mag = 1.0
 
     # bathymetry
-    p1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    p1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry2d = Function(p1_2d, name='Bathymetry')
     bathymetry2d.assign(depth)
 

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -23,7 +23,7 @@ def basic_setup():
     timestep = 0.5
 
     # bathymetry
-    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     depth = 50.0

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -23,7 +23,7 @@ def basic_setup():
     timestep = 0.5
 
     # bathymetry
-    P1_2d = FunctionSpace(mesh2d, 'CG', 1)
+    P1_2d = get_functionspace_2d(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
 
     depth = 50.0

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -25,10 +25,10 @@ def get_visu_space(fs):
     family = 'Lagrange' if is_cg(fs) else 'Discontinuous Lagrange'
     if is_vector:
         dim = fs.ufl_element().value_shape()[0]
-        visu_fs = VectorFunctionSpace(mesh, family, 1,
-                                      vfamily=family, vdegree=1, dim=dim)
+        visu_fs = get_functionspace(mesh, family, 1, family, 1,
+                                    vector=True, dim=dim)
     else:
-        visu_fs = FunctionSpace(mesh, family, 1, vfamily=family, vdegree=1)
+        visu_fs = get_functionspace(mesh, family, 1, family, 1)
     # make sure that you always get the same temp work function
     visu_fs.max_work_functions = 1
     return visu_fs
@@ -305,12 +305,13 @@ class ExportManager(object):
         """
         if is_2d(fs):
             if self.coords_dg_2d is None:
-                coord_fs = VectorFunctionSpace(fs.mesh(), 'DG', 1, name='P1DGv_2d')
+                coord_fs = get_functionspace(fs.mesh(), 'DG', 1, vector=True,
+                                             name='P1DGv_2d')
                 self.coords_dg_2d = Function(coord_fs, name='coordinates 2d dg')
             return self.coords_dg_2d
         if self.coords_dg_3d is None:
-            coord_fs = VectorFunctionSpace(fs.mesh(), 'DG', 1,
-                                           vfamily='DG', vdegree=1, name='P1DGv')
+            coord_fs = get_functionspace(fs.mesh(), 'DG', 1, vector=True,
+                                         name='P1DGv')
             self.coords_dg_3d = Function(coord_fs, name='coords 3d dg')
         return self.coords_dg_3d
 

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -20,6 +20,25 @@ from .log import *
 from collections import OrderedDict
 
 
+def get_functionspace_2d(mesh2d, family, degree, vector=False,
+                         variant='equispaced', **kwargs):
+    elt = FiniteElement(family, mesh2d.ufl_cell(), degree, variant=variant)
+    constructor = VectorFunctionSpace if vector else FunctionSpace
+    return constructor(mesh2d, elt, **kwargs)
+
+
+def get_functionspace_3d(mesh, h_family, h_degree, v_family, v_degree,
+                         vector=False, hdiv=False, variant='equispaced', **kwargs):
+    h_cell, v_cell = mesh.ufl_cell().sub_cells()
+    h_elt = FiniteElement(h_family, h_cell, h_degree, variant=variant)
+    v_elt = FiniteElement(v_family, v_cell, v_degree, variant=variant)
+    elt = TensorProductElement(h_elt, v_elt)
+    if hdiv:
+        elt = HDiv(elt)
+    constructor = VectorFunctionSpace if vector else FunctionSpace
+    return constructor(mesh, elt, **kwargs)
+
+
 class FlowSolver(FrozenClass):
     """
     Main object for 3D solver
@@ -387,64 +406,46 @@ class FlowSolver(FrozenClass):
         """
         self._isfrozen = False
         # ----- function spaces: elev in H, uv in U, mixed is W
-        self.function_spaces.P0 = FunctionSpace(self.mesh, 'DG', 0, vfamily='DG', vdegree=0, name='P0')
-        self.function_spaces.P1 = FunctionSpace(self.mesh, 'CG', 1, vfamily='CG', vdegree=1, name='P1')
-        self.function_spaces.P1v = VectorFunctionSpace(self.mesh, 'CG', 1, vfamily='CG', vdegree=1, name='P1v')
-        self.function_spaces.P1DG = FunctionSpace(self.mesh, 'DG', 1, vfamily='DG', vdegree=1, name='P1DG')
-        self.function_spaces.P1DGv = VectorFunctionSpace(self.mesh, 'DG', 1, vfamily='DG', vdegree=1, name='P1DGv')
+        self.function_spaces.P0 = get_functionspace_3d(self.mesh, 'DG', 0, 'DG', 0, name='P0')
+        self.function_spaces.P1 = get_functionspace_3d(self.mesh, 'CG', 1, 'CG', 1, name='P1')
+        self.function_spaces.P1v = get_functionspace_3d(self.mesh, 'CG', 1, 'CG', 1, name='P1v', vector=True)
+        self.function_spaces.P1DG = get_functionspace_3d(self.mesh, 'DG', 1, 'DG', 1, name='P1DG')
+        self.function_spaces.P1DGv = get_functionspace_3d(self.mesh, 'DG', 1, 'DG', 1, name='P1DGv', vector=True)
 
-        # Construct HDiv TensorProductElements
-        # for horizontal velocity component
-        u_h_elt = FiniteElement('RT', triangle, self.options.polynomial_degree+1)
-        u_v_elt = FiniteElement('DG', interval, self.options.polynomial_degree)
-        u_elt = HDiv(TensorProductElement(u_h_elt, u_v_elt))
-        # for vertical velocity component
-        w_h_elt = FiniteElement('DG', triangle, self.options.polynomial_degree)
-        w_v_elt = FiniteElement('CG', interval, self.options.polynomial_degree+1)
-        w_elt = HDiv(TensorProductElement(w_h_elt, w_v_elt))
-        # final spaces
+        # function spaces for (u,v) and w
         if self.options.element_family == 'rt-dg':
-            # self.U = FunctionSpace(self.mesh, UW_elt)  # uv
-            self.function_spaces.U = FunctionSpace(self.mesh, u_elt, name='U')  # uv
-            self.function_spaces.W = FunctionSpace(self.mesh, w_elt, name='W')  # w
+            self.function_spaces.U = get_functionspace_3d(self.mesh, 'RT', self.options.polynomial_degree+1, 'DG', self.options.polynomial_degree, name='U', hdiv=True)
+            self.function_spaces.W = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'CG', self.options.polynomial_degree+1, name='W', hdiv=True)
         elif self.options.element_family == 'dg-dg':
-            self.function_spaces.U = VectorFunctionSpace(self.mesh, 'DG', self.options.polynomial_degree,
-                                                         vfamily='DG', vdegree=self.options.polynomial_degree,
-                                                         name='U')
-            # NOTE for tracer consistency W should be equivalent to tracer space H
-            self.function_spaces.W = VectorFunctionSpace(self.mesh, 'DG', self.options.polynomial_degree,
-                                                         vfamily='DG', vdegree=self.options.polynomial_degree,
-                                                         name='W')
+            self.function_spaces.U = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='U', vector=True)
+            self.function_spaces.W = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='W', vector=True)
         else:
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
-        # auxiliary function space that will be used to transfer data between 2d/3d modes
-        self.function_spaces.Uproj = self.function_spaces.U
 
         self.function_spaces.Uint = self.function_spaces.U  # vertical integral of uv
         # tracers
-        self.function_spaces.H = FunctionSpace(self.mesh, 'DG', self.options.polynomial_degree, vfamily='DG', vdegree=max(0, self.options.polynomial_degree), name='H')
+        self.function_spaces.H = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='H')
         self.function_spaces.turb_space = self.function_spaces.P0
 
         # 2D spaces
-        self.function_spaces.P1_2d = FunctionSpace(self.mesh2d, 'CG', 1, name='P1_2d')
-        self.function_spaces.P1v_2d = VectorFunctionSpace(self.mesh2d, 'CG', 1, name='P1v_2d')
-        self.function_spaces.P1DG_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='P1DG_2d')
-        self.function_spaces.P1DGv_2d = VectorFunctionSpace(self.mesh2d, 'DG', 1, name='P1DGv_2d')
+        self.function_spaces.P1_2d = get_functionspace_2d(self.mesh2d, 'CG', 1, name='P1_2d')
+        self.function_spaces.P1v_2d = get_functionspace_2d(self.mesh2d, 'CG', 1, name='P1v_2d', vector=True)
+        self.function_spaces.P1DG_2d = get_functionspace_2d(self.mesh2d, 'DG', 1, name='P1DG_2d')
+        self.function_spaces.P1DGv_2d = get_functionspace_2d(self.mesh2d, 'DG', 1, name='P1DGv_2d', vector=True)
         # 2D velocity space
         if self.options.element_family == 'rt-dg':
-            self.function_spaces.U_2d = FunctionSpace(self.mesh2d, 'RT', self.options.polynomial_degree+1)
+            self.function_spaces.U_2d = get_functionspace_2d(self.mesh2d, 'RT', self.options.polynomial_degree+1, name='U_2d')
         elif self.options.element_family == 'dg-dg':
-            self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d')
-        self.function_spaces.Uproj_2d = self.function_spaces.U_2d
-        self.function_spaces.H_2d = FunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
+            self.function_spaces.U_2d = get_functionspace_2d(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d', vector=True)
+        self.function_spaces.H_2d = get_functionspace_2d(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d], name='V_2d')
 
         # define function spaces for baroclinic head and internal pressure gradient
         if self.options.use_quadratic_pressure:
-            self.function_spaces.P2DGxP2 = FunctionSpace(self.mesh, 'DG', 2, vfamily='CG', vdegree=2, name='P2DGxP2')
-            self.function_spaces.P2DG_2d = FunctionSpace(self.mesh2d, 'DG', 2, name='P2DG_2d')
+            self.function_spaces.P2DGxP2 = get_functionspace_3d(self.mesh, 'DG', 2, 'CG', 2, name='P2DGxP2')
+            self.function_spaces.P2DG_2d = get_functionspace_2d(self.mesh2d, 'DG', 2, name='P2DG_2d')
             if self.options.element_family == 'dg-dg':
-                self.function_spaces.P2DGxP1DGv = VectorFunctionSpace(self.mesh, 'DG', 2, vfamily='DG', vdegree=1, name='P2DGxP1DGv', dim=2)
+                self.function_spaces.P2DGxP1DGv = get_functionspace_3d(self.mesh, 'DG', 2, 'DG', 1, name='P2DGxP1DGv', dim=2)
                 self.function_spaces.H_bhead = self.function_spaces.P2DGxP2
                 self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
                 self.function_spaces.U_int_pg = self.function_spaces.P2DGxP1DGv
@@ -453,7 +454,7 @@ class FlowSolver(FrozenClass):
                 self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
                 self.function_spaces.U_int_pg = self.function_spaces.U
         else:
-            self.function_spaces.P1DGxP2 = FunctionSpace(self.mesh, 'DG', 1, vfamily='CG', vdegree=2, name='P1DGxP2')
+            self.function_spaces.P1DGxP2 = get_functionspace_3d(self.mesh, 'DG', 1, 'CG', 2, name='P1DGxP2')
             self.function_spaces.H_bhead = self.function_spaces.P1DGxP2
             self.function_spaces.H_bhead_2d = self.function_spaces.P1DG_2d
             self.function_spaces.U_int_pg = self.function_spaces.U
@@ -507,9 +508,9 @@ class FlowSolver(FrozenClass):
         self.fields.z_coord_3d = Function(coord_fs)
         # z coordinate in the reference mesh (eta=0)
         self.fields.z_coord_ref_3d = Function(coord_fs)
-        self.fields.uv_dav_3d = Function(self.function_spaces.Uproj)
-        self.fields.uv_dav_2d = Function(self.function_spaces.Uproj_2d)
-        self.fields.split_residual_2d = Function(self.function_spaces.Uproj_2d)
+        self.fields.uv_dav_3d = Function(self.function_spaces.U)
+        self.fields.uv_dav_2d = Function(self.function_spaces.U_2d)
+        self.fields.split_residual_2d = Function(self.function_spaces.U_2d)
         self.fields.uv_mag_3d = Function(self.function_spaces.P0)
         self.fields.uv_p1_3d = Function(self.function_spaces.P1v)
         self.fields.w_3d = Function(self.function_spaces.W)

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -387,46 +387,46 @@ class FlowSolver(FrozenClass):
         """
         self._isfrozen = False
         # ----- function spaces: elev in H, uv in U, mixed is W
-        self.function_spaces.P0 = get_functionspace_3d(self.mesh, 'DG', 0, 'DG', 0, name='P0')
-        self.function_spaces.P1 = get_functionspace_3d(self.mesh, 'CG', 1, 'CG', 1, name='P1')
-        self.function_spaces.P1v = get_functionspace_3d(self.mesh, 'CG', 1, 'CG', 1, name='P1v', vector=True)
-        self.function_spaces.P1DG = get_functionspace_3d(self.mesh, 'DG', 1, 'DG', 1, name='P1DG')
-        self.function_spaces.P1DGv = get_functionspace_3d(self.mesh, 'DG', 1, 'DG', 1, name='P1DGv', vector=True)
+        self.function_spaces.P0 = get_functionspace(self.mesh, 'DG', 0, 'DG', 0, name='P0')
+        self.function_spaces.P1 = get_functionspace(self.mesh, 'CG', 1, 'CG', 1, name='P1')
+        self.function_spaces.P1v = get_functionspace(self.mesh, 'CG', 1, 'CG', 1, name='P1v', vector=True)
+        self.function_spaces.P1DG = get_functionspace(self.mesh, 'DG', 1, 'DG', 1, name='P1DG')
+        self.function_spaces.P1DGv = get_functionspace(self.mesh, 'DG', 1, 'DG', 1, name='P1DGv', vector=True)
 
         # function spaces for (u,v) and w
         if self.options.element_family == 'rt-dg':
-            self.function_spaces.U = get_functionspace_3d(self.mesh, 'RT', self.options.polynomial_degree+1, 'DG', self.options.polynomial_degree, name='U', hdiv=True)
-            self.function_spaces.W = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'CG', self.options.polynomial_degree+1, name='W', hdiv=True)
+            self.function_spaces.U = get_functionspace(self.mesh, 'RT', self.options.polynomial_degree+1, 'DG', self.options.polynomial_degree, name='U', hdiv=True)
+            self.function_spaces.W = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'CG', self.options.polynomial_degree+1, name='W', hdiv=True)
         elif self.options.element_family == 'dg-dg':
-            self.function_spaces.U = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='U', vector=True)
-            self.function_spaces.W = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='W', vector=True)
+            self.function_spaces.U = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='U', vector=True)
+            self.function_spaces.W = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='W', vector=True)
         else:
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
 
         self.function_spaces.Uint = self.function_spaces.U  # vertical integral of uv
         # tracers
-        self.function_spaces.H = get_functionspace_3d(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='H')
+        self.function_spaces.H = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='H')
         self.function_spaces.turb_space = self.function_spaces.P0
 
         # 2D spaces
-        self.function_spaces.P1_2d = get_functionspace_2d(self.mesh2d, 'CG', 1, name='P1_2d')
-        self.function_spaces.P1v_2d = get_functionspace_2d(self.mesh2d, 'CG', 1, name='P1v_2d', vector=True)
-        self.function_spaces.P1DG_2d = get_functionspace_2d(self.mesh2d, 'DG', 1, name='P1DG_2d')
-        self.function_spaces.P1DGv_2d = get_functionspace_2d(self.mesh2d, 'DG', 1, name='P1DGv_2d', vector=True)
+        self.function_spaces.P1_2d = get_functionspace(self.mesh2d, 'CG', 1, name='P1_2d')
+        self.function_spaces.P1v_2d = get_functionspace(self.mesh2d, 'CG', 1, name='P1v_2d', vector=True)
+        self.function_spaces.P1DG_2d = get_functionspace(self.mesh2d, 'DG', 1, name='P1DG_2d')
+        self.function_spaces.P1DGv_2d = get_functionspace(self.mesh2d, 'DG', 1, name='P1DGv_2d', vector=True)
         # 2D velocity space
         if self.options.element_family == 'rt-dg':
-            self.function_spaces.U_2d = get_functionspace_2d(self.mesh2d, 'RT', self.options.polynomial_degree+1, name='U_2d')
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, 'RT', self.options.polynomial_degree+1, name='U_2d')
         elif self.options.element_family == 'dg-dg':
-            self.function_spaces.U_2d = get_functionspace_2d(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d', vector=True)
-        self.function_spaces.H_2d = get_functionspace_2d(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d', vector=True)
+        self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d], name='V_2d')
 
         # define function spaces for baroclinic head and internal pressure gradient
         if self.options.use_quadratic_pressure:
-            self.function_spaces.P2DGxP2 = get_functionspace_3d(self.mesh, 'DG', 2, 'CG', 2, name='P2DGxP2')
-            self.function_spaces.P2DG_2d = get_functionspace_2d(self.mesh2d, 'DG', 2, name='P2DG_2d')
+            self.function_spaces.P2DGxP2 = get_functionspace(self.mesh, 'DG', 2, 'CG', 2, name='P2DGxP2')
+            self.function_spaces.P2DG_2d = get_functionspace(self.mesh2d, 'DG', 2, name='P2DG_2d')
             if self.options.element_family == 'dg-dg':
-                self.function_spaces.P2DGxP1DGv = get_functionspace_3d(self.mesh, 'DG', 2, 'DG', 1, name='P2DGxP1DGv', vector=True, dim=2)
+                self.function_spaces.P2DGxP1DGv = get_functionspace(self.mesh, 'DG', 2, 'DG', 1, name='P2DGxP1DGv', vector=True, dim=2)
                 self.function_spaces.H_bhead = self.function_spaces.P2DGxP2
                 self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
                 self.function_spaces.U_int_pg = self.function_spaces.P2DGxP1DGv
@@ -435,7 +435,7 @@ class FlowSolver(FrozenClass):
                 self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
                 self.function_spaces.U_int_pg = self.function_spaces.U
         else:
-            self.function_spaces.P1DGxP2 = get_functionspace_3d(self.mesh, 'DG', 1, 'CG', 2, name='P1DGxP2')
+            self.function_spaces.P1DGxP2 = get_functionspace(self.mesh, 'DG', 1, 'CG', 2, name='P1DGxP2')
             self.function_spaces.H_bhead = self.function_spaces.P1DGxP2
             self.function_spaces.H_bhead_2d = self.function_spaces.P1DG_2d
             self.function_spaces.U_int_pg = self.function_spaces.U

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -20,25 +20,6 @@ from .log import *
 from collections import OrderedDict
 
 
-def get_functionspace_2d(mesh2d, family, degree, vector=False,
-                         variant='equispaced', **kwargs):
-    elt = FiniteElement(family, mesh2d.ufl_cell(), degree, variant=variant)
-    constructor = VectorFunctionSpace if vector else FunctionSpace
-    return constructor(mesh2d, elt, **kwargs)
-
-
-def get_functionspace_3d(mesh, h_family, h_degree, v_family, v_degree,
-                         vector=False, hdiv=False, variant='equispaced', **kwargs):
-    h_cell, v_cell = mesh.ufl_cell().sub_cells()
-    h_elt = FiniteElement(h_family, h_cell, h_degree, variant=variant)
-    v_elt = FiniteElement(v_family, v_cell, v_degree, variant=variant)
-    elt = TensorProductElement(h_elt, v_elt)
-    if hdiv:
-        elt = HDiv(elt)
-    constructor = VectorFunctionSpace if vector else FunctionSpace
-    return constructor(mesh, elt, **kwargs)
-
-
 class FlowSolver(FrozenClass):
     """
     Main object for 3D solver
@@ -445,7 +426,7 @@ class FlowSolver(FrozenClass):
             self.function_spaces.P2DGxP2 = get_functionspace_3d(self.mesh, 'DG', 2, 'CG', 2, name='P2DGxP2')
             self.function_spaces.P2DG_2d = get_functionspace_2d(self.mesh2d, 'DG', 2, name='P2DG_2d')
             if self.options.element_family == 'dg-dg':
-                self.function_spaces.P2DGxP1DGv = get_functionspace_3d(self.mesh, 'DG', 2, 'DG', 1, name='P2DGxP1DGv', dim=2)
+                self.function_spaces.P2DGxP1DGv = get_functionspace_3d(self.mesh, 'DG', 2, 'DG', 1, name='P2DGxP1DGv', vector=True, dim=2)
                 self.function_spaces.H_bhead = self.function_spaces.P2DGxP2
                 self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
                 self.function_spaces.U_int_pg = self.function_spaces.P2DGxP1DGv

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -197,26 +197,26 @@ class FlowSolver2d(FrozenClass):
         """
         self._isfrozen = False
         # ----- function spaces: elev in H, uv in U, mixed is W
-        self.function_spaces.P0_2d = FunctionSpace(self.mesh2d, 'DG', 0, name='P0_2d')
-        self.function_spaces.P1_2d = FunctionSpace(self.mesh2d, 'CG', 1, name='P1_2d')
+        self.function_spaces.P0_2d = get_functionspace(self.mesh2d, 'DG', 0, name='P0_2d')
+        self.function_spaces.P1_2d = get_functionspace(self.mesh2d, 'CG', 1, name='P1_2d')
         self.function_spaces.P1v_2d = VectorFunctionSpace(self.mesh2d, 'CG', 1, name='P1v_2d')
-        self.function_spaces.P1DG_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='P1DG_2d')
+        self.function_spaces.P1DG_2d = get_functionspace(self.mesh2d, 'DG', 1, name='P1DG_2d')
         self.function_spaces.P1DGv_2d = VectorFunctionSpace(self.mesh2d, 'DG', 1, name='P1DGv_2d')
         # 2D velocity space
         if self.options.element_family == 'rt-dg':
-            self.function_spaces.U_2d = FunctionSpace(self.mesh2d, 'RT', self.options.polynomial_degree+1, name='U_2d')
-            self.function_spaces.H_2d = FunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, 'RT', self.options.polynomial_degree+1, name='U_2d')
+            self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
         elif self.options.element_family == 'dg-cg':
             self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d')
-            self.function_spaces.H_2d = FunctionSpace(self.mesh2d, 'CG', self.options.polynomial_degree+1, name='H_2d')
+            self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'CG', self.options.polynomial_degree+1, name='H_2d')
         elif self.options.element_family == 'dg-dg':
             self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d')
-            self.function_spaces.H_2d = FunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
+            self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
         else:
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d])
 
-        self.function_spaces.Q_2d = FunctionSpace(self.mesh2d, 'DG', 1, name='Q_2d')
+        self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'DG', 1, name='Q_2d')
 
         self._isfrozen = True
 

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -113,25 +113,24 @@ class FieldDict(AttrDict):
         super(FieldDict, self).__setattr__(key, value)
 
 
-def get_functionspace_2d(mesh2d, family, degree, vector=False,
-                         variant='equispaced', **kwargs):
-    elt = FiniteElement(family, mesh2d.ufl_cell(), degree, variant=variant)
-    constructor = VectorFunctionSpace if vector else FunctionSpace
-    return constructor(mesh2d, elt, **kwargs)
+def get_functionspace(mesh, h_family, h_degree, v_family=None, v_degree=None,
+                      vector=False, hdiv=False, variant='equispaced', **kwargs):
+    gdim = mesh.geometric_dimension()
+    assert gdim in [2, 3]
+    if gdim == 3:
+        if v_family is None:
+            v_family = h_family
+        if v_degree is None:
+            v_degree = h_degree
+        h_cell, v_cell = mesh.ufl_cell().sub_cells()
+        h_elt = FiniteElement(h_family, h_cell, h_degree, variant=variant)
+        v_elt = FiniteElement(v_family, v_cell, v_degree, variant=variant)
+        elt = TensorProductElement(h_elt, v_elt)
+        if hdiv:
+            elt = HDiv(elt)
+    else:
+        elt = FiniteElement(h_family, mesh.ufl_cell(), h_degree, variant=variant)
 
-
-def get_functionspace_3d(mesh, h_family, h_degree, v_family=None, v_degree=None,
-                         vector=False, hdiv=False, variant='equispaced', **kwargs):
-    if v_family is None:
-        v_family = h_family
-    if v_degree is None:
-        v_degree = h_degree
-    h_cell, v_cell = mesh.ufl_cell().sub_cells()
-    h_elt = FiniteElement(h_family, h_cell, h_degree, variant=variant)
-    v_elt = FiniteElement(v_family, v_cell, v_degree, variant=variant)
-    elt = TensorProductElement(h_elt, v_elt)
-    if hdiv:
-        elt = HDiv(elt)
     constructor = VectorFunctionSpace if vector else FunctionSpace
     return constructor(mesh, elt, **kwargs)
 

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -113,6 +113,29 @@ class FieldDict(AttrDict):
         super(FieldDict, self).__setattr__(key, value)
 
 
+def get_functionspace_2d(mesh2d, family, degree, vector=False,
+                         variant='equispaced', **kwargs):
+    elt = FiniteElement(family, mesh2d.ufl_cell(), degree, variant=variant)
+    constructor = VectorFunctionSpace if vector else FunctionSpace
+    return constructor(mesh2d, elt, **kwargs)
+
+
+def get_functionspace_3d(mesh, h_family, h_degree, v_family=None, v_degree=None,
+                         vector=False, hdiv=False, variant='equispaced', **kwargs):
+    if v_family is None:
+        v_family = h_family
+    if v_degree is None:
+        v_degree = h_degree
+    h_cell, v_cell = mesh.ufl_cell().sub_cells()
+    h_elt = FiniteElement(h_family, h_cell, h_degree, variant=variant)
+    v_elt = FiniteElement(v_family, v_cell, v_degree, variant=variant)
+    elt = TensorProductElement(h_elt, v_elt)
+    if hdiv:
+        elt = HDiv(elt)
+    constructor = VectorFunctionSpace if vector else FunctionSpace
+    return constructor(mesh, elt, **kwargs)
+
+
 ElementContinuity = namedtuple("ElementContinuity", ["horizontal", "vertical"])
 """
 A named tuple describing the continuity of an element in the horizontal/vertical direction.


### PR DESCRIPTION
By default, Firedrake now uses spectral elements for which the current 2D-3D function mapping does not work. All 3D function spaces are therefore set to "equispaced" variant.