### PR TITLE
Spatially varying SIPG parameter

### DIFF
--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -191,7 +191,9 @@ def test_sipg_ratio_scalar(c2d_x):
     c += 1.0
     if c.ufl_element().degree() > 1:
         pytest.xfail("Only currently implemented for constant or linear elements")
-    assert np.allclose(utility.get_sipg_ratio(c), 1.4)
+    with utility.get_sipg_ratio(c).dat.vec_ro as v:
+        assert np.allclose(v.max()[1], 1.4/1.0)
+        assert np.allclose(v.min()[1], 3.0/2.6)
 
 
 def test_minimum_angle(mesh2d):

--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -181,7 +181,9 @@ def test_copy_2d_field_to_3d_vec(uv_2d, uv_3d):
 def test_sipg_ratio_constant(c2d):
     if c2d.ufl_element().degree() > 1:
         pytest.xfail("Only currently implemented for constant or linear elements")
-    assert np.allclose(utility.get_sipg_ratio(c2d), 1.0)
+    with utility.get_sipg_ratio(c2d).dat.vec_ro as v:
+        assert np.allclose(v.max()[1], 1.0)
+        assert np.allclose(v.min()[1], 1.0)
 
 
 def test_sipg_ratio_scalar(c2d_x):

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -582,7 +582,7 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
             alpha = self.options.sipg_parameter
             assert alpha is not None
             f += (
-                + alpha/avg(h)*inner(tensor_jump(self.u_test, n), stress_jump)*self.dS
+                + avg(alpha/h)*inner(tensor_jump(self.u_test, n), stress_jump)*self.dS
                 - inner(avg(grad(self.u_test)), stress_jump)*self.dS
                 - inner(tensor_jump(self.u_test, n), avg(stress))*self.dS
             )

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -511,14 +511,14 @@ class FlowSolver(FrozenClass):
                         max_sipg = self.options.sipg_parameter_turb.vector().gather().max()
                         print_output("Maximum turbulence SIPG value in horizontal: {:.2f}".format(max_sipg))
                 else:
-                    if self.options.solve_salinity or self.options.solve_temperature
+                    if self.options.solve_salinity or self.options.solve_temperature:
                         print_output("Tracer SIPG parameter in horizontal: {:.2f}".format(alpha_h_tracer))
 
                     if self.options.use_turbulence:
                         print_output("Turbulence SIPG parameter in horizontal: {:.2f}".format(alpha_h_turb))
 
                 # Vertical component
