### PR TITLE
Conservative tracer equation in 2D

### DIFF
--- a/examples/balzano/balzano.py
+++ b/examples/balzano/balzano.py
@@ -89,7 +89,7 @@ eta_tilde = Function(P1_2d, name="eta_tilde")
 
 # user-specified export function
 def export_func():
-    wd_bath_displacement = solverObj.eq_sw.bathymetry_displacement_mass_term.depth.wd_bathymetry_displacement
+    wd_bath_displacement = solverObj.depth.wd_bathymetry_displacement
     eta = solverObj.fields.elev_2d
     moving_bath.project(bathymetry + wd_bath_displacement(eta))
     wd_bathfile.write(moving_bath)

--- a/examples/balzano/balzano.py
+++ b/examples/balzano/balzano.py
@@ -89,7 +89,7 @@ eta_tilde = Function(P1_2d, name="eta_tilde")
 
 # user-specified export function
 def export_func():
-    wd_bath_displacement = solverObj.eq_sw.bathymetry_displacement_mass_term.wd_bathymetry_displacement
+    wd_bath_displacement = solverObj.eq_sw.bathymetry_displacement_mass_term.depth.wd_bathymetry_displacement
     eta = solverObj.fields.elev_2d
     moving_bath.project(bathymetry + wd_bath_displacement(eta))
     wd_bathfile.write(moving_bath)

--- a/test/tracerEq/test_consistency_2d.py
+++ b/test/tracerEq/test_consistency_2d.py
@@ -45,9 +45,9 @@ def run_tracer_consistency(constant_c=True, **model_options):
     # create solver
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
     options = solver_obj.options
-    options.use_limiter_for_tracers = not constant_c
     options.use_nonlinear_equations = True
     options.solve_tracer = True
+    options.use_limiter_for_tracers = not constant_c
     options.simulation_export_time = t_export
     options.simulation_end_time = t_end
     options.horizontal_velocity_scale = Constant(u_mag)
@@ -93,6 +93,7 @@ def run_tracer_consistency(constant_c=True, **model_options):
             msg = 'Tracer overshoots are too large: {:}'.format(max_abs_overshoot)
             assert max_abs_overshoot < overshoot_tol, msg
 
+
 def test_const_tracer():
     """
     Test CrankNicolson timeintegrator without slope limiters
@@ -116,6 +117,7 @@ def test_nonconst_tracer():
                            use_limiter_for_tracers=True,
                            no_exports=True)
 
+
 def test_nonconst_tracer_conservative():
     """
     Test CrankNicolson timeintegrator without slope limiters
@@ -127,6 +129,7 @@ def test_nonconst_tracer_conservative():
                            use_limiter_for_tracers=False,
                            no_exports=True,
                            use_tracer_conservative_form=True)
