### PR TITLE
Prescribed velocity test

### DIFF
--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -149,13 +149,15 @@ def run_convergence(**model_options):
     assert slope > 2, msg.format(slope)
 
 
-@pytest.fixture(params=[1, 2])
+@pytest.fixture(params=[1])
 def polynomial_degree(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
+@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
+def stepper(request):
+    return request.param
+
 @pytest.mark.parametrize(('diffusivity'),
                          [(Constant(0.1))])
 def test_horizontal_advection(polynomial_degree, stepper, diffusivity):

--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -154,7 +154,7 @@ def polynomial_degree(request):
     return request.param
 
 
-@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
+@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'BackwardEuler', 'DIRK22', 'DIRK33'])
 def stepper(request):
     return request.param
 

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -181,7 +181,7 @@ def polynomial_degree(request):
     return request.param
 
 
-@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
+@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33', 'DIRK22', 'DIRK33'])
 def stepper(request):
     return request.param
 

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -181,9 +181,12 @@ def polynomial_degree(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
-def test_horizontal_advection(polynomial_degree, stepper, ):
+@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
+def stepper(request):
+    return request.param
+
+
+def test_horizontal_advection(polynomial_degree, stepper):
     run_convergence([1, 2, 3], polynomial_degree=polynomial_degree,
                     timestepper_type=stepper)
 

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -166,13 +166,17 @@ def auto_sipg(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
+@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
+def stepper(request):
+    return request.param
+
+
 def test_horizontal_diffusion(auto_sipg, stepper):
     run_convergence([1, 2, 3], polynomial_degree=1,
                     timestepper_type=stepper,
                     use_automatic_sipg_parameter=auto_sipg,
                     )
+
 # ---------------------------
 # run individual setup for debugging
 # ---------------------------

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -166,7 +166,7 @@ def auto_sipg(request):
     return request.param
 
 
-@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
+@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'BackwardEuler', 'DIRK22', 'DIRK33'])
 def stepper(request):
     return request.param
 

--- a/test/tracerEq/test_prescribed_velocity.py
+++ b/test/tracerEq/test_prescribed_velocity.py
@@ -55,6 +55,8 @@ def run(refinement_level, velocity_type, **model_options):
 
 
 def run_convergence(ref_list, velocity_type, **options):
+    """Runs test for a list of refinements and computes error convergence rate."""
+    setup_name = 'prescribed-velocity'
     l2_err = []
     for r in ref_list:
         l2_err.append(run(r, velocity_type, **options))
@@ -62,12 +64,20 @@ def run_convergence(ref_list, velocity_type, **options):
     def check_convergence(ref_list, l2_err, field_str):
         slope_rtol = 0.2
         setup_name = 'prescribed-velocity'
+
+        # Check convergence of L2 errors
         for i in range(1, len(l2_err)):
             slope = l2_err[i-1]/l2_err[i]
             expected_slope = ref_list[i]/ref_list[i-1]
             err_msg = '{:s}: Wrong convergence rate {:.4f}, expected {:.4f}'
             assert slope > expected_slope*(1 - slope_rtol), err_msg.format(setup_name, slope, expected_slope)
             print_output('{:s}: {:s} convergence rate {:.4f}'.format(setup_name, field_str, slope))
+
+        # Check magnitude of L2 errors
+        for i in range(len(l2_err)):
+            msg = "{:s}: L2 error {:.4e} does not match recorded value, expected < 0.7"
+            assert l2_err[i] < 0.7, msg.format(setup_name, l2_err[i])
+            print_output("{:s}: L2 error magnitude index {:d} PASSED".format(setup_name, i))
 
     check_convergence(ref_list, l2_err, 'tracer')
 