-                if self.options.solve_salinity or self.options.solve_temperature
+                if self.options.solve_salinity or self.options.solve_temperature:
                     print_output("Tracer SIPG parameter in vertical: {:.2f}".format(alpha_v_tracer))
                 if self.options.use_turbulence:
                     print_output("Turbulence SIPG parameter in vertical: {:.2f}".format(alpha_v_turb))

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -462,14 +462,14 @@ class FlowSolver(FrozenClass):
         :math:`p` the degree, and :math:`\theta_K` is the minimum angle in the element.
         """
         degree_h, degree_v = self.function_spaces.U.ufl_element().degree()
-        alpha_h = 5.0*degree_h*(degree_h+1) if degree_h != 0 else 1.5
-        alpha_v = 5.0*degree_v*(degree_v+1) if degree_v != 0 else 1.0
+        alpha_h = Constant(5.0*degree_h*(degree_h+1) if degree_h != 0 else 1.5)
+        alpha_v = Constant(5.0*degree_v*(degree_v+1) if degree_v != 0 else 1.0)
         degree_h_tracer, degree_v_tracer = self.function_spaces.H.ufl_element().degree()
-        alpha_h_tracer = 5.0*degree_h_tracer*(degree_h_tracer+1) if degree_h_tracer != 0 else 1.5
-        alpha_v_tracer = 5.0*degree_v_tracer*(degree_v_tracer+1) if degree_v_tracer != 0 else 1.0
+        alpha_h_tracer = Constant(5.0*degree_h_tracer*(degree_h_tracer+1) if degree_h_tracer != 0 else 1.5)
+        alpha_v_tracer = Constant(5.0*degree_v_tracer*(degree_v_tracer+1) if degree_v_tracer != 0 else 1.0)
         degree_h_turb, degree_v_turb = self.function_spaces.turb_space.ufl_element().degree()
-        alpha_h_turb = 5.0*degree_h_turb*(degree_h_turb+1) if degree_h_turb != 0 else 1.5
-        alpha_v_turb = 5.0*degree_v_turb*(degree_v_turb+1) if degree_v_turb != 0 else 1.0
+        alpha_h_turb = Constant(5.0*degree_h_turb*(degree_h_turb+1) if degree_h_turb != 0 else 1.5)
+        alpha_v_turb = Constant(5.0*degree_v_turb*(degree_v_turb+1) if degree_v_turb != 0 else 1.0)
 
         if self.options.use_automatic_sipg_parameter:
 
@@ -492,10 +492,10 @@ class FlowSolver(FrozenClass):
                 max_sipg = self.options.sipg_parameter.vector().gather().max()
                 print_output("Maximum SIPG value in horizontal: {:.2f}".format(max_sipg))
             else:
-                print_output("SIPG parameter in horizontal: {:.2f}".format(alpha_h))
+                print_output("SIPG parameter in horizontal: {:.2f}".format(alpha_h.values()[0]))
 
             # Vertical component
-            print_output("SIPG parameter in vertical: {:.2f}".format(alpha_v))
+            print_output("SIPG parameter in vertical: {:.2f}".format(alpha_v.values()[0]))
 
             # Penalty parameter for tracers / turbulence model
             if self.options.solve_salinity or self.options.solve_temperature or self.options.use_turbulence:
@@ -516,15 +516,15 @@ class FlowSolver(FrozenClass):
                         print_output("Maximum turbulence SIPG value in horizontal: {:.2f}".format(max_sipg))
                 else:
                     if self.options.solve_salinity or self.options.solve_temperature:
-                        print_output("Tracer SIPG parameter in horizontal: {:.2f}".format(alpha_h_tracer))
+                        print_output("Tracer SIPG parameter in horizontal: {:.2f}".format(alpha_h_tracer.values()[0]))
                     if self.options.use_turbulence:
-                        print_output("Turbulence SIPG parameter in horizontal: {:.2f}".format(alpha_h_turb))
+                        print_output("Turbulence SIPG parameter in horizontal: {:.2f}".format(alpha_h_turb.values()[0]))
 
                 # Vertical component
                 if self.options.solve_salinity or self.options.solve_temperature:
-                    print_output("Tracer SIPG parameter in vertical: {:.2f}".format(alpha_v_tracer))
+                    print_output("Tracer SIPG parameter in vertical: {:.2f}".format(alpha_v_tracer.values()[0]))
                 if self.options.use_turbulence:
-                    print_output("Turbulence SIPG parameter in vertical: {:.2f}".format(alpha_v_turb))
+                    print_output("Turbulence SIPG parameter in vertical: {:.2f}".format(alpha_v_turb.values()[0]))
         else:
             print_output("Using default SIPG parameters")
             self.options.sipg_parameter.assign(alpha_h)

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -206,9 +206,6 @@ class FlowSolver2d(FrozenClass):
             X = \frac{\max_{x\in K}(\nu(x))}{\min_{x\in K}(\nu(x))},
 
         :math:`p` the degree, and :math:`\theta_K` is the minimum angle in the element.
-
-        In practice, we take the maximum value of :math:`X` and minimum value of
-        :math:`\alpha_K` over all elements.
         """
         degree = self.function_spaces.U_2d.ufl_element().degree()
         alpha = Constant(5.0*degree*(degree+1) if degree != 0 else 1.5)

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1232,7 +1232,7 @@ def get_minimum_angles_2d(mesh2d):
     return min_angles
 
 
-def get_sipg_ratios(nu):
+def get_sipg_ratio(nu):
     """
     Compute the ratio between the maximum of `nu` and the minimum of `nu` in each element. If `nu`
     is P0 or a `Constant` then the resulting ratio is unity in each element. If `nu` varies linearly
@@ -1276,15 +1276,6 @@ def get_sipg_ratios(nu):
         # TODO: For higher order elements, the extrema aren't necessarily achieved at the
         #       vertices. Perhaps we could project or interpolate into a matching Bernstein
         #       element and use the property that the Bernstein polynomials bound the solution.
-
-
-# TODO: This becomes redundant once spatially varying SIPG parameter is implemented.
-def get_sipg_ratio(nu):
-    """
-    Take maximum over all elemental SIPG parameter ratios.
-    """
-    nu_max = get_sipg_ratios(nu)
-    return nu_max.values()[0] if isinstance(nu_max, Constant) else nu_max.vector().gather().max()
 
 
 class ALEMeshUpdater(object):


### PR DESCRIPTION
This PR extends the automatic SIPG parameter generation implemented in #176 so that it is allowed to vary in space.

SIPG parameters for all equations (momentum/swe/tracer) default to `Constant`s, but can be set as P0 fields. Where the previous PR computed the minimum angle in all elements and multiplied it by the maximum ratio of viscosity or diffusivity (as appropriate) in all elements, this PR actually takes the elementwise values, in line with [Epshteyn & Riviere, 2007].