+
 
 if __name__ == '__main__':
     run_tracer_consistency(constant_c=False,

--- a/test/tracerEq/test_consistency_2d.py
+++ b/test/tracerEq/test_consistency_2d.py
@@ -45,9 +45,9 @@ def run_tracer_consistency(constant_c=True, **model_options):
     # create solver
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
     options = solver_obj.options
+    options.use_limiter_for_tracers = not constant_c
     options.use_nonlinear_equations = True
     options.solve_tracer = True
-    options.use_limiter_for_tracers = not constant_c
     options.simulation_export_time = t_export
     options.simulation_end_time = t_end
     options.horizontal_velocity_scale = Constant(u_mag)
@@ -57,6 +57,7 @@ def run_tracer_consistency(constant_c=True, **model_options):
     options.timestepper_type = 'CrankNicolson'
     options.output_directory = outputdir
     options.fields_to_export = ['uv_2d', 'elev_2d', 'tracer_2d']
+    options.use_tracer_conservative_form = False
     options.update(model_options)
 
     if not options.no_exports:
@@ -88,9 +89,9 @@ def run_tracer_consistency(constant_c=True, **model_options):
         smin, smax, undershoot, overshoot = solver_obj.callbacks['export']['tracer_2d overshoot']()
         max_abs_overshoot = max(abs(undershoot), abs(overshoot))
         overshoot_tol = 1e-12
-        msg = 'Tracer overshoots are too large: {:}'.format(max_abs_overshoot)
-        assert max_abs_overshoot < overshoot_tol, msg
-
+        if not options.use_tracer_conservative_form:
+            msg = 'Tracer overshoots are too large: {:}'.format(max_abs_overshoot)
+            assert max_abs_overshoot < overshoot_tol, msg
 
 def test_const_tracer():
     """
@@ -115,6 +116,17 @@ def test_nonconst_tracer():
                            use_limiter_for_tracers=True,
                            no_exports=True)
 
+def test_nonconst_tracer_conservative():
+    """
+    Test CrankNicolson timeintegrator without slope limiters
+    Non-trivial tracer, should be conserved
+    """
+    run_tracer_consistency(constant_c=False,
+                           use_nonlinear_equations=True,
+                           solve_tracer=True,
+                           use_limiter_for_tracers=False,
+                           no_exports=True,
+                           use_tracer_conservative_form=True)
 
 if __name__ == '__main__':
     run_tracer_consistency(constant_c=False,

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -277,14 +277,14 @@ def test_convergence(setup, timestepper_type, conservative_form):
 
 
 # only setup2 has nonzero diffusion:
-def test_consergence_auto_sipg(timestepper_type, conservative_form):
+def test_convergence_auto_sipg(timestepper_type, conservative_form):
     run_convergence(Setup2, [1, 2, 3], save_plot=False, timestepper_type=timestepper_type,
                     use_automatic_sipg_parameter=True,
                     use_tracer_conservative_form=conservative_form)
 
 
 # setup4 is valid for conservative only
-def test_consergence_conservative_only(timestepper_type):
+def test_convergence_conservative_only(timestepper_type):
     run_convergence(Setup4, [1, 2, 3], save_plot=False, timestepper_type=timestepper_type,
                     use_automatic_sipg_parameter=False,
                     use_tracer_conservative_form=True)

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -350,11 +350,14 @@ class TracerMassConservation2DCallback(ScalarConservationCallback):
         """
         self.name = tracer_name + ' mass'  # override name for given tracer
 
-        def mass():
-            return comp_tracer_mass_2d(self.solver_obj.fields.elev_2d,
-                                       self.solver_obj.eq_tracer.terms,
-                                       self.solver_obj.options.use_tracer_conservative_form,
-                                       self.solver_obj.fields[tracer_name])
+        if solver_obj.options.use_tracer_conservative_form:
+            def mass():
+                # tracer is depth-integrated already, so just integrate over domain
+                return assemble(solver_obj.fields[tracer_name]*dx)
+        else:
+            def mass():
+                H = solver_obj.depth.get_total_depth(solver_obj.fields.elev_2d)
+                return comp_tracer_mass_2d(solver_obj.fields[tracer_name], H)
         super(TracerMassConservation2DCallback, self).__init__(mass, solver_obj, **kwargs)
 
 

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -352,7 +352,8 @@ class TracerMassConservation2DCallback(ScalarConservationCallback):
 
         def mass():
             return comp_tracer_mass_2d(self.solver_obj.fields.elev_2d,
-                                       self.solver_obj.fields.bathymetry_2d,
+                                       self.solver_obj.eq_tracer.terms,
+                                       self.solver_obj.options.use_tracer_conservative_form,
                                        self.solver_obj.fields[tracer_name])
         super(TracerMassConservation2DCallback, self).__init__(mass, solver_obj, **kwargs)
 

--- a/thetis/conservative_tracer_eq_2d.py
+++ b/thetis/conservative_tracer_eq_2d.py
@@ -1,0 +1,185 @@
+r"""
+2D advection diffusion equation for tracers.
+
+The advection-diffusion equation of depth-integrated tracer :math:`q=HT` in conservative form reads
+
+.. math::
+    \frac{\partial q}{\partial t}
+    + \nabla_h \cdot (\textbf{u} q)
+    = \nabla_h \cdot (\mu_h \nabla_h q)
+    :label: tracer_eq_2d
+
+where :math:`\nabla_h` denotes horizontal gradient, :math:`\textbf{u}` are the horizontal
+velocities, and
+:math:`\mu_h` denotes horizontal diffusivity.
+"""
+from __future__ import absolute_import
+from .utility import *
+from .equation import Term, Equation
+from .shallowwater_eq import ShallowWaterTermMixin
+from .tracer_eq_2d import HorizontalDiffusionTerm
+
+__all__ = [
+    'ConservativeTracerEquation2D',
+]
+
+
+class ConservativeTracerTerm(TracerTerm, ShallowWaterTermMixin):
+    """
+    Generic depth-integrated tracer term that provides commonly used members and mapping for
+    boundary functions.
+    """
+    def __init__(self, function_space, bathymetry=None, options=None):
+        """
+        :arg function_space: :class:`FunctionSpace` where the solution belongs
+        :kwarg bathymetry: bathymetry of the domain
+        :type bathymetry: 2D :class:`Function` or :class:`Constant`
+        """
+        super().__init__(function_space, bathymetry=bathymetry, options=options)
+
+
+    # TODO: at the moment this is the same as TracerTerm, but we probably want to overload its
+    # get_bnd_functions method
+
+
+class ConservativeHorizontalAdvectionTerm(ConservativeTracerTerm):
+    r"""
+    Advection of tracer term, :math:`\nabla \cdot \bar{\textbf{u}} \nabla q`
+
+    The weak form is
+
+    .. math::
+        \int_\Omega \boldsymbol{\psi} \nabla\cdot \bar{\textbf{u}} \nabla q  dx
+        = - \int_\Omega \left(\nabla_h \boldsymbol{\psi})\right) \cdot \bar{\textbf{u}} \cdot q dx
+        + \int_\Gamma \text{avg}(q\bar{\textbf{u}}\cdot\textbf{n}) \cdot \text{jump}(\boldsymbol{\psi}) dS
+
+    where the right hand side has been integrated by parts;
+    :math:`\textbf{n}` is the unit normal of
+    the element interfaces, and :math:`\text{jump}` and :math:`\text{avg}` denote the
+    jump and average operators across the interface.
+    """
+    def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
+        if fields_old.get('uv_2d') is None:
+            return 0
+        elev = fields_old['elev_2d']
+        self.corr_factor = fields_old.get('tracer_advective_velocity_factor')
+
+        uv = self.corr_factor * fields_old['uv_2d']
+        uv_p1 = fields_old.get('uv_p1')
+        uv_mag = fields_old.get('uv_mag')
+
+        lax_friedrichs_factor = fields_old.get('lax_friedrichs_tracer_scaling_factor')
+
+        f = 0
+        f += -(Dx(self.test, 0) * uv[0] * solution
+               + Dx(self.test, 1) * uv[1] * solution) * self.dx
+
+        if self.horizontal_dg:
+            # add interface term
+            uv_av = avg(uv)
+            un_av = (uv_av[0]*self.normal('-')[0]
+                     + uv_av[1]*self.normal('-')[1])
+            s = 0.5*(sign(un_av) + 1.0)
+            flux_up = solution('-')*uv('-')*s + solution('+')*uv('+')*(1-s)
+
+            f += (flux_up[0] * jump(self.test, self.normal[0]) +
+                  flux_up[1] * jump(self.test, self.normal[1])) * self.dS
+            # Lax-Friedrichs stabilization
+            if self.options.use_lax_friedrichs_tracer:
+                if uv_p1 is not None:
+                    gamma = 0.5*abs((avg(uv_p1)[0]*self.normal('-')[0]
+                                     + avg(uv_p1)[1]*self.normal('-')[1]))*lax_friedrichs_factor
+                elif uv_mag is not None:
+                    gamma = 0.5*avg(uv_mag)*lax_friedrichs_factor
+                else:
+                    gamma = 0.5*abs(un_av)*lax_friedrichs_factor
+                f += gamma*dot(jump(self.test), jump(solution))*self.dS
+            if bnd_conditions is not None:
+                for bnd_marker in self.boundary_markers:
+                    funcs = bnd_conditions.get(bnd_marker)
+                    ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
+                    c_in = solution
+                    if funcs is not None and 'value' in funcs:
+                        c_ext, uv_ext, eta_ext = self.get_bnd_functions(c_in, uv, elev, bnd_marker, bnd_conditions)
+                        uv_av = 0.5*(uv + uv_ext)
+                        un_av = self.normal[0]*uv_av[0] + self.normal[1]*uv_av[1]
+                        s = 0.5*(sign(un_av) + 1.0)
+                        flux_up = c_in*uv*s + c_ext*uv_ext*(1-s)
+                        f += (flux_up[0]*self.normal[0] +
+                              flux_up[1]*self.normal[1])*self.test*ds_bnd
+                    else:
+                        f += c_in * (uv[0]*self.normal[0]
+                                     + uv[1]*self.normal[1])*self.test*ds_bnd
+
+        return -f
+
+
+class ConverservativeHorizontalDiffusionTerm(ConservativeTracerTerm, HorizontalDiffusionTerm):
+    r"""
+    Horizontal diffusion term :math:`-\nabla_h \cdot (\mu_h \nabla_h q)`
+
+    Using the symmetric interior penalty method the weak form becomes
+
+    .. math::
+        -\int_\Omega \nabla_h \cdot (\mu_h \nabla_h q) \phi dx
+        =& \int_\Omega \mu_h (\nabla_h \phi) \cdot (\nabla_h q) dx \\
+        &- \int_{\mathcal{I}_h\cup\mathcal{I}_v} \text{jump}(\phi \textbf{n}_h)
+        \cdot \text{avg}(\mu_h \nabla_h q) dS
+        - \int_{\mathcal{I}_h\cup\mathcal{I}_v} \text{jump}(q \textbf{n}_h)
+        \cdot \text{avg}(\mu_h  \nabla \phi) dS \\
+        &+ \int_{\mathcal{I}_h\cup\mathcal{I}_v} \sigma \text{avg}(\mu_h) \text{jump}(q \textbf{n}_h) \cdot
+            \text{jump}(\phi \textbf{n}_h) dS \\
+        &- \int_\Gamma \mu_h (\nabla_h \phi) \cdot \textbf{n}_h ds
+
+    where :math:`\sigma` is a penalty parameter,
+    see Epshteyn and Riviere (2007).
+
+    Epshteyn and Riviere (2007). Estimation of penalty parameters for symmetric
+    interior penalty Galerkin methods. Journal of Computational and Applied
+    Mathematics, 206(2):843-872. http://dx.doi.org/10.1016/j.cam.2006.08.029
+
+    """
+    # TODO: at the moment the same as HorizontalDiffusionTerm
+    # do we need additional H-derivative term?
+    # would also become different if ConservativeTracerTerm gets different bc options
+
+class ConservativeSourceTerm(ConservativeTracerTerm):
+    r"""
+    Generic source term
+
+    The weak form reads
+
+    .. math::
+        F_s = \int_\Omega \sigma \phi dx
+
+    where :math:`\sigma` is a user defined scalar :class:`Function`.
+
+    """
+    def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
+        f = 0
+        source = fields_old.get('source')
+        if source is not None:
+            H = self.get_total_depth(fields_old['elev'])
+            f += -inner(H*source, self.test)*self.dx
+        return -f
+
+
+class ConservativeTracerEquation2D(Equation):
+    """
+    2D tracer advection-diffusion equation :eq:`tracer_eq` in conservative form
+    """
+    def __init__(self, function_space, bathymetry=None, options=None):
+        """
+        :arg function_space: :class:`FunctionSpace` where the solution belongs
+        :kwarg bathymetry: bathymetry of the domain
+        :type bathymetry: 2D :class:`Function` or :class:`Constant`
+
+        :kwarg bool use_symmetric_surf_bnd: If True, use symmetric surface boundary
+            condition in the horizontal advection term
+        """
+        super(TracerEquation2D, self).__init__(function_space)
+
+        args = (function_space, bathymetry, options)
+        self.add_term(ConservativeHorizontalAdvectionTerm(*args), 'explicit')
+        self.add_term(ConservativeHorizontalDiffusionTerm(*args), 'explicit')
+        self.add_term(ConservativeSourceTerm(*args), 'source')

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -522,6 +522,7 @@ class ModelOptions2d(CommonModelOptions):
     """Options for 2D depth-averaged shallow water model"""
     name = 'Depth-averaged 2D model'
     solve_tracer = Bool(False, help='Solve tracer transport').tag(config=True)
+    use_tracer_conservative_form = Bool(False, help='Solve 2D tracer transport in the conservative form').tag(config=True)
     use_wetting_and_drying = Bool(
         False, help=r"""bool: Turn on wetting and drying
 

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -208,7 +208,7 @@ class ShallowWaterTerm(Term):
     """
     Generic term in the shallow water equations that provides commonly used
     members and mapping for boundary functions.
-        """
+    """
     def __init__(self, space,
                  depth, options=None):
         super(ShallowWaterTerm, self).__init__(space)
@@ -843,7 +843,8 @@ class ShallowWaterEquations(BaseShallowWaterEquation):
         self.add_momentum_terms(u_test, u_space, eta_space, depth, options)
 
         self.add_continuity_terms(eta_test, eta_space, u_space, depth, options)
-        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(eta_test, eta_space, u_space, depth, options)
+        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(
+            eta_test, eta_space, u_space, depth, options)
 
     def mass_term(self, solution):
         f = super(ShallowWaterEquations, self).mass_term(solution)
@@ -912,7 +913,8 @@ class FreeSurfaceEquation(BaseShallowWaterEquation):
         """
         super(FreeSurfaceEquation, self).__init__(eta_space, depth, options)
         self.add_continuity_terms(eta_test, eta_space, u_space, depth, options)
-        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(eta_test, eta_space, u_space, depth, options)
+        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(
+            eta_test, eta_space, u_space, depth, options)
 
     def mass_term(self, solution):
         f = super(ShallowWaterEquations, self).mass_term(solution)

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -183,7 +183,6 @@ __all__ = [
     'ModeSplit2DEquations',
     'ShallowWaterMomentumEquation',
     'FreeSurfaceEquation',
-    'ShallowWaterTermMixin',
     'ShallowWaterTerm',
     'ShallowWaterMomentumTerm',
     'ShallowWaterContinuityTerm',
@@ -205,84 +204,16 @@ g_grav = physical_constants['g_grav']
 rho_0 = physical_constants['rho0']
 
 
-class ShallowWaterTermMixin:
-    """
-    Mixin class that provides methods in common to
-    ShallowWaterTerm and (Conservative)TracerTerm. Requires self.bathymetry
-    and self.options attributes."""
-
-    def wd_bathymetry_displacement(self, eta):
-        """
-        Returns wetting and drying bathymetry displacement as described in:
-        Karna et al.,  2011.
-        """
-        H = self.bathymetry + eta
-        return 0.5 * (sqrt(H ** 2 + self.options.wetting_and_drying_alpha ** 2) - H)
-
-    def get_total_depth(self, eta):
-        """
-        Returns total water column depth
-        """
-        if self.options.use_nonlinear_equations:
-            total_h = self.bathymetry + eta
-            if hasattr(self.options, 'use_wetting_and_drying') and self.options.use_wetting_and_drying:
-                total_h = self.bathymetry + eta + self.wd_bathymetry_displacement(eta)
-        else:
-            total_h = self.bathymetry
-        return total_h
-
-    def get_bnd_functions(self, eta_in, uv_in, bnd_id, bnd_conditions):
-        """
-        Returns external values of elev and uv for all supported
-        boundary conditions.
-
-        Volume flux (flux) and normal velocity (un) are defined positive out of
-        the domain.
-        """
-        bath = self.bathymetry
-        bnd_len = self.boundary_len[bnd_id]
-        funcs = bnd_conditions.get(bnd_id)
-        if 'elev' in funcs and 'uv' in funcs:
-            eta_ext = funcs['elev']
-            uv_ext = funcs['uv']
-        elif 'elev' in funcs and 'un' in funcs:
-            eta_ext = funcs['elev']
-            uv_ext = funcs['un']*self.normal
-        elif 'elev' in funcs and 'flux' in funcs:
-            eta_ext = funcs['elev']
-            h_ext = eta_ext + bath
-            area = h_ext*bnd_len  # NOTE using external data only
-            uv_ext = funcs['flux']/area*self.normal
-        elif 'elev' in funcs:
-            eta_ext = funcs['elev']
-            uv_ext = uv_in  # assume symmetry
-        elif 'uv' in funcs:
-            eta_ext = eta_in  # assume symmetry
-            uv_ext = funcs['uv']
-        elif 'un' in funcs:
-            eta_ext = eta_in  # assume symmetry
-            uv_ext = funcs['un']*self.normal
-        elif 'flux' in funcs:
-            eta_ext = eta_in  # assume symmetry
-            h_ext = eta_ext + bath
-            area = h_ext*bnd_len  # NOTE using internal elevation
-            uv_ext = funcs['flux']/area*self.normal
-        else:
-            raise Exception('Unsupported bnd type: {:}'.format(funcs.keys()))
-        return eta_ext, uv_ext
-
-
-class ShallowWaterTerm(Term, ShallowWaterTermMixin):
+class ShallowWaterTerm(Term):
     """
     Generic term in the shallow water equations that provides commonly used
     members and mapping for boundary functions.
-    """
+        """
     def __init__(self, space,
-                 bathymetry=None,
-                 options=None):
+                 depth, options=None):
         super(ShallowWaterTerm, self).__init__(space)
 
-        self.bathymetry = bathymetry
+        self.depth = depth
         self.options = options
 
         # mesh dependent variables
@@ -296,6 +227,45 @@ class ShallowWaterTerm(Term, ShallowWaterTermMixin):
         self.dS = dS(degree=self.quad_degree,
                      domain=self.function_space.ufl_domain())
 
+    def get_bnd_functions(self, eta_in, uv_in, bnd_id, bnd_conditions):
+        """
+        Returns external values of elev and uv for all supported
+        boundary conditions.
+
+        Volume flux (flux) and normal velocity (un) are defined positive out of
+        the domain.
+        """
+        bnd_len = self.boundary_len[bnd_id]
+        funcs = bnd_conditions.get(bnd_id)
+        if 'elev' in funcs and 'uv' in funcs:
+            eta_ext = funcs['elev']
+            uv_ext = funcs['uv']
+        elif 'elev' in funcs and 'un' in funcs:
+            eta_ext = funcs['elev']
+            uv_ext = funcs['un']*self.normal
+        elif 'elev' in funcs and 'flux' in funcs:
+            eta_ext = funcs['elev']
+            h_ext = self.depth.get_total_depth(eta_ext)
+            area = h_ext*bnd_len  # NOTE using external data only
+            uv_ext = funcs['flux']/area*self.normal
+        elif 'elev' in funcs:
+            eta_ext = funcs['elev']
+            uv_ext = uv_in  # assume symmetry
+        elif 'uv' in funcs:
+            eta_ext = eta_in  # assume symmetry
+            uv_ext = funcs['uv']
+        elif 'un' in funcs:
+            eta_ext = eta_in  # assume symmetry
+            uv_ext = funcs['un']*self.normal
+        elif 'flux' in funcs:
+            eta_ext = eta_in  # assume symmetry
+            h_ext = self.depth.get_total_depth(eta_ext)
+            area = h_ext*bnd_len  # NOTE using internal elevation
+            uv_ext = funcs['flux']/area*self.normal
+        else:
+            raise Exception('Unsupported bnd type: {:}'.format(funcs.keys()))
+        return eta_ext, uv_ext
+
 
 class ShallowWaterMomentumTerm(ShallowWaterTerm):
     """
@@ -303,9 +273,8 @@ class ShallowWaterMomentumTerm(ShallowWaterTerm):
     members and mapping for boundary functions.
     """
     def __init__(self, u_test, u_space, eta_space,
-                 bathymetry=None,
-                 options=None):
-        super(ShallowWaterMomentumTerm, self).__init__(u_space, bathymetry, options)
+                 depth, options=None):
+        super(ShallowWaterMomentumTerm, self).__init__(u_space, depth, options)
 
         self.options = options
 
