### PR TITLE
Use new integrated firedrake adjoint

### DIFF
--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -12,16 +12,16 @@ the integral of the density. For more details, see:
   S.W. Funke, S.C. Kramer, and M.D. Piggott, "Design optimisation and resource assessment
   for tidal-stream renewable energy farms using a new continuous turbine approach",
   Renewable Energy 99 (2016), pp. 1046-1061, http://doi.org/10.1016/j.renene.2016.07.039
+
+The optimisation is performed using a gradient-based optimisation algorithm (L-BFGS-B)
+where the gradient is computed using the adjoint method. The adjoint is implemented, in
+firedrake, via the dolfin-adjoint approach (http://http://www.dolfin-adjoint.org) which annotates
+the forward model and automatically derives the adjoint.
 """
 
-# to enable a gradient-based optimisation using the adjoint to compute
-# gradients, we need to import from thetis_adjoint instead of thetis. This
-# ensure all firedrake operations in the Thetis model are annotated
-# automatically, in such a way that we can rerun the model with different input
-# parameters, and also derive the adjoint-based gradient of a specified input
-# (the functional) with respect to a specified input (the control)
-from thetis_adjoint import *
-from pyadjoint.optimization.optimization import minimise
+from thetis import *
+# this import automatically starts the annotation:
+from firedrake_adjoint import *
 import numpy
 op2.init(log_level=INFO)
 
@@ -169,6 +169,9 @@ callback_list = optimisation.OptimisationCallbackList([
     turbines.TurbineOptimisationCallback(solver_obj, cb),
 ])
 
+# anything that follows, is no longer annotated:
+pause_annotation()
+
 # this reduces the functional J(u, td) to a function purely of the control td:
 # rf(td) = J(u(td), td) where the velocities u(td) of the entire simulation
 # are computed by replaying the forward model for any provided turbine density td
@@ -187,6 +190,7 @@ if test_gradient:
     # values between 0 and 1 and choose a random direction dtd to vary it in
     td0 = Function(turbine_density)
     dtd = Function(turbine_density)
+    numpy.random.seed(42)  # set seed to make test deterministic
     td0.dat.data[:] = numpy.random.random(td0.dat.data.shape)
     dtd.dat.data[:] = numpy.random.random(dtd.dat.data.shape)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(name='thetis',
       author='Tuomas Karna',
       author_email='tuomas.karna@gmail.com',
       url='https://github.com/thetisproject/thetis',
-      packages=['thetis', 'test', 'examples',
-                'thetis_config', 'thetis_adjoint'],
+      packages=['thetis', 'test', 'examples'],
       scripts=glob('scripts/*'),
      )

--- a/test_adjoint/conftest.py
+++ b/test_adjoint/conftest.py
@@ -6,7 +6,7 @@ def pytest_runtest_teardown(item, nextitem):
     from firedrake.tsfc_interface import TSFCKernel
     from pyop2.op2 import Kernel
     from pyop2.base import JITModule
-    from firedrake_adjoint import get_working_tape
+    from pyadjoint import get_working_tape
 
     # disgusting hack, clear the Class-Cached objects in PyOP2 and
     # Firedrake, otherwise these will never be collected.  The Kernels

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -6,7 +6,9 @@ via firedrake_adjoint.
 Stephan Kramer 25-05-16
 """
 import pytest
-from thetis_adjoint import *
+from thetis import *
+from firedrake_adjoint import *
+
 op2.init(log_level=INFO)
 
 velocity_u = 2.0
@@ -50,7 +52,7 @@ def basic_setup():
     x0 = lx/2
     y0 = ly/2
     sigma = 20.0
-    drag_func.project(drag_center*exp(-((x[0]-x0)**2 + (x[1]-y0)**2)/sigma**2) + drag_bg, annotate=False)
+    drag_func.project(drag_center*exp(-((x[0]-x0)**2 + (x[1]-y0)**2)/sigma**2) + drag_bg)
     # assign fiction field
     options.quadratic_drag_coefficient = drag_func
 

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractproperty, abstractmethod
 import h5py
 from collections import defaultdict
 from .log import *
-from .firedrake import *
+from firedrake import *
 import numpy as np
 
 

--- a/thetis/configuration.py
+++ b/thetis/configuration.py
@@ -1,10 +1,10 @@
 """
 Utility function and extensions to traitlets used for specifying Thetis options
 """
-from .utility import FiredrakeConstant, FiredrakeFunction
 from ipython_genutils.text import indent, dedent
 from traitlets.config.configurable import Configurable
 from traitlets import *
+from firedrake import Constant, Function
 
 import ufl
 
@@ -143,7 +143,7 @@ class FiredrakeConstantTraitlet(TraitType):
     info_text = 'a Firedrake Constant'
 
     def validate(self, obj, value):
-        if isinstance(value, FiredrakeConstant):
+        if isinstance(value, Constant):
             return value
         self.error(obj, value)
 
@@ -156,12 +156,12 @@ class FiredrakeCoefficient(TraitType):
     info_text = 'a Firedrake Constant or Function'
 
     def validate(self, obj, value):
-        if isinstance(value, (FiredrakeConstant, FiredrakeFunction)):
+        if isinstance(value, (Constant, Function)):
             return value
         self.error(obj, value)
 
     def default_value_repr(self):
-        if isinstance(self.default_value, FiredrakeConstant):
+        if isinstance(self.default_value, Constant):
             return 'Constant({:})'.format(self.default_value.dat.data[0])
         return 'Function'
 
@@ -177,9 +177,9 @@ class FiredrakeScalarExpression(TraitType):
         self.error(obj, value)
 
     def default_value_repr(self):
-        if isinstance(self.default_value, FiredrakeConstant):
+        if isinstance(self.default_value, Constant):
             return 'Constant({:})'.format(self.default_value.dat.data[0])
-        if isinstance(self.default_value, FiredrakeFunction):
+        if isinstance(self.default_value, Function):
             return 'Function'
         return 'UFL scalar expression'
 
@@ -195,9 +195,9 @@ class FiredrakeVectorExpression(TraitType):
         self.error(obj, value)
 
     def default_value_repr(self):
-        if isinstance(self.default_value, FiredrakeConstant):
+        if isinstance(self.default_value, Constant):
             return 'Constant({:})'.format(self.default_value.dat.data[0])
-        if isinstance(self.default_value, FiredrakeFunction):
+        if isinstance(self.default_value, Function):
             return 'Function'
         return 'UFL vector expression'
 

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -247,7 +247,7 @@ class ExportManager(object):
         self.exporters = OrderedDict()
         for key in fields_to_export:
             field = self.functions.get(key)
-            if field is not None and isinstance(field, FiredrakeFunction):
+            if field is not None and isinstance(field, Function):
                 self.add_export(key, field, export_type,
                                 next_export_ix=next_export_ix)
 
@@ -284,7 +284,7 @@ class ExportManager(object):
         field = self.functions.get(fieldname)
         if preproc_func is not None:
             self.preproc_callbacks[fieldname] = preproc_func
-        if field is not None and isinstance(field, FiredrakeFunction):
+        if field is not None and isinstance(field, Function):
             native_space = field.function_space()
             visu_space = get_visu_space(native_space)
             coords_dg = self._get_dg_coordinates(visu_space)

--- a/thetis/firedrake.py
+++ b/thetis/firedrake.py
@@ -1,9 +1,0 @@
-# Import firedrake stuff here so that adjoint mode works
-from __future__ import absolute_import
-
-import thetis_config
-
-from firedrake import *  # NOQA
-
-if thetis_config.adjoint:
-    from firedrake_adjoint import *  # NOQA

--- a/thetis/limiter.py
+++ b/thetis/limiter.py
@@ -3,7 +3,7 @@ Slope limiters for discontinuous fields
 """
 from __future__ import absolute_import
 from .utility import *
-from .firedrake import VertexBasedLimiter
+from firedrake import VertexBasedLimiter
 import ufl
 from pyop2.profiling import timed_region, timed_function, timed_stage  # NOQA
 

--- a/thetis/optimisation.py
+++ b/thetis/optimisation.py
@@ -11,7 +11,7 @@ OptimisationCallbacks that (can) use controls, functional and derivative informa
 what is provided by the number of arguments: current control values are always in the last argument;
 if more than 2 arguments are provided, the first is the latest evaluated functional value.
 """
-from .firedrake import *
+from firedrake import *
 from .callback import DiagnosticCallback
 from .exporter import ExportManager
 import thetis.field_defs as field_defs

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -5,7 +5,7 @@ All options are type-checked and they are stored in traitlets Configurable
 objects.
 """
 from .configuration import *
-from .firedrake import Constant
+from firedrake import Constant
 
 
 class TimeStepperOptions(FrozenHasTraits):

--- a/thetis/physical_constants.py
+++ b/thetis/physical_constants.py
@@ -2,7 +2,7 @@
 Default values for physical constants and parameters
 """
 from __future__ import absolute_import
-from .firedrake import Constant
+from firedrake import Constant
 
 physical_constants = {
     'g_grav': Constant(9.81),      # gravitational acceleration

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -229,7 +229,7 @@ class FlowSolver(FrozenClass):
         :type u_scale: float or :class:`Constant`
         """
         u = u_scale
-        if isinstance(u_scale, FiredrakeConstant):
+        if isinstance(u_scale, Constant):
             u = u_scale.dat.data[0]
         min_dx = self.fields.h_elem_size_2d.dat.data.min()
         # alpha = 0.5 if self.options.element_family == 'rt-dg' else 1.0
@@ -251,7 +251,7 @@ class FlowSolver(FrozenClass):
         :type w_scale: float or :class:`Constant`
         """
         w = w_scale
-        if isinstance(w_scale, FiredrakeConstant):
+        if isinstance(w_scale, Constant):
             w = w_scale.dat.data[0]
         min_dz = self.fields.v_elem_size_2d.dat.data.min()
         # alpha = 0.5 if self.options.element_family == 'rt-dg' else 1.0
@@ -270,7 +270,7 @@ class FlowSolver(FrozenClass):
         where :math:`\nu_{scale}` is estimated diffusivity scale.
         """
         nu = nu_scale
-        if isinstance(nu_scale, FiredrakeConstant):
+        if isinstance(nu_scale, Constant):
             nu = nu_scale.dat.data[0]
         min_dx = self.fields.h_elem_size_2d.dat.data.min()
         factor = 2.0
@@ -596,17 +596,17 @@ class FlowSolver(FrozenClass):
             self.fields.baroc_head_3d = Function(self.function_spaces.H_bhead)
             self.fields.int_pg_3d = Function(self.function_spaces.U_int_pg, name='int_pg_3d')
         if self.options.coriolis_frequency is not None:
-            if isinstance(self.options.coriolis_frequency, FiredrakeConstant):
+            if isinstance(self.options.coriolis_frequency, Constant):
                 self.fields.coriolis_3d = self.options.coriolis_frequency
             else:
                 self.fields.coriolis_3d = Function(self.function_spaces.P1)
                 ExpandFunctionTo3d(self.options.coriolis_frequency, self.fields.coriolis_3d).solve()
         if self.options.wind_stress is not None:
-            if isinstance(self.options.wind_stress, FiredrakeFunction):
+            if isinstance(self.options.wind_stress, Function):
                 assert self.options.wind_stress.function_space().mesh().geometric_dimension() == 3, \
                     'wind stress field must be a 3D function'
                 self.fields.wind_stress_3d = self.options.wind_stress
-            elif isinstance(self.options.wind_stress, FiredrakeConstant):
+            elif isinstance(self.options.wind_stress, Constant):
                 self.fields.wind_stress_3d = self.options.wind_stress
             else:
                 raise Exception('Unsupported wind stress type: {:}'.format(type(self.options.wind_stress)))

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -96,10 +96,10 @@ class ForwardEuler(TimeIntegrator):
         self.fields_old = {}
         for k in sorted(self.fields):
             if self.fields[k] is not None:
-                if isinstance(self.fields[k], FiredrakeFunction):
+                if isinstance(self.fields[k], Function):
                     self.fields_old[k] = Function(
                         self.fields[k].function_space())
-                elif isinstance(self.fields[k], FiredrakeConstant):
+                elif isinstance(self.fields[k], Constant):
                     self.fields_old[k] = Constant(self.fields[k])
 
         u_old = self.solution_old
@@ -162,10 +162,10 @@ class CrankNicolson(TimeIntegrator):
         self.fields_old = {}
         for k in sorted(self.fields):
             if self.fields[k] is not None:
-                if isinstance(self.fields[k], FiredrakeFunction):
+                if isinstance(self.fields[k], Function):
                     self.fields_old[k] = Function(
                         self.fields[k].function_space(), name=self.fields[k].name()+'_old')
-                elif isinstance(self.fields[k], FiredrakeConstant):
+                elif isinstance(self.fields[k], Constant):
                     self.fields_old[k] = Constant(self.fields[k])
 
         u = self.solution
@@ -333,10 +333,10 @@ class PressureProjectionPicard(TimeIntegrator):
         self.fields_old = {}
         for k in sorted(self.fields):
             if self.fields[k] is not None:
-                if isinstance(self.fields[k], FiredrakeFunction):
+                if isinstance(self.fields[k], Function):
                     self.fields_old[k] = Function(
                         self.fields[k].function_space())
-                elif isinstance(self.fields[k], FiredrakeConstant):
+                elif isinstance(self.fields[k], Constant):
                     self.fields_old[k] = Constant(self.fields[k])
         # for the mom. eqn. the 'eta' field is just one of the 'other' fields
         fields_mom = self.fields.copy()

--- a/thetis/turbines.py
+++ b/thetis/turbines.py
@@ -1,7 +1,7 @@
 """
 Classes related to tidal turbine farms in Thetis.
 """
-from .firedrake import *
+from firedrake import *
 from .log import *
 from .callback import DiagnosticCallback
 from .optimisation import DiagnosticOptimisationCallback

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -2,7 +2,7 @@
 Utility functions and classes for 3D hydrostatic ocean model
 """
 from __future__ import absolute_import
-from .firedrake import *
+from firedrake import *
 import os
 import numpy as np
 import sys
@@ -14,9 +14,6 @@ import coffee.base as ast  # NOQA
 from collections import OrderedDict, namedtuple  # NOQA
 from .field_defs import field_metadata
 from .log import *
-from firedrake import Function as FiredrakeFunction
-from firedrake import Constant as FiredrakeConstant
-from firedrake import Expression as FiredrakeExpression
 from abc import ABCMeta, abstractmethod
 
 ds_surf = ds_t
@@ -86,7 +83,7 @@ class FieldDict(AttrDict):
     def _check_inputs(self, key, value):
         if key != '__dict__':
             from firedrake.functionspaceimpl import MixedFunctionSpace, WithGeometry
-            if not isinstance(value, (FiredrakeFunction, FiredrakeConstant)):
+            if not isinstance(value, (Function, Constant)):
                 raise TypeError('Value must be a Function or Constant object')
             fs = value.function_space()
             is_mixed = (isinstance(fs, MixedFunctionSpace)
@@ -99,7 +96,7 @@ class FieldDict(AttrDict):
 
     def _set_functionname(self, key, value):
         """Set function.name to key to ensure consistent naming"""
-        if isinstance(value, FiredrakeFunction):
+        if isinstance(value, Function):
             value.rename(name=key)
 
     def __setitem__(self, key, value):
@@ -235,7 +232,7 @@ def extrude_mesh_sigma(mesh2d, n_layers, bathymetry_2d, z_stretch_fact=1.0,
     new_coordinates = Function(fs_3d)
 
     z_stretch_func = Function(fs_2d)
-    if isinstance(z_stretch_fact, FiredrakeFunction):
+    if isinstance(z_stretch_fact, Function):
         assert z_stretch_fact.function_space() == fs_2d
         z_stretch_func = z_stretch_fact
     else:
@@ -539,9 +536,9 @@ class DensitySolver(object):
         self.fs = density.function_space()
         self.eos = eos_class
 
-        if isinstance(salinity, FiredrakeFunction):
+        if isinstance(salinity, Function):
             assert self.fs == salinity.function_space()
-        if isinstance(temperature, FiredrakeFunction):
+        if isinstance(temperature, Function):
             assert self.fs == temperature.function_space()
 
         self.s = salinity
@@ -550,10 +547,10 @@ class DensitySolver(object):
 
     def _get_array(self, function):
         """Returns numpy data array from a :class:`Function`"""
-        if isinstance(function, FiredrakeFunction):
+        if isinstance(function, Function):
             assert self.fs == function.function_space()
             return function.dat.data[:]
-        if isinstance(function, FiredrakeConstant):
+        if isinstance(function, Constant):
             return function.dat.data[0]
         # assume that function is a float
         return function
@@ -595,8 +592,8 @@ class DensitySolverWeak(object):
         self.fs = density.function_space()
         self.eos = eos_class
 
-        assert isinstance(salinity, (FiredrakeFunction, FiredrakeConstant))
-        assert isinstance(temperature, (FiredrakeFunction, FiredrakeConstant))
+        assert isinstance(salinity, (Function, Constant))
+        assert isinstance(temperature, (Function, Constant))
 
         self.s = salinity
         self.t = temperature
@@ -1027,8 +1024,8 @@ class SubdomainProjector(object):
     """Projector that projects the restriction of an expression to the specified subdomain."""
     def __init__(self, v, v_out, subdomain_id, solver_parameters=None, constant_jacobian=True):
 
-        if isinstance(v, FiredrakeExpression) or \
-           not isinstance(v, (ufl.core.expr.Expr, FiredrakeFunction)):
+        if isinstance(v, Expression) or \
+           not isinstance(v, (ufl.core.expr.Expr, Function)):
             raise ValueError("Can only project UFL expression or Functions not '%s'" % type(v))
 
         self.v = v

--- a/thetis_adjoint/__init__.py
+++ b/thetis_adjoint/__init__.py
@@ -1,4 +1,0 @@
-from __future__ import absolute_import
-import thetis_config
-thetis_config.adjoint = True
-from thetis import *

--- a/thetis_config/__init__.py
+++ b/thetis_config/__init__.py
@@ -1,2 +1,0 @@
-# Globally configurable options for thetis
-adjoint = False


### PR DESCRIPTION
This simplifies the code a lot as we no longer need a thetis_adjoint
thetis_config and a thetis/firedrake and no longer need to distinguish
between FiredrakeFunction (which was always the "real"
firedrake.Function and Function which was potentially the wrapped
firedrake_adjoint.Function).

Also removes a number of other workarounds (e.g. stop_annotation() around
split())