### PR TITLE
Automatic wetting and drying alpha

### DIFF
--- a/test/swe2d/test_thacker.py
+++ b/test/swe2d/test_thacker.py
@@ -14,16 +14,16 @@ from thetis import *
 import pytest
 
 
-@pytest.mark.parametrize("stepper,n,dt,alpha,max_err",
+@pytest.mark.parametrize("stepper,n,dt,max_err",
                          [
-                             ('BackwardEuler', 10, 600., 2., 0.33),
-                             ('BackwardEuler', 25, 300., 2., 0.19),
-                             ('CrankNicolson', 10, 600., 2., 0.26),
-                             ('CrankNicolson', 25, 300., 2., 0.15),
-                             ('DIRK22', 10, 600., 2., 0.26),
-                             ('DIRK22', 25, 300., 2., 0.15),
-                             ('DIRK33', 10, 600., 2., 0.26),
-                             ('DIRK33', 25, 300., 2., 0.15),
+                             ('BackwardEuler', 10, 600., 0.33),
+                             ('BackwardEuler', 25, 300., 0.19),
+                             ('CrankNicolson', 10, 600., 0.26),
+                             ('CrankNicolson', 25, 300., 0.15),
+                             ('DIRK22', 10, 600., 0.26),
+                             ('DIRK22', 25, 300., 0.15),
+                             ('DIRK33', 10, 600., 0.26),
+                             ('DIRK33', 25, 300., 0.15),
                          ],
                          ids=[
                              'BackwardEuler-coarse',
@@ -35,7 +35,7 @@ import pytest
                              'DIRK33-coarse',
                              'DIRK33-fine',
                          ])
-def test_thacker(stepper, n, dt, alpha, max_err):
+def test_thacker(stepper, n, dt, max_err):
     """
     Run Thacker wetting-drying test case
     """
@@ -65,7 +65,7 @@ def test_thacker(stepper, n, dt, alpha, max_err):
     options.no_exports = True
     options.timestepper_type = stepper
     options.use_wetting_and_drying = True
-    options.wetting_and_drying_alpha = Constant(alpha)
+    options.use_automatic_wetting_and_drying_alpha = True
 
     # initial conditions
     elev_init = D0*(sqrt(1-A*A)/(1-A) - 1

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -625,6 +625,12 @@ class ModelOptions2d(CommonModelOptions):
         For problems whose bathymetry varies wildly in coastal regions, it is advisable to use the
         automatic wetting and drying parameter, rather than the default.
         """).tag(config=True)
+    wetting_and_drying_alpha_max = FiredrakeScalarExpression(
+        Constant(2.0), help=r"""
+        Maximum value to be taken by wetting and drying parameter :math:`\alpha`.
+
+        Note this is only relevant if `use_automatic_wetting_and_drying_alpha` is set to ``True``.
+        """).tag(config=True)
     tidal_turbine_farms = Dict(trait=TidalTurbineFarmOptions(),
                                default_value={}, help='Dictionary mapping subdomain ids to the options of the corresponding farm')
     check_tracer_conservation = Bool(

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -617,6 +617,14 @@ class ModelOptions2d(CommonModelOptions):
 
         Used in bathymetry displacement function that ensures positive water depths. Unit is meters.
         """).tag(config=True)
+    use_automatic_wetting_and_drying_alpha = Bool(False, help=r"""
+        Toggle automatic computation of the alpha parameter used in wetting and drying schemes.
+
+        By default, this parameter is set to 0.5.
+
+        For problems whose bathymetry varies wildly in coastal regions, it is advisable to use the
+        automatic wetting and drying parameter, rather than the default.
+        """).tag(config=True)
     tidal_turbine_farms = Dict(trait=TidalTurbineFarmOptions(),
                                default_value={}, help='Dictionary mapping subdomain ids to the options of the corresponding farm')
     check_tracer_conservation = Bool(

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -625,8 +625,14 @@ class ModelOptions2d(CommonModelOptions):
         For problems whose bathymetry varies wildly in coastal regions, it is advisable to use the
         automatic wetting and drying parameter, rather than the default.
         """).tag(config=True)
+    wetting_and_drying_alpha_min = FiredrakeScalarExpression(
+        None, allow_none=True, help=r"""
+        Minimum value to be taken by wetting and drying parameter :math:`\alpha`.
+
+        Note this is only relevant if `use_automatic_wetting_and_drying_alpha` is set to ``True``.
+        """).tag(config=True)
     wetting_and_drying_alpha_max = FiredrakeScalarExpression(
-        Constant(2.0), help=r"""
+        Constant(2.0), allow_none=True, help=r"""
         Maximum value to be taken by wetting and drying parameter :math:`\alpha`.
 
         Note this is only relevant if `use_automatic_wetting_and_drying_alpha` is set to ``True``.

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -255,7 +255,7 @@ class FlowSolver2d(FrozenClass):
             self.options.sipg_parameter.assign(alpha)
             self.options.sipg_parameter_tracer.assign(alpha_tracer)
 
-    def set_wetting_and_drying_alpha(self, max_val=7.5):  # TODO: This value could be tweaked
+    def set_wetting_and_drying_alpha(self):
         r"""
         Compute a wetting and drying parameter :math:`\alpha` which ensures positive water
         depth using the approximate method suggested by Karna et al. (2011).
@@ -268,14 +268,16 @@ class FlowSolver2d(FrozenClass):
         where :math:`L_x` is the horizontal length scale of the mesh elements at the wet-dry
         front and :math:`h` is the bathymetry profile.
 
-        :kwarg max_val: maximum value at which to cap the alpha parameter.
+        NOTE: The maximum value at which to cap the alpha parameter may be specified via
+        :attr:`ModelOptions2d.wetting_and_drying_alpha_max`.
         """
         if not self.options.use_wetting_and_drying:
             return
         if self.options.use_automatic_wetting_and_drying_alpha:
             alpha = dot(get_cell_widths_2d(self.mesh2d), abs(grad(self.fields.bathymetry_2d)))
+            max_alpha = self.options.wetting_and_drying_alpha_max
             self.options.wetting_and_drying_alpha = Function(self.function_spaces.P0_2d)
-            self.options.wetting_and_drying_alpha.interpolate(min_value(max_val, alpha))
+            self.options.wetting_and_drying_alpha.interpolate(min_value(max_alpha, alpha))
 
             msg = "Using automatic wetting and drying parameter (min {:.2f} max {:.2f})"
             with self.options.wetting_and_drying_alpha.dat.vec_ro as v:

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -276,8 +276,8 @@ class FlowSolver2d(FrozenClass):
         if self.options.use_automatic_wetting_and_drying_alpha:
             alpha = dot(get_cell_widths_2d(self.mesh2d), abs(grad(self.fields.bathymetry_2d)))
             max_alpha = self.options.wetting_and_drying_alpha_max
-            self.options.wetting_and_drying_alpha = Function(self.function_spaces.P0_2d)
-            self.options.wetting_and_drying_alpha.interpolate(min_value(max_alpha, alpha))
+            self.options.wetting_and_drying_alpha = Function(self.function_spaces.P1_2d)
+            self.options.wetting_and_drying_alpha.project(min_value(max_alpha, alpha))
 
             msg = "Using automatic wetting and drying parameter (min {:.2f} max {:.2f})"
             with self.options.wetting_and_drying_alpha.dat.vec_ro as v:

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1250,6 +1250,7 @@ def get_cell_widths_2d(mesh2d):
                   widths[0] = fmax(widths[0], fabs(coords[2*i] - coords[(2*i+2)%6]));
                   widths[1] = fmax(widths[1], fabs(coords[2*i+1] - coords[(2*i+3)%6]));
                 }""", dx, {'coords': (mesh2d.coordinates, READ), 'widths': (cell_widths, RW)})
+    assert cell_widths.vector().gather().min() >= 0.0  # TODO: TEMPORARY
     return cell_widths
 
 

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1235,6 +1235,25 @@ def get_minimum_angles_2d(mesh2d):
     return min_angles
 
 
+def get_cell_widths_2d(mesh2d):
+    """
+    Compute widths of mesh elements in each coordinate direction as the maximum distance
+    between components of vertex coordinates.
+    """
+    try:
+        assert mesh2d.topological_dimension() == 2
+        assert mesh2d.ufl_cell() == ufl.triangle
+    except AssertionError:
+        raise NotImplementedError("Cell widths only currently implemented for triangles.")
+    cell_widths = Function(VectorFunctionSpace(mesh2d, "DG", 0)).assign(np.finfo(0.0).min)
+    par_loop("""for (int i=0; i<coords.dofs; i++) {
+                  widths[0] = fmax(widths[0], fabs(coords[2*i] - coords[(2*i+2)%6]));
+                  widths[1] = fmax(widths[1], fabs(coords[2*i+1] - coords[(2*i+3)%6]));
+                }""", dx, {'coords': (mesh2d.coordinates, READ), 'widths': (cell_widths, RW)})
+    return cell_widths
+
+
+# TODO: Could also consider maximum variation of nu in each coordinate direction
 def get_sipg_ratio(nu):
     """
     Compute the ratio between the maximum of `nu` and the minimum of `nu` in each element. If `nu`

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1253,7 +1253,6 @@ def get_cell_widths_2d(mesh2d):
     return cell_widths
 
 
-# TODO: Could also consider maximum variation of nu in each coordinate direction
 def get_sipg_ratio(nu):
     """
     Compute the ratio between the maximum of `nu` and the minimum of `nu` in each element. If `nu`


### PR DESCRIPTION
This PR allows the wetting and drying alpha parameter to be set automatically as a P1 field.

It follows the recommendation in [Karna et al. 2011]:
  \alpha \approx |L_x \nabla h|,
where L_x is the horizontal length scale of mesh elements at the wet-dry interface and h is the bathymetry.

An approximation is used here:
  element_width_x * abs(h_x) + element_width_y * abs(h_y).

The value may be capped using `options.wetting_and_drying_alpha_max`, which is set to 2 by default.