@@ -323,9 +292,8 @@ class ShallowWaterContinuityTerm(ShallowWaterTerm):
     members and mapping for boundary functions.
     """
     def __init__(self, eta_test, eta_space, u_space,
-                 bathymetry=None,
-                 options=None):
-        super(ShallowWaterContinuityTerm, self).__init__(eta_space, bathymetry, options)
+                 depth, options=None):
+        super(ShallowWaterContinuityTerm, self).__init__(eta_space, depth, options)
 
         self.eta_test = eta_test
         self.eta_space = eta_space
@@ -354,7 +322,7 @@ class ExternalPressureGradientTerm(ShallowWaterMomentumTerm):
     right hand side is used.
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
-        total_h = self.get_total_depth(eta_old)
+        total_h = self.depth.get_total_depth(eta_old)
 
         head = eta
 
@@ -417,7 +385,7 @@ class HUDivTerm(ShallowWaterContinuityTerm):
     the form on the right hand side is used.
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
-        total_h = self.get_total_depth(eta_old)
+        total_h = self.depth.get_total_depth(eta_old)
 
         hu_by_parts = self.u_continuity in ['dg', 'hdiv']
 
@@ -435,13 +403,13 @@ class HUDivTerm(ShallowWaterContinuityTerm):
                     eta_ext, uv_ext = self.get_bnd_functions(eta, uv, bnd_marker, bnd_conditions)
                     eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
-                    total_h_ext = self.get_total_depth(eta_ext_old)
+                    total_h_ext = self.depth.get_total_depth(eta_ext_old)
                     h_av = 0.5*(total_h + total_h_ext)
                     eta_jump = eta - eta_ext
                     un_rie = 0.5*inner(uv + uv_ext, self.normal) + sqrt(g_grav/h_av)*eta_jump
                     un_jump = inner(uv_old - uv_ext_old, self.normal)
                     eta_rie = 0.5*(eta_old + eta_ext_old) + sqrt(h_av/g_grav)*un_jump
-                    h_rie = self.bathymetry + eta_rie
+                    h_rie = self.depth.get_total_depth(eta_rie)
                     f += h_rie*un_rie*self.eta_test*ds_bnd
         else:
             f = div(total_h*uv)*self.eta_test*self.dx
@@ -518,7 +486,7 @@ class HorizontalAdvectionTerm(ShallowWaterMomentumTerm):
                     eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
                     eta_jump = eta_old - eta_ext_old
-                    total_h = self.get_total_depth(eta_old)
+                    total_h = self.depth.get_total_depth(eta_old)
                     un_rie = 0.5*inner(uv_old + uv_ext_old, self.normal) + sqrt(g_grav/total_h)*eta_jump
                     uv_av = 0.5*(uv_ext + uv)
                     f += (uv_av[0]*self.u_test[0]*un_rie
@@ -568,7 +536,7 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
     Mathematics, 206(2):843-872. http://dx.doi.org/10.1016/j.cam.2006.08.029
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
-        total_h = self.get_total_depth(eta_old)
+        total_h = self.depth.get_total_depth(eta_old)
 
         nu = fields_old.get('viscosity_h')
         if nu is None:
@@ -645,7 +613,7 @@ class WindStressTerm(ShallowWaterMomentumTerm):
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
         wind_stress = fields_old.get('wind_stress')
-        total_h = self.get_total_depth(eta_old)
+        total_h = self.depth.get_total_depth(eta_old)
         f = 0
         if wind_stress is not None:
             f += dot(wind_stress, self.u_test)/total_h/rho_0*self.dx
@@ -680,7 +648,7 @@ class QuadraticDragTerm(ShallowWaterMomentumTerm):
     Otherwise :math:`C_D` is taken as a constant (see field :attr:`quadratic_drag_coefficient`).
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
-        total_h = self.get_total_depth(eta_old)
+        total_h = self.depth.get_total_depth(eta_old)
         manning_drag_coefficient = fields_old.get('manning_drag_coefficient')
         C_D = fields_old.get('quadratic_drag_coefficient')
         f = 0
@@ -719,7 +687,7 @@ class BottomDrag3DTerm(ShallowWaterMomentumTerm):
     These fields are computed in the 3D model.
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
-        total_h = self.get_total_depth(eta_old)
+        total_h = self.depth.get_total_depth(eta_old)
         bottom_drag = fields_old.get('bottom_drag')
         uv_bottom = fields_old.get('uv_bottom')
         f = 0
@@ -745,7 +713,7 @@ class TurbineDragTerm(ShallowWaterMomentumTerm):
 
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
-        total_h = self.get_total_depth(eta_old)
+        total_h = self.depth.get_total_depth(eta_old)
         f = 0
         for subdomain_id, farm_options in self.options.tidal_turbine_farms.items():
             density = farm_options.turbine_density
@@ -812,9 +780,7 @@ class BathymetryDisplacementMassTerm(ShallowWaterContinuityTerm):
             uv, eta = solution
         else:
             uv, eta = split(solution)
-        f = 0
-        if self.options.use_wetting_and_drying:
-            f += inner(self.wd_bathymetry_displacement(eta), self.eta_test)*self.dx
+        f = inner(self.depth.wd_bathymetry_displacement(eta), self.eta_test)*self.dx
         return -f
 
 
@@ -827,10 +793,9 @@ class BaseShallowWaterEquation(Equation):
     or continuity terms.
     """
     def __init__(self, function_space,
-                 bathymetry,
-                 options):
+                 depth, options):
         super(BaseShallowWaterEquation, self).__init__(function_space)
