### PR TITLE
Dirk22 and norm smoother

### DIFF
--- a/thetis/options.py
+++ b/thetis/options.py
@@ -462,7 +462,8 @@ class CommonModelOptions(FrozenConfigurable):
     norm_smoother = FiredrakeConstantTraitlet(
         Constant(0.0), help=r"""
         Coefficient used to avoid non-differentiable functions in the continuous formulation of the velocity norm in
-        the drag term in the momentum equation
+        the quadratic bottom drag term in the momentum equation. This replaces the velocity norm in the quadratic
+        bottom drag term with :math:`\|u\| \approx \sqrt{\|u\|^2 + \alpha^2}`
         """).tag(config=True)
     horizontal_viscosity = FiredrakeScalarExpression(
         None, allow_none=True, help="Horizontal viscosity").tag(config=True)

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -459,6 +459,11 @@ class CommonModelOptions(FrozenConfigurable):
 
         Bottom stress is :math:`\tau_b/\rho_0 = -g \mu^2 |\mathbf{u}|\mathbf{u}/H^{1/3}`
         """).tag(config=True)
+    norm_smoother = FiredrakeConstantTraitlet(
+        Constant(0.0), help=r"""
+        Coefficient used to avoid non-differentiable functions in the continuous formulation of the velocity norm in
+        the drag term in the momentum equation
+        """).tag(config=True)
     horizontal_viscosity = FiredrakeScalarExpression(
         None, allow_none=True, help="Horizontal viscosity").tag(config=True)
     coriolis_frequency = FiredrakeScalarExpression(

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -682,7 +682,7 @@ class QuadraticDragTerm(ShallowWaterMomentumTerm):
             C_D = g_grav * manning_drag_coefficient**2 / total_h**(1./3.)
 
         if C_D is not None:
-            f += C_D * sqrt(dot(uv_old, uv_old) + (self.options.norm_smoother)**2) * inner(self.u_test, uv) / total_h * self.dx
+            f += C_D * sqrt(dot(uv_old, uv_old) + self.options.norm_smoother**2) * inner(self.u_test, uv) / total_h * self.dx
         return -f
 
 

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -682,7 +682,7 @@ class QuadraticDragTerm(ShallowWaterMomentumTerm):
             C_D = g_grav * manning_drag_coefficient**2 / total_h**(1./3.)
 
         if C_D is not None:
-            f += C_D * sqrt(dot(uv_old, uv_old)) * inner(self.u_test, uv) / total_h * self.dx
+            f += C_D * sqrt(dot(uv_old, uv_old) + (self.options.norm_smoother)**2) * inner(self.u_test, uv) / total_h * self.dx
         return -f
 
 


### PR DESCRIPTION
An extra option was also added to the solver object to smooth the velocity norm in the friction term in the shallow water equations. This is to avoid non-differentiable functions in the continuous formulation and is discussed in section 2.1 in "Funke, S., Farrell, P., & Piggott, M. (2017). Reconstructing wave profiles from inundation data. Computer Methods in Applied Mechanics and Engineering, 322, 167–186. Retrieved from https://arxiv.org/pdf/1612.09597.pdf". The default is that this smoother = 0 unless set by the user and thus all tests should be unaffected by this change. 