### PR TITLE
Un-xfail adjoint tests

### DIFF
--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -25,9 +25,6 @@ from pyadjoint.optimization.optimization import minimise
 import numpy
 op2.init(log_level=INFO)
 
-test_gradient = False  # whether to check the gradient computed by the adjoint (see note below)
-optimise = True
-
 # setup the Thetis solver obj as usual:
 mesh2d = Mesh('headland.msh')
 
@@ -38,7 +35,15 @@ timestep = 800.
 
 t_end = tidal_period
 if os.getenv('THETIS_REGRESSION_TEST') is not None:
-    t_end = 10*timestep
+    # when run as a pytest test, only run 5 timesteps
+    # and test the gradient
+    t_end = 5*timestep
+    test_gradient = True  # test gradient using Taylor test (see below)
+    optimise = False  # skip actual gradient based optimisation
+else:
+    test_gradient = False
+    optimise = True
+
 
 # create solver and set options
 solver_obj = solver2d.FlowSolver2d(mesh2d, Constant(H))

--- a/test_adjoint/examples/test_examples.py
+++ b/test_adjoint/examples/test_examples.py
@@ -32,7 +32,6 @@ def example_file(request):
 
 
 def test_examples(example_file, tmpdir, monkeypatch):
-    pytest.xfail("This test is currently broken")  # FIXME
     assert os.path.isfile(example_file), 'File not found {:}'.format(example_file)
     # copy mesh files
     source = os.path.dirname(example_file)

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -66,7 +66,6 @@ def basic_setup():
 
 
 def setup_steady():
-    pytest.xfail("This test is currently broken")  # FIXME
     solver_obj = basic_setup()
     solver_obj.options.timestepper_type = 'SteadyState'
     solver_obj.options.simulation_end_time = 0.499
@@ -82,7 +81,6 @@ def setup_steady():
 
 
 def setup_unsteady():
-    pytest.xfail("Function.split is currently broken in Firedrake")  # FIXME
     solver_obj = basic_setup()
     solver_obj.options.timestepper_type = 'CrankNicolson'
     solver_obj.options.simulation_end_time = 2.0


### PR DESCRIPTION
Two of the adjoint tests were xfailed as a temporary measure due to changes in Firedrake. Following recent fixes in Firedrake, the tests now pass and can be included in the test suite again.