-        self.bathymetry = bathymetry
+        self.depth = depth
         self.options = options
 
     def add_momentum_terms(self, *args):
@@ -864,25 +829,21 @@ class ShallowWaterEquations(BaseShallowWaterEquation):
     This defines the full 2D SWE equations :eq:`swe_freesurf` -
     :eq:`swe_momentum`.
     """
-    def __init__(self, function_space,
-                 bathymetry,
-                 options):
+    def __init__(self, function_space, depth, options):
         """
         :arg function_space: Mixed function space where the solution belongs
-        :arg bathymetry: bathymetry of the domain
-        :type bathymetry: :class:`Function` or :class:`Constant`
+        :arg depth: :class: `DepthExpression` containing depth info
         :arg options: :class:`.AttrDict` object containing all circulation model options
         """
-        super(ShallowWaterEquations, self).__init__(function_space, bathymetry, options)
+        super(ShallowWaterEquations, self).__init__(function_space, depth, options)
 
         u_test, eta_test = TestFunctions(function_space)
         u_space, eta_space = function_space.split()
 
-        self.add_momentum_terms(u_test, u_space, eta_space,
-                                bathymetry, options)
+        self.add_momentum_terms(u_test, u_space, eta_space, depth, options)
 
-        self.add_continuity_terms(eta_test, eta_space, u_space, bathymetry, options)
-        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(eta_test, eta_space, u_space, bathymetry, options)
+        self.add_continuity_terms(eta_test, eta_space, u_space, depth, options)
+        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(eta_test, eta_space, u_space, depth, options)
 
     def mass_term(self, solution):
         f = super(ShallowWaterEquations, self).mass_term(solution)
@@ -905,26 +866,21 @@ class ModeSplit2DEquations(BaseShallowWaterEquation):
     Defines the equations :eq:`swe_freesurf_modesplit` -
     :eq:`swe_momentum_modesplit`.
     """
