### PR TITLE
Allow wetting and drying alpha to vary spatially

### DIFF
--- a/thetis/options.py
+++ b/thetis/options.py
@@ -528,7 +528,7 @@ class ModelOptions2d(CommonModelOptions):
         Uses the wetting and drying scheme from Karna et al (2011).
         If ``True``, one should also set :attr:`wetting_and_drying_alpha` to control the bathymetry displacement.
         """).tag(config=True)
-    wetting_and_drying_alpha = FiredrakeConstantTraitlet(
+    wetting_and_drying_alpha = FiredrakeScalarExpression(
         Constant(0.5), help=r"""
         Coefficient: Wetting and drying parameter :math:`\alpha`.
 


### PR DESCRIPTION
As it stands, the wetting and drying parameter which ensures a positive water height is assumed to be constant across the domain. Whilst this is a reasonable assumption for many problems, in some cases it would be advantageous to allow the parameter to vary spatially. One example is the case where we seek to model inundation of a coast near to a deep ocean trench with sharp gradients.

In a future PR we could consider automatically selecting the (spatially varying) wetting and drying parameter in a similar way as was done for the SIPG parameter in PR #176.