--- a/test/tracerEq/test_prescribed_velocity.py
+++ b/test/tracerEq/test_prescribed_velocity.py
@@ -1,0 +1,103 @@
+"""
+Simple 2D tracer advection problem in a doubly periodic domain with prescribed fluid velocities.
+"""
+from thetis import *
+import pytest
+
+
+def run(refinement_level, velocity_type, **model_options):
+    print_output("--- running refinement level {:d} with {:s} prescribed velocity".format(refinement_level, velocity_type))
+
+    # Set up domain
+    n, L = 10*refinement_level, 10.0
+    mesh2d = PeriodicRectangleMesh(n, n, L, L)
+    x, y = SpatialCoordinate(mesh2d)
+    T = 10.0
+
+    # Physics
+    P1_2d = FunctionSpace(mesh2d, "CG", 1)
+    bathymetry2d = Function(P1_2d).assign(1.0)
+
+    # Create solver object
+    solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry2d)
+    options = solver_obj.options
+    options.timestep = 0.5/refinement_level
+    options.simulation_export_time = T/10
+    options.simulation_end_time = T
+    options.fields_to_export_hdf5 = []
+    options.no_exports = True
+    options.solve_tracer = True
+    options.tracer_only = True
+    options.horizontal_diffusivity = None
+    options.update(model_options)
+    solver_obj.create_function_spaces()
+
+    # Prescribed velocity
+    if velocity_type == 'constant':
+        update_forcings = None
+    elif velocity_type == 'sinusoidal':
+        def update_forcings(t):
+            solver_obj.fields.uv_2d.interpolate(as_vector([L/T, cos(pi*t/5.0)]))
+    else:
+        raise ValueError("Velocity type '{:s}' not recognised.".format(velocity_type))
+
+    # Apply initial conditions
+    init = project(exp(-((x-L/2)**2 + (y-L/2)**2)), solver_obj.function_spaces.Q_2d)
+    fluid_velocity = interpolate(as_vector([L/T, 0.0]), solver_obj.function_spaces.U_2d)
+    solver_obj.assign_initial_conditions(uv=fluid_velocity, tracer=init)
+    init = solver_obj.fields.tracer_2d.copy(deepcopy=True)
+
+    # Solve and check advection cycle is complete
+    solver_obj.iterate(update_forcings=update_forcings)
+    error = errornorm(init, solver_obj.fields.tracer_2d)
+    print_output("Relative L2 error: {:.2f}%".format(100*error/norm(init)))
+    return error
+
+
+def run_convergence(ref_list, velocity_type, **options):
+    l2_err = []
+    for r in ref_list:
+        l2_err.append(run(r, velocity_type, **options))
+
+    def check_convergence(ref_list, l2_err, field_str):
+        slope_rtol = 0.2
+        setup_name = 'prescribed-velocity'
+        for i in range(1, len(l2_err)):
+            slope = l2_err[i-1]/l2_err[i]
+            expected_slope = ref_list[i]/ref_list[i-1]
+            err_msg = '{:s}: Wrong convergence rate {:.4f}, expected {:.4f}'
+            assert slope > expected_slope*(1 - slope_rtol), err_msg.format(setup_name, slope, expected_slope)
+            print_output('{:s}: {:s} convergence rate {:.4f}'.format(setup_name, field_str, slope))
+
+    check_convergence(ref_list, l2_err, 'tracer')
+
+
+# ---------------------------
+# standard tests for pytest
+# ---------------------------
+
+@pytest.fixture(params=['CrankNicolson'])  # TODO: Implement other time integration methods
+def stepper(request):
+    return request.param
+
+
+@pytest.fixture(params=['constant', 'sinusoidal'])
+def velocity_type(request):
+    return request.param
+
+
+def test_periodic(stepper, velocity_type):
+    run_convergence([1, 2, 4], velocity_type, timestepper_type=stepper)
+
+
+# ---------------------------
+# run individual setup for debugging
+# ---------------------------
+
+
+if __name__ == "__main__":
+    options = {
+        'no_exports': False,
+        'fields_to_export': ['tracer_2d'],
+    }
+    run_convergence([1, 2, 4], 'sinusoidal', **options)