-    def __init__(self, function_space,
-                 bathymetry,
-                 options):
+    def __init__(self, function_space, depth, options):
         """
         :arg function_space: Mixed function space where the solution belongs
-        :arg bathymetry: bathymetry of the domain
-        :type bathymetry: :class:`Function` or :class:`Constant`
+        :arg depth: :class: `DepthExpression` containing depth info
         :arg options: :class:`.AttrDict` object containing all circulation model options
         """
         # TODO remove include_grad_* options as viscosity operator is omitted
-        super(ModeSplit2DEquations, self).__init__(function_space, bathymetry, options)
+        super(ModeSplit2DEquations, self).__init__(function_space, depth, options)
 
         u_test, eta_test = TestFunctions(function_space)
         u_space, eta_space = function_space.split()
 
-        self.add_momentum_terms(u_test, u_space, eta_space,
-                                bathymetry,
-                                options)
+        self.add_momentum_terms(u_test, u_space, eta_space, depth, options)
 
-        self.add_continuity_terms(eta_test, eta_space, u_space, bathymetry, options)
+        self.add_continuity_terms(eta_test, eta_space, u_space, depth, options)
 
     def add_momentum_terms(self, *args):
         self.add_term(ExternalPressureGradientTerm(*args), 'implicit')
@@ -945,21 +901,18 @@ class FreeSurfaceEquation(BaseShallowWaterEquation):
     """
     2D free surface equation :eq:`swe_freesurf` in non-conservative form.
     """
