### PR TITLE
Reduce reference mesh refinement level for Rossby wave test

### DIFF
--- a/test/swe2d/test_rossby_wave.py
+++ b/test/swe2d/test_rossby_wave.py
@@ -251,6 +251,6 @@ def family(request):
 
 
 def test_convergence(stepper, family):
-    run_convergence([12, 24], timestepper_type=stepper,
+    run_convergence([24, 48], timestepper_type=stepper,
                     simulation_end_time=30.0, polynomial_degree=1, element_family=family,
                     no_exports=True, expansion_order=1)

--- a/test/swe2d/test_rossby_wave.py
+++ b/test/swe2d/test_rossby_wave.py
@@ -359,7 +359,7 @@ def family(request):
 
 
 def test_convergence(stepper, family):
-    run_convergence([12, 24], reference_refinement_level=768, timestepper_type=stepper,
+    run_convergence([12, 24], reference_refinement_level=96, timestepper_type=stepper,
                     simulation_end_time=30.0, polynomial_degree=1, element_family=family,
                     no_exports=True, expansion_order=1, model_comparison=False, overlap=1)
 


### PR DESCRIPTION
Running `test_rossby_wave.py` for just SSPRK33 and dg-dg uses
* ~1.75GB at the original reference_refinement_level=768
* ~273MB at the reduced reference_refinement_level=96
The test also runs a lot quicker at the lower refinement level.

Given that this test has recently caused Jenkins to crash, reducing unnecessarily high resolution would probably be a good idea.