--- a/test/tracerEq/test_prescribed_velocity.py
+++ b/test/tracerEq/test_prescribed_velocity.py
@@ -7,6 +7,7 @@ import pytest
 
 def run(refinement_level, velocity_type, **model_options):
     print_output("--- running refinement level {:d} with {:s} prescribed velocity".format(refinement_level, velocity_type))
+    stepper = model_options.get('timestepper_type')
 
     # Set up domain
     n, L = 10*refinement_level, 10.0
@@ -18,18 +19,24 @@ def run(refinement_level, velocity_type, **model_options):
     P1_2d = FunctionSpace(mesh2d, "CG", 1)
     bathymetry2d = Function(P1_2d).assign(1.0)
 
+    # Timestep
+    base_ts = 0.02 if stepper in ('ForwardEuler', 'SSPRK33') else 0.5
+
     # Create solver object
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry2d)
     options = solver_obj.options
-    options.timestep = 0.5/refinement_level
+    options.timestepper_type = stepper
+    options.timestep = base_ts/refinement_level
     options.simulation_export_time = T/10
     options.simulation_end_time = T
     options.fields_to_export_hdf5 = []
     options.no_exports = True
     options.solve_tracer = True
     options.tracer_only = True
-    options.horizontal_diffusivity = None
+    options.horizontal_diffusivity = Constant(1.0e-8)
     options.update(model_options)
+    if hasattr(options.timestepper_options, 'use_automatic_timestep'):
+        options.timestepper_options.use_automatic_timestep = False
     solver_obj.create_function_spaces()
 
     # Prescribed velocity
@@ -50,34 +57,35 @@ def run(refinement_level, velocity_type, **model_options):
     # Solve and check advection cycle is complete
     solver_obj.iterate(update_forcings=update_forcings)
     error = errornorm(init, solver_obj.fields.tracer_2d)
-    print_output("Relative L2 error: {:.2f}%".format(100*error/norm(init)))
+    print_output("Relative L2 error: {:.4f}%".format(100*error/norm(init)))
     return error
 
 
 def run_convergence(ref_list, velocity_type, **options):
     """Runs test for a list of refinements and computes error convergence rate."""
     setup_name = 'prescribed-velocity'
+    stepper = options.get('timestepper_type')
     l2_err = []
     for r in ref_list:
         l2_err.append(run(r, velocity_type, **options))
 
     def check_convergence(ref_list, l2_err, field_str):
         slope_rtol = 0.2
-        setup_name = 'prescribed-velocity'
 
         # Check convergence of L2 errors
         for i in range(1, len(l2_err)):
             slope = l2_err[i-1]/l2_err[i]
             expected_slope = ref_list[i]/ref_list[i-1]
-            err_msg = '{:s}: Wrong convergence rate {:.4f}, expected {:.4f}'
+            err_msg = "{:s}: Wrong convergence rate {:.4f}, expected {:.4f}"
             assert slope > expected_slope*(1 - slope_rtol), err_msg.format(setup_name, slope, expected_slope)
-            print_output('{:s}: {:s} convergence rate {:.4f}'.format(setup_name, field_str, slope))
+            print_output("{:s}: {:s} convergence rate {:.4f}".format(setup_name, stepper, slope))
 
         # Check magnitude of L2 errors
+        rec = 0.8
         for i in range(len(l2_err)):
-            msg = "{:s}: L2 error {:.4e} does not match recorded value, expected < 0.7"
-            assert l2_err[i] < 0.7, msg.format(setup_name, l2_err[i])
-            print_output("{:s}: L2 error magnitude index {:d} PASSED".format(setup_name, i))
+            msg = "{:s}: L2 error {:.4e} does not match recorded value, expected < {:.1f}"
+            assert l2_err[i] < rec, msg.format(setup_name, l2_err[i], rec)
+            print_output("{:s}: {:s} L2 error magnitude index {:d} PASSED".format(setup_name, stepper, i))
 
     check_convergence(ref_list, l2_err, 'tracer')
 