-    def __init__(self, eta_test, eta_space, u_space,
-                 bathymetry,
-                 options):
+    def __init__(self, eta_test, eta_space, u_space, depth, options):
         """
         :arg eta_test: test function of the elevation function space
         :arg eta_space: elevation function space
         :arg u_space: velocity function space
         :arg function_space: Mixed function space where the solution belongs
-        :arg bathymetry: bathymetry of the domain
-        :type bathymetry: :class:`Function` or :class:`Constant`
+        :arg depth: :class: `DepthExpression` containing depth info
         :arg options: :class:`.AttrDict` object containing all circulation model options
         """
-        super(FreeSurfaceEquation, self).__init__(eta_space, bathymetry, options)
-        self.add_continuity_terms(eta_test, eta_space, u_space, bathymetry, options)
-        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(eta_test, eta_space, u_space, bathymetry, options)
+        super(FreeSurfaceEquation, self).__init__(eta_space, depth, options)
+        self.add_continuity_terms(eta_test, eta_space, u_space, depth, options)
+        self.bathymetry_displacement_mass_term = BathymetryDisplacementMassTerm(eta_test, eta_space, u_space, depth, options)
 
     def mass_term(self, solution):
         f = super(ShallowWaterEquations, self).mass_term(solution)
@@ -979,20 +932,16 @@ class ShallowWaterMomentumEquation(BaseShallowWaterEquation):
     2D depth averaged momentum equation :eq:`swe_momentum` in non-conservative
     form.
     """
-    def __init__(self, u_test, u_space, eta_space,
-                 bathymetry,
-                 options):
+    def __init__(self, u_test, u_space, eta_space, depth, options):
         """
         :arg u_test: test function of the velocity function space
         :arg u_space: velocity function space
         :arg eta_space: elevation function space
-        :arg bathymetry: bathymetry of the domain
-        :type bathymetry: :class:`Function` or :class:`Constant`
+        :arg depth: :class: `DepthExpression` containing depth info
         :arg options: :class:`.AttrDict` object containing all circulation model options
         """
-        super(ShallowWaterMomentumEquation, self).__init__(u_space, bathymetry, options)
-        self.add_momentum_terms(u_test, u_space, eta_space,
-                                bathymetry, options)
+        super(ShallowWaterMomentumEquation, self).__init__(u_space, depth, options)
+        self.add_momentum_terms(u_test, u_space, eta_space, depth, options)
 
     def residual(self, label, solution, solution_old, fields, fields_old, bnd_conditions):
         uv = solution

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -297,7 +297,6 @@ class ShallowWaterTerm(Term, ShallowWaterTermMixin):
                      domain=self.function_space.ufl_domain())
 
 
-
 class ShallowWaterMomentumTerm(ShallowWaterTerm):
     """
     Generic term in the shallow water momentum equation that provides commonly used

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -707,7 +707,7 @@ class FlowSolver(FrozenClass):
 
         self.eq_sw = shallowwater_eq.ModeSplit2DEquations(
             self.fields.solution_2d.function_space(),
-            depth, self.options)
+            self.depth, self.options)
 
         expl_bottom_friction = self.options.use_bottom_friction and not self.options.use_implicit_vertical_diffusion
         self.eq_momentum = momentum_eq.MomentumEquation(self.fields.uv_3d.function_space(),

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -702,10 +702,12 @@ class FlowSolver(FrozenClass):
             output_logger.addHandler(filehandler)
         self.set_sipg_parameter()
 
+        self.depth = DepthExpression(self.fields.bathymetry_2d,
+                use_nonlinear_equations=self.options.use_nonlinear_equations)
+
         self.eq_sw = shallowwater_eq.ModeSplit2DEquations(
             self.fields.solution_2d.function_space(),
-            self.fields.bathymetry_2d,
-            self.options)
+            depth, self.options)
 
         expl_bottom_friction = self.options.use_bottom_friction and not self.options.use_implicit_vertical_diffusion
         self.eq_momentum = momentum_eq.MomentumEquation(self.fields.uv_3d.function_space(),

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -703,7 +703,7 @@ class FlowSolver(FrozenClass):
         self.set_sipg_parameter()
 
         self.depth = DepthExpression(self.fields.bathymetry_2d,
-                use_nonlinear_equations=self.options.use_nonlinear_equations)
+                                     use_nonlinear_equations=self.options.use_nonlinear_equations)
 
         self.eq_sw = shallowwater_eq.ModeSplit2DEquations(
             self.fields.solution_2d.function_space(),

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -306,13 +306,15 @@ class FlowSolver2d(FrozenClass):
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             if self.options.timestepper_type == 'CrankNicolson':
                 if self.options.use_tracer_conservative_form:
-                    self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(self.function_spaces.Q_2d, self.depth,
-                                                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                                                            sipg_parameter=self.options.sipg_parameter_tracer)
+                    self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(
+                        self.function_spaces.Q_2d, self.depth,
+                        use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
+                        sipg_parameter=self.options.sipg_parameter_tracer)
                 else:
-                    self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, self.depth,
-                                                                   use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                                   sipg_parameter=self.options.sipg_parameter_tracer)
+                    self.eq_tracer = tracer_eq_2d.TracerEquation2D(
+                        self.function_spaces.Q_2d, self.depth,
+                        use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
+                        sipg_parameter=self.options.sipg_parameter_tracer)
                 if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                     self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
                 else:

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -300,9 +300,12 @@ class FlowSolver2d(FrozenClass):
         if self.options.solve_tracer:
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             if self.options.timestepper_type == 'CrankNicolson':
-                self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
-                                                               use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                               sipg_parameter=self.options.sipg_parameter_tracer)
+                if self.options.use_tracer_conservative_form:
+                    self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
+                                                                   options=self.options)
+                else:
+                    self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
+                                                                   options=self.options)
                 if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                     self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
                 else:

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -307,10 +307,12 @@ class FlowSolver2d(FrozenClass):
             if self.options.timestepper_type == 'CrankNicolson':
                 if self.options.use_tracer_conservative_form:
                     self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(self.function_spaces.Q_2d, self.depth,
-                                                                                            options=self.options)
+                                                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
+                                                                                            sipg_parameter=self.options.sipg_parameter_tracer)
                 else:
                     self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, self.depth,