@@ -86,7 +94,7 @@ def run_convergence(ref_list, velocity_type, **options):
 # standard tests for pytest
 # ---------------------------
 
-@pytest.fixture(params=['CrankNicolson'])  # TODO: Implement other time integration methods
+@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
 def stepper(request):
     return request.param
 
@@ -109,5 +117,6 @@ if __name__ == "__main__":
     options = {
         'no_exports': False,
         'fields_to_export': ['tracer_2d'],
+        'timestepper_type': 'SSPRK33',
     }
     run_convergence([1, 2, 4], 'sinusoidal', **options)

--- a/test/tracerEq/test_prescribed_velocity.py
+++ b/test/tracerEq/test_prescribed_velocity.py
@@ -94,7 +94,7 @@ def run_convergence(ref_list, velocity_type, **options):
 # standard tests for pytest
 # ---------------------------
 
-@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33'])
+@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'DIRK22', 'DIRK33'])
 def stepper(request):
     return request.param
 

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -98,7 +98,8 @@ def run(setup, refinement, do_export=True, **options):
     solver_obj.options.horizontal_viscosity_scale = Constant(50.0)
     solver_obj.options.update(options)
     solver_obj.options.solve_tracer = True
-    solver_obj.options.timestepper_options.implicitness_theta = 1.0
+    if hasattr(solver_obj.options.timestepper_options, 'implicitness_theta'):
+        solver_obj.options.timestepper_options.implicitness_theta = 1.0
     solver_obj.create_function_spaces()
 
     # functions for source terms

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -194,7 +194,7 @@ def run_convergence(setup, ref_list, do_export=False, save_plot=False, **options
 # standard tests for pytest
 # ---------------------------
 
-@pytest.fixture(params=['CrankNicolson'])
+@pytest.fixture(params=['CrankNicolson', 'DIRK22', 'DIRK33', 'BackwardEuler'])
 def timestepper_type(request):
     return request.param
 

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -4,6 +4,7 @@ Time integrators for solving coupled shallow water equations with one tracer.
 from __future__ import absolute_import
 from .utility import *
 from . import timeintegrator
+from . import rungekutta
 from .log import *
 from abc import ABCMeta, abstractproperty
 
@@ -91,8 +92,12 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                                                                   solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
                                                                   semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
                                                                   theta=self.options.timestepper_options.implicitness_theta)
+            elif issubclass(self.tracer_integrator, timeintegrator.ForwardEuler) or issubclass(self.tracer_integrator, rungekutta.SSPRK33):
+                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d,
+                                                                  fields, solver.dt, bnd_conditions=solver.bnd_functions['tracer'],
+                                                                  solver_parameters=self.options.timestepper_options.solver_parameters_tracer)
             else:
-                raise NotImplementedError("Tracer equation is currently only implemented for the CrankNicolson timestepper scheme")
+                raise NotImplementedError("Tracer equation is currently only implemented for the CrankNicolson, ForwardEuler and SSPRK33 timestepper schemes")
 
     def _create_integrators(self):
         """
@@ -144,3 +149,13 @@ class CoupledCrankNicolson2D(CoupledTimeIntegrator2D):
 class CoupledCrankEuler2D(CoupledTimeIntegrator2D):
     swe_integrator = timeintegrator.CrankNicolson
     tracer_integrator = timeintegrator.ForwardEuler
+
+
+class CoupledForwardEuler2D(CoupledTimeIntegrator2D):
+    swe_integrator = timeintegrator.ForwardEuler
+    tracer_integrator = timeintegrator.ForwardEuler
+
+
+class CoupledSSPRK332D(CoupledTimeIntegrator2D):
+    swe_integrator = rungekutta.SSPRK33
+    tracer_integrator = rungekutta.SSPRK33

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -55,7 +55,8 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
             'wind_stress': self.options.wind_stress,
             'atmospheric_pressure': self.options.atmospheric_pressure,
             'momentum_source': self.options.momentum_source_2d,
-            'volume_source': self.options.volume_source_2d, }
+            'volume_source': self.options.volume_source_2d,
+        }
 
         if issubclass(self.swe_integrator, timeintegrator.CrankNicolson):
             self.timesteppers.swe2d = self.swe_integrator(
@@ -64,12 +65,14 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                 bnd_conditions=solver.bnd_functions['shallow_water'],
                 solver_parameters=self.options.timestepper_options.solver_parameters,
                 semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
-                theta=self.options.timestepper_options.implicitness_theta)
+                theta=self.options.timestepper_options.implicitness_theta,
+            )
         else:
-            self.timesteppers.swe2d = self.swe_integrator(solver.eq_sw, self.fields.solution_2d,
-                                                          fields, solver.dt,
-                                                          bnd_conditions=solver.bnd_functions['shallow_water'],
-                                                          solver_parameters=self.options.timestepper_options.solver_parameters)
+            self.timesteppers.swe2d = self.swe_integrator(
+                solver.eq_sw, self.fields.solution_2d, fields, solver.dt,
+                bnd_conditions=solver.bnd_functions['shallow_water'],
+                solver_parameters=self.options.timestepper_options.solver_parameters,
+            )
 
     def _create_tracer_integrator(self):
         """
@@ -79,23 +82,29 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
 
         if self.solver.options.solve_tracer:
             uv, elev = self.fields.solution_2d.split()
-            fields = {'elev_2d': elev,
-                      'uv_2d': uv,
-                      'diffusivity_h': self.options.horizontal_diffusivity,
-                      'source': self.options.tracer_source_2d,
-                      'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
-                      'tracer_advective_velocity_factor': self.options.tracer_advective_velocity_factor,
-                      }
+            fields = {
+                'elev_2d': elev,
+                'uv_2d': uv,
+                'diffusivity_h': self.options.horizontal_diffusivity,
+                'source': self.options.tracer_source_2d,
+                'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
+                'tracer_advective_velocity_factor': self.options.tracer_advective_velocity_factor,
+            }
             if issubclass(self.tracer_integrator, timeintegrator.CrankNicolson):
-                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d,
-                                                                  fields, solver.dt, bnd_conditions=solver.bnd_functions['tracer'],
-                                                                  solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
-                                                                  semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
-                                                                  theta=self.options.timestepper_options.implicitness_theta)
-            elif issubclass(self.tracer_integrator, timeintegrator.ForwardEuler) or issubclass(self.tracer_integrator, rungekutta.SSPRK33):
-                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d,
-                                                                  fields, solver.dt, bnd_conditions=solver.bnd_functions['tracer'],
-                                                                  solver_parameters=self.options.timestepper_options.solver_parameters_tracer)
+                self.timesteppers.tracer = self.tracer_integrator(
+                    solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt,
+                    bnd_conditions=solver.bnd_functions['tracer'],
+                    solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
+                    semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
+                    theta=self.options.timestepper_options.implicitness_theta,
+                )
+            elif issubclass(self.tracer_integrator, rungekutta.SSPRK33) or \
+                    issubclass(self.tracer_integrator, timeintegrator.ForwardEuler):
+                self.timesteppers.tracer = self.tracer_integrator(
+                    solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt,
+                    bnd_conditions=solver.bnd_functions['tracer'],
+                    solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
+                )
             else:
                 raise NotImplementedError("Tracer equation is currently only implemented for the CrankNicolson, ForwardEuler and SSPRK33 timestepper schemes")
 

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -105,8 +105,15 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                     bnd_conditions=solver.bnd_functions['tracer'],
                     solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
                 )