-                                                                   options=self.options)
+                                                                   use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
+                                                                   sipg_parameter=self.options.sipg_parameter_tracer)
                 if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                     self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
                 else:

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -9,6 +9,7 @@ from . import rungekutta
 from . import implicitexplicit
 from . import coupled_timeintegrator_2d
 from . import tracer_eq_2d
+from . import conservative_tracer_eq_2d
 import weakref
 import time as time_mod
 import numpy as np

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -290,11 +290,15 @@ class FlowSolver2d(FrozenClass):
         self.fields.h_elem_size_2d = Function(self.function_spaces.P1_2d)
         get_horizontal_elem_size_2d(self.fields.h_elem_size_2d)
         self.set_sipg_parameter()
+        self.depth = DepthExpression(self.fields.bathymetry_2d,
+                use_nonlinear_equations=self.options.use_nonlinear_equations,
+                use_wetting_and_drying=self.options.use_wetting_and_drying,
+                wetting_and_drying_alpha=self.options.wetting_and_drying_alpha)
 
         # ----- Equations
         self.eq_sw = shallowwater_eq.ShallowWaterEquations(
             self.fields.solution_2d.function_space(),
-            self.fields.bathymetry_2d,
+            self.depth,
             self.options
         )
         self.eq_sw.bnd_functions = self.bnd_functions['shallow_water']
@@ -302,10 +306,10 @@ class FlowSolver2d(FrozenClass):
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             if self.options.timestepper_type == 'CrankNicolson':
                 if self.options.use_tracer_conservative_form:
-                    self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
-                                                                   options=self.options)
+                    self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(self.function_spaces.Q_2d, self.depth,
+                                                                                            options=self.options)
                 else:
-                    self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, bathymetry=self.fields.bathymetry_2d,
+                    self.eq_tracer = tracer_eq_2d.TracerEquation2D(self.function_spaces.Q_2d, self.depth,
                                                                    options=self.options)
                 if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                     self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