+            elif issubclass(self.tracer_integrator, rungekutta.DIRKGenericUForm):
+                self.timesteppers.tracer = self.tracer_integrator(
+                    solver.eq_tracer, solver.fields.tracer_2d, fields, solver.dt,
+                    bnd_conditions=solver.bnd_functions['tracer'],
+                    solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
+                    semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
+                )
             else:
-                raise NotImplementedError("Tracer equation is currently only implemented for the CrankNicolson, ForwardEuler and SSPRK33 timestepper schemes")
+                raise NotImplementedError("Tracer equation is currently only implemented for the CrankNicolson, SSPRK33, ForwardEuler, BackwardEuler, DIRK22 and DIRK33 timestepper schemes")
 
     def _create_integrators(self):
         """
@@ -160,11 +167,26 @@ class CoupledCrankEuler2D(CoupledTimeIntegrator2D):
     tracer_integrator = timeintegrator.ForwardEuler
 
 
+class CoupledSSPRK332D(CoupledTimeIntegrator2D):
+    swe_integrator = rungekutta.SSPRK33
+    tracer_integrator = rungekutta.SSPRK33
+
+
 class CoupledForwardEuler2D(CoupledTimeIntegrator2D):
     swe_integrator = timeintegrator.ForwardEuler
     tracer_integrator = timeintegrator.ForwardEuler
 
 
-class CoupledSSPRK332D(CoupledTimeIntegrator2D):
-    swe_integrator = rungekutta.SSPRK33
-    tracer_integrator = rungekutta.SSPRK33
+class CoupledBackwardEuler2D(CoupledTimeIntegrator2D):
+    swe_integrator = rungekutta.BackwardEulerUForm
+    tracer_integrator = rungekutta.BackwardEulerUForm
+
+
+class CoupledDIRK222D(CoupledTimeIntegrator2D):
+    swe_integrator = rungekutta.DIRK22UForm
+    tracer_integrator = rungekutta.DIRK22UForm
+
+
+class CoupledDIRK332D(CoupledTimeIntegrator2D):
+    swe_integrator = rungekutta.DIRK33UForm
+    tracer_integrator = rungekutta.DIRK33UForm

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -16,6 +16,10 @@ class TimeStepperOptions(FrozenHasTraits):
 class ExplicitTimestepperOptions(TimeStepperOptions):
     """Options for explicit time integrator"""
     use_automatic_timestep = Bool(True, help='Set time step automatically based on local CFL conditions.').tag(config=True)
+    solver_parameters_tracer = PETScSolverParameters({
+        'ksp_type': 'gmres',
+        'pc_type': 'sor',
+    }).tag(config=True)
 
 
 class SemiImplicitTimestepperOptions2d(TimeStepperOptions):
@@ -508,6 +512,7 @@ class CommonModelOptions(FrozenConfigurable):
                                    ('ForwardEuler', ExplicitTimestepperOptions2d),
                                    ('BackwardEuler', SemiImplicitTimestepperOptions2d),
                                    ('CrankNicolson', CrankNicolsonTimestepperOptions2d),
+                                   ('CrankEuler', CrankNicolsonTimestepperOptions2d),
                                    ('DIRK22', SemiImplicitTimestepperOptions2d),
                                    ('DIRK33', SemiImplicitTimestepperOptions2d),
                                    ('SteadyState', SteadyStateTimestepperOptions2d),


### PR DESCRIPTION
Here's another simple test which will be useful for testing ALE in 2d (when I get round to implementing it).

A Gaussian tracer concentration profile is advected in: (a) a uniform velocity field; and (b) a velocity field whose y-component varies sinusoidally with time. The domain is periodic and the problem is inviscid, set up such that the exact solution at t=10 is identical to the initial condition (under both velocity fields).

The convergence test iteratively doubles the mesh resolution and halves the timestep, checking the resulting L2 error converges with slope 2.

Once ALE is implemented, we should see that advecting the mesh in the prescribed velocity field (i.e. the Lagrangian case) leads to much smaller errors.