@@ -395,7 +399,7 @@ class FlowSolver2d(FrozenClass):
             u_test = TestFunction(self.function_spaces.U_2d)
             self.eq_mom = shallowwater_eq.ShallowWaterMomentumEquation(
                 u_test, self.function_spaces.U_2d, self.function_spaces.H_2d,
-                self.fields.bathymetry_2d,
+                self.depth,
                 options=self.options
             )
             self.eq_mom.bnd_functions = self.bnd_functions['shallow_water']

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -291,9 +291,9 @@ class FlowSolver2d(FrozenClass):
         get_horizontal_elem_size_2d(self.fields.h_elem_size_2d)
         self.set_sipg_parameter()
         self.depth = DepthExpression(self.fields.bathymetry_2d,
-                use_nonlinear_equations=self.options.use_nonlinear_equations,
-                use_wetting_and_drying=self.options.use_wetting_and_drying,
-                wetting_and_drying_alpha=self.options.wetting_and_drying_alpha)
+                                     use_nonlinear_equations=self.options.use_nonlinear_equations,
+                                     use_wetting_and_drying=self.options.use_wetting_and_drying,
+                                     wetting_and_drying_alpha=self.options.wetting_and_drying_alpha)
 
         # ----- Equations
         self.eq_sw = shallowwater_eq.ShallowWaterEquations(

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -83,7 +83,7 @@ class TracerTerm(Term):
         if 'uv' in funcs:
             uv_ext = self.corr_factor * funcs['uv']
         elif 'flux' in funcs:
-            h_ext = self.depth.get_entire_depth(elev_ext)
+            h_ext = self.depth.get_total_depth(elev_ext)
             area = h_ext*self.boundary_len[bnd_id]  # NOTE using external data only
             uv_ext = self.corr_factor * funcs['flux']/area*self.normal
         elif 'un' in funcs:

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -189,7 +189,7 @@ class HorizontalDiffusionTerm(TracerTerm):
         f += inner(grad_test, diff_flux)*self.dx
 
         if self.horizontal_dg:
-            alpha = self.soptions.sipg_parameter_tracer
+            alpha = self.options.sipg_parameter_tracer
             assert alpha is not None
             sigma = avg(alpha / self.cellsize)
             ds_interior = self.dS

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -83,8 +83,7 @@ class TracerTerm(Term):
         if 'uv' in funcs:
             uv_ext = self.corr_factor * funcs['uv']
         elif 'flux' in funcs:
-            assert self.bathymetry is not None
-            h_ext = elev_ext + self.bathymetry
+            h_ext = self.depth.get_entire_depth(elev_ext)
             area = h_ext*self.boundary_len[bnd_id]  # NOTE using external data only
             uv_ext = self.corr_factor * funcs['flux']/area*self.normal
         elif 'un' in funcs:

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -74,7 +74,7 @@ class TracerTerm(Term,ShallowWaterTermMixin):
             c_ext = funcs['value']
         else:
             c_ext = c_in
-        uv_ext, elev_ext = super().get_bnd_functions(elev_in, uv_in, bnd_id, bnd_conditions)
+        elev_ext, uv_ext = super().get_bnd_functions(elev_in, uv_in, bnd_id, bnd_conditions)
         return c_ext, uv_ext, elev_ext
 
 

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1730,7 +1730,6 @@ class DepthExpression:
     r"""
     Construct expression for depth depending on options
 
-
     If `not use_nonlinear_equations`, then the depth is simply the bathymetry:
         :math:`H = h`
     Otherwise we include the free surface elevation:
@@ -1739,18 +1738,12 @@ class DepthExpression:
     to ensure a positive depth (see Karna et al. 2011):
         :math:`H = h + f(h+\eta) + \eta`
     where
-        :math:`f(h+\eta) = (\sqrt{(h+\eta)^2 +\alpha^2} - (h+\eta))/2
+        :math:`f(h+\eta) = (\sqrt{(h+\eta)^2 +\alpha^2} - (h+\eta))/2`
     This introduces a wetting-drying parameter :math:`\alpha`, with dimensions
     of length. The value for :math:`\alpha` is specified by
-    `wetting_and_drying_alpha`, in units of meters. The default value is 0.5,
-    but the appropriate value is problem specific and should be set by the user.
-
-    An approximate method for selecting a suitable value for :math:`\alpha` is suggested
-    by Karna et al. (2011). Defining :math:`L_x` as the horizontal length scale of the
-    mesh elements at the wet-dry front, it can be reasoned that :math:`\alpha \approx |L_x
-    \nabla h|` yields a suitable choice. Smaller :math:`\alpha` leads to a more accurate
-    solution to the shallow water equations in wet regions, but if :math:`\alpha` is too
-    small the simulation will become unstable.
+    :attr:`.ModelOptions.wetting_and_drying_alpha`, in units of meters. The
+    default value is 0.5, but the appropriate value is problem specific and
+    should be set by the user.
     """
 
     def __init__(self, bathymetry_2d, use_nonlinear_equations=True,

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1727,8 +1727,30 @@ def select_and_move_detectors(mesh, detector_locations, detector_names=None,
 
 
 class DepthExpression:
-    """
+    r"""
     Construct expression for depth depending on options
+
+
+    If `not use_nonlinear_equations`, then the depth is simply the bathymetry:
+        :math:`H = h`
+    Otherwise we include the free surface elevation:
+        :math:`H = h + \eta`
+    and if `use_wetting_and_drying`, includes a bathymetry displacement term
+    to ensure a positive depth (see Karna et al. 2011):
+        :math:`H = h + f(h+\eta) + \eta`
+    where
+        :math:`f(h+\eta) = (\sqrt{(h+\eta)^2 +\alpha^2} - (h+\eta))/2
+    This introduces a wetting-drying parameter :math:`\alpha`, with dimensions
+    of length. The value for :math:`\alpha` is specified by
+    `wetting_and_drying_alpha`, in units of meters. The default value is 0.5,
+    but the appropriate value is problem specific and should be set by the user.
+
+    An approximate method for selecting a suitable value for :math:`\alpha` is suggested
+    by Karna et al. (2011). Defining :math:`L_x` as the horizontal length scale of the
+    mesh elements at the wet-dry front, it can be reasoned that :math:`\alpha \approx |L_x
+    \nabla h|` yields a suitable choice. Smaller :math:`\alpha` leads to a more accurate
+    solution to the shallow water equations in wet regions, but if :math:`\alpha` is too
+    small the simulation will become unstable.
     """
 
     def __init__(self, bathymetry_2d, use_nonlinear_equations=True,
@@ -1752,9 +1774,7 @@ class DepthExpression:
 
     def get_total_depth(self, eta):
         """
-        Returns total water column depth based on options:
-        * use_nonlinear_equations
-        * use_wetting_and_drying
+        Returns total water column depth based on options
         :arg eta: current elevation as UFL expression
         """
         if self.use_nonlinear_equations:

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -299,15 +299,20 @@ def comp_volume_3d(mesh):
     return val
 
 
-def comp_tracer_mass_2d(eta, bath, scalar_func):
+def comp_tracer_mass_2d(eta, tracer_terms, opt_cons, scalar_func):
     """
     Computes total tracer mass in the 2D domain
     :arg eta: elevation :class:`Function`
-    :arg bath: bathymetry :class:`Function`
+    :arg tracer_terms: terms from tracer equation :class: 'Dictionary'
+    :opt_cons switch for conservative or non-conservative tracer
     :arg scalar_func: scalar :class:`Function` to integrate
     """
-
-    val = assemble((eta+bath)*scalar_func*dx)
+    if opt_cons:
+        val = assemble(scalar_func*dx)
+    else:
+        keys = [i for i in tracer_terms.keys()]
+        H = tracer_terms[keys[0]].get_total_depth(eta)
+        val = assemble(H*scalar_func*dx)
     return val
 
 

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1725,6 +1725,7 @@ def select_and_move_detectors(mesh, detector_locations, detector_names=None,
     else:
         return accepted_locations, accepted_names
 
+
 class DepthExpression:
     """
     Construct expression for depth depending on options


### PR DESCRIPTION
Conservative tracer equation, guarantees conservation of tracer also with wetting and drying and discontinuous bathymetry. New implementation as discussed, now solves for depth-integrated `q=Hc` tracer. Includes tests. Separated depth functions (based on wetting and drying options and nonlinear switch) in separate class to make these available in both `ShallowWaterTerm`s and `TracerTerm`s but also in diagnostics.