### PR TITLE
Timesteppers other than Crank-Nicolson for 2D tracer

### DIFF
--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -149,13 +149,15 @@ def run_convergence(**model_options):
     assert slope > 2, msg.format(slope)
 
 
-@pytest.fixture(params=[1, 2])
+@pytest.fixture(params=[1])
 def polynomial_degree(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
+@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'BackwardEuler', 'DIRK22', 'DIRK33'])
+def stepper(request):
+    return request.param
+
 @pytest.mark.parametrize(('diffusivity'),
                          [(Constant(0.1))])
 def test_horizontal_advection(polynomial_degree, stepper, diffusivity):

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -181,9 +181,12 @@ def polynomial_degree(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
-def test_horizontal_advection(polynomial_degree, stepper, ):
+@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33', 'DIRK22', 'DIRK33'])
+def stepper(request):
+    return request.param
+
+
+def test_horizontal_advection(polynomial_degree, stepper):
     run_convergence([1, 2, 3], polynomial_degree=polynomial_degree,
                     timestepper_type=stepper)
 

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -166,13 +166,17 @@ def auto_sipg(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper'),
-                         [('CrankNicolson')])
+@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'BackwardEuler', 'DIRK22', 'DIRK33'])
+def stepper(request):
+    return request.param
+
+
 def test_horizontal_diffusion(auto_sipg, stepper):
     run_convergence([1, 2, 3], polynomial_degree=1,
                     timestepper_type=stepper,
                     use_automatic_sipg_parameter=auto_sipg,
                     )
+
 # ---------------------------
 # run individual setup for debugging
 # ---------------------------

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -151,7 +151,8 @@ def run(setup, refinement, do_export=True, **options):
     solver_obj.options.horizontal_viscosity_scale = Constant(50.0)
     solver_obj.options.update(options)
     solver_obj.options.solve_tracer = True
-    solver_obj.options.timestepper_options.implicitness_theta = 1.0
+    if hasattr(solver_obj.options.timestepper_options, 'implicitness_theta'):
+        solver_obj.options.timestepper_options.implicitness_theta = 1.0
     solver_obj.create_function_spaces()
 
     # functions for source terms
@@ -253,7 +254,7 @@ def run_convergence(setup, ref_list, do_export=False, save_plot=False, **options
 # standard tests for pytest
 # ---------------------------
 
-@pytest.fixture(params=['CrankNicolson'])
+@pytest.fixture(params=['CrankNicolson', 'DIRK22', 'DIRK33', 'BackwardEuler'])
 def timestepper_type(request):
     return request.param
 

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -37,42 +37,13 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
 
         self._create_integrators()
 
-    def _create_swe_integrator(self):
-        """
-        Create time integrator for 2D system
-        """
-        self.timesteppers.swe2d = self.solver.get_swe_timestepper(self.swe_integrator)
-
-    def _create_tracer_integrator(self):
-        """
-        Create time integrator for tracer equation
-        """
-        solver = self.solver
-
-        if self.solver.options.solve_tracer:
-            uv, elev = self.fields.solution_2d.split()
-            fields = {'elev_2d': elev,
-                      'uv_2d': uv,
-                      'diffusivity_h': self.options.horizontal_diffusivity,
-                      'source': self.options.tracer_source_2d,
-                      'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
-                      'tracer_advective_velocity_factor': self.options.tracer_advective_velocity_factor,
-                      }
-            if issubclass(self.tracer_integrator, timeintegrator.CrankNicolson):
-                self.timesteppers.tracer = self.tracer_integrator(solver.eq_tracer, solver.fields.tracer_2d,
-                                                                  fields, solver.dt, bnd_conditions=solver.bnd_functions['tracer'],
-                                                                  solver_parameters=self.options.timestepper_options.solver_parameters_tracer,
-                                                                  semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
-                                                                  theta=self.options.timestepper_options.implicitness_theta)
-            else:
-                raise NotImplementedError("Tracer equation is currently only implemented for the CrankNicolson timestepper scheme")
-
     def _create_integrators(self):
         """
         Creates all time integrators with the correct arguments
         """
-        self._create_swe_integrator()
-        self._create_tracer_integrator()
+        self.timesteppers.swe2d = self.solver.get_swe_timestepper(self.swe_integrator)
+        if self.solver.options.solve_tracer:
+            self.timesteppers.tracer = self.solver.get_tracer_timestepper(self.tracer_integrator)
         self.cfl_coeff_2d = min(self.timesteppers.swe2d.cfl_coeff, self.timesteppers.tracer.cfl_coeff)
 
     def set_dt(self, dt):

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from .utility import *
 from . import timeintegrator
 from .log import *
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta
 
 
 class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
@@ -14,12 +14,10 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
     """
     __metaclass__ = ABCMeta
 
-    @abstractproperty
     def swe_integrator(self):
         """time integrator for the shallow water equations"""
         pass
 
-    @abstractproperty
     def tracer_integrator(self):
         """time integrator for the tracer equation"""
         pass
@@ -136,9 +134,11 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
             self.solver.tracer_limiter.apply(self.fields.tracer_2d)
 
 
-class CoupledCrankNicolson2D(CoupledTimeIntegrator2D):
-    swe_integrator = timeintegrator.CrankNicolson
-    tracer_integrator = timeintegrator.CrankNicolson
+class CoupledMatchingTimeIntegrator2D(CoupledTimeIntegrator2D):
+    def __init__(self, solver, integrator):
+        self.swe_integrator = integrator
+        self.tracer_integrator = integrator
+        super(CoupledMatchingTimeIntegrator2D, self).__init__(solver)
 
 
 class CoupledCrankEuler2D(CoupledTimeIntegrator2D):

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -41,32 +41,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
         """
         Create time integrator for 2D system
         """
-        solver = self.solver
-        fields = {
-            'linear_drag_coefficient': self.options.linear_drag_coefficient,
-            'quadratic_drag_coefficient': self.options.quadratic_drag_coefficient,
-            'manning_drag_coefficient': self.options.manning_drag_coefficient,
-            'viscosity_h': self.options.horizontal_viscosity,
-            'lax_friedrichs_velocity_scaling_factor': self.options.lax_friedrichs_velocity_scaling_factor,
-            'coriolis': self.options.coriolis_frequency,
-            'wind_stress': self.options.wind_stress,
-            'atmospheric_pressure': self.options.atmospheric_pressure,
-            'momentum_source': self.options.momentum_source_2d,
-            'volume_source': self.options.volume_source_2d, }
-
-        if issubclass(self.swe_integrator, timeintegrator.CrankNicolson):
-            self.timesteppers.swe2d = self.swe_integrator(
-                solver.eq_sw, self.fields.solution_2d,
-                fields, solver.dt,
-                bnd_conditions=solver.bnd_functions['shallow_water'],
-                solver_parameters=self.options.timestepper_options.solver_parameters,
-                semi_implicit=self.options.timestepper_options.use_semi_implicit_linearization,
-                theta=self.options.timestepper_options.implicitness_theta)
-        else:
-            self.timesteppers.swe2d = self.swe_integrator(solver.eq_sw, self.fields.solution_2d,
-                                                          fields, solver.dt,
-                                                          bnd_conditions=solver.bnd_functions['shallow_water'],
-                                                          solver_parameters=self.options.timestepper_options.solver_parameters)
+        self.timesteppers.swe2d = self.solver.get_swe_timestepper(self.swe_integrator)
 
     def _create_tracer_integrator(self):
         """

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -106,6 +106,10 @@ class ExplicitTimestepperOptions2d(ExplicitTimestepperOptions):
         'sub_pc_type': 'ilu',
         'mat_type': 'aij',
     }).tag(config=True)
+    solver_parameters_tracer = PETScSolverParameters({
+        'ksp_type': 'gmres',
+        'pc_type': 'sor',
+    }).tag(config=True)
 
 
 class ExplicitTimestepperOptions3d(ExplicitTimestepperOptions):

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -321,6 +321,59 @@ class FlowSolver2d(FrozenClass):
 
         self._isfrozen = True  # disallow creating new attributes
 
+    def get_swe_timestepper(self, integrator):
+        """
+        Gets timestepper object with appropriate parameters
+        """
+        fields = {
+            'linear_drag_coefficient': self.options.linear_drag_coefficient,
+            'quadratic_drag_coefficient': self.options.quadratic_drag_coefficient,
+            'manning_drag_coefficient': self.options.manning_drag_coefficient,
+            'viscosity_h': self.options.horizontal_viscosity,
+            'lax_friedrichs_velocity_scaling_factor': self.options.lax_friedrichs_velocity_scaling_factor,
+            'coriolis': self.options.coriolis_frequency,
+            'wind_stress': self.options.wind_stress,
+            'atmospheric_pressure': self.options.atmospheric_pressure,
+            'momentum_source': self.options.momentum_source_2d,
+            'volume_source': self.options.volume_source_2d,
+        }
+
+        args = (self.eq_sw, self.fields.solution_2d, fields, self.dt, )
+        kwargs = {
+            'bnd_conditions': self.bnd_functions['shallow_water'],
+            'solver_parameters': self.options.timestepper_options.solver_parameters,
+        }
+        if hasattr(self.options.timestepper_options, 'use_semi_implicit_linearization'):
+            kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
+        if hasattr(self.options.timestepper_options, 'implicitness_theta'):
+            kwargs['theta'] = self.options.timestepper_options.implicitness_theta
+        if self.options.timestepper_type == 'PressureProjectionPicard':
+            # TODO: Probably won't work in coupled mode
+            u_test = TestFunction(self.function_spaces.U_2d)
+            self.eq_mom = shallowwater_eq.ShallowWaterMomentumEquation(
+                u_test, self.function_spaces.U_2d, self.function_spaces.H_2d,
+                self.fields.bathymetry_2d,
+                options=self.options
+            )
+            self.eq_mom.bnd_functions = self.bnd_functions['shallow_water']
+            args = (self.eq_sw, self.eq_mom, self.fields.solution_2d, fields, self.dt, )
+            kwargs['solver_parameters'] = self.options.timestepper_options.solver_parameters_pressure
+            kwargs['solver_parameters_mom'] = self.options.timestepper_options.solver_parameters_momentum
+            kwargs['iterations'] = self.options.timestepper_options.picard_iterations
+        elif self.options.timestepper_type == 'SSPIMEX':
+            # TODO meaningful solver params
+            kwargs['solver_parameters'] = {
+                'ksp_type': 'gmres',
+                'pc_type': 'fieldsplit',
+                'pc_fieldsplit_type': 'multiplicative',
+            }
+            kwargs['solver_parameters_dirk'] = {
+                'ksp_type': 'gmres',
+                'pc_type': 'fieldsplit',
+                'pc_fieldsplit_type': 'multiplicative',
+            }
+        return integrator(*args, **kwargs)
+
     def create_timestepper(self):
         """
         Creates time stepper instance
@@ -336,22 +389,10 @@ class FlowSolver2d(FrozenClass):
             filehandler.setFormatter(logging.logging.Formatter('%(message)s'))
             output_logger.addHandler(filehandler)
 
-        # ----- Time integrators
-        fields = {
-            'linear_drag_coefficient': self.options.linear_drag_coefficient,
-            'quadratic_drag_coefficient': self.options.quadratic_drag_coefficient,
-            'manning_drag_coefficient': self.options.manning_drag_coefficient,
-            'viscosity_h': self.options.horizontal_viscosity,
-            'lax_friedrichs_velocity_scaling_factor': self.options.lax_friedrichs_velocity_scaling_factor,
-            'coriolis': self.options.coriolis_frequency,
-            'wind_stress': self.options.wind_stress,
-            'atmospheric_pressure': self.options.atmospheric_pressure,
-            'momentum_source': self.options.momentum_source_2d,
-            'volume_source': self.options.volume_source_2d,
-        }
         self.set_time_step()
 
-        steppers = {
+        # ----- Time integrators
+        self.steppers = {
             'SSPRK33': rungekutta.SSPRK33,
             'ForwardEuler': timeintegrator.ForwardEuler,
             'SteadyState': timeintegrator.SteadyState,
@@ -362,57 +403,20 @@ class FlowSolver2d(FrozenClass):
             'PressureProjectionPicard': timeintegrator.PressureProjectionPicard,
             'SSPIMEX': implicitexplicit.IMEXLPUM2,
         }
-        ts = self.options.timestepper_type
         try:
-            assert ts in steppers
+            assert self.options.timestepper_type in self.steppers
         except AssertionError:
-            raise Exception('Unknown time integrator type: {:s}'.format(ts))
-
+            raise Exception('Unknown time integrator type: {:s}'.format(self.options.timestepper_type))
         if self.options.solve_tracer:
             try:
-                assert ts == 'CrankNicolson'
+                assert self.options.timestepper_type == 'CrankNicolson'
             except AssertionError:
                 raise NotImplementedError("Tracer model currently only supports CrankNicolson time integration.")  # TODO
             self.timestepper = coupled_timeintegrator_2d.CoupledMatchingTimeIntegrator2D(
-                weakref.proxy(self), steppers[ts],
+                weakref.proxy(self), self.steppers[self.options.timestepper_type],
             )
         else:
-            args = (self.eq_sw, self.fields.solution_2d, fields, self.dt, )
-            kwargs = {
-                'bnd_conditions': self.bnd_functions['shallow_water'],
-                'solver_parameters': self.options.timestepper_options.solver_parameters,
-            }
-            if ts in ('BackwardEuler', 'DIRK22', 'DIRK33', 'CrankNicolson', 'PressureProjectionPicard'):
-                kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
-            if ts in ('CrankNicolson', 'PressureProjectionPicard'):
-                kwargs['theta'] = self.options.timestepper_options.implicitness_theta
-            if ts == 'PressureProjectionPicard':
-
-                u_test = TestFunction(self.function_spaces.U_2d)
-                self.eq_mom = shallowwater_eq.ShallowWaterMomentumEquation(
-                    u_test, self.function_spaces.U_2d, self.function_spaces.H_2d,
-                    self.fields.bathymetry_2d,
-                    options=self.options
-                )
-                self.eq_mom.bnd_functions = self.bnd_functions['shallow_water']
-                args = (self.eq_sw, self.eq_mom, self.fields.solution_2d, fields, self.dt, )
-                kwargs['solver_parameters'] = self.options.timestepper_options.solver_parameters_pressure
-                kwargs['solver_parameters_mom'] = self.options.timestepper_options.solver_parameters_momentum
-                kwargs['iterations'] = self.options.timestepper_options.picard_iterations
-
-            elif ts == 'SSPIMEX':
-                # TODO meaningful solver params
-                kwargs['solver_parameters'] = {
-                    'ksp_type': 'gmres',
-                    'pc_type': 'fieldsplit',
-                    'pc_fieldsplit_type': 'multiplicative',
-                }
-                kwargs['solver_parameters_dirk'] = {
-                    'ksp_type': 'gmres',
-                    'pc_type': 'fieldsplit',
-                    'pc_fieldsplit_type': 'multiplicative',
-                }
-            self.timestepper = steppers[ts](*args, **kwargs)
+            self.timestepper = self.get_swe_timestepper(self.steppers[self.options.timestepper_type])
         print_output('Using time integrator: {:}'.format(self.timestepper.__class__.__name__))
         self._isfrozen = True  # disallow creating new attributes
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -433,9 +433,9 @@ class FlowSolver2d(FrozenClass):
             raise Exception('Unknown time integrator type: {:s}'.format(self.options.timestepper_type))
         if self.options.solve_tracer:
             try:
-                assert self.options.timestepper_type not in ('PressureProjectionPicard', 'SSPIMEX')
+                assert self.options.timestepper_type not in ('PressureProjectionPicard', 'SSPIMEX', 'SteadyState')
             except AssertionError:
-                raise NotImplementedError("2D tracer model currently only supports SSPRK33, ForwardEuler, SteadyState, BackwardEuler, DIRK22, DIRK33 and CrankNicolson time integrators.")
+                raise NotImplementedError("2D tracer model currently only supports SSPRK33, ForwardEuler, BackwardEuler, DIRK22, DIRK33 and CrankNicolson time integrators.")
             self.timestepper = coupled_timeintegrator_2d.CoupledMatchingTimeIntegrator2D(
                 weakref.proxy(self), steppers[self.options.timestepper_type],
             )

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -339,10 +339,7 @@ class FlowSolver2d(FrozenClass):
         }
 
         args = (self.eq_sw, self.fields.solution_2d, fields, self.dt, )
-        kwargs = {
-            'bnd_conditions': self.bnd_functions['shallow_water'],
-            'solver_parameters': self.options.timestepper_options.solver_parameters,
-        }
+        kwargs = {'bnd_conditions': self.bnd_functions['shallow_water']}
         if hasattr(self.options.timestepper_options, 'use_semi_implicit_linearization'):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
         if hasattr(self.options.timestepper_options, 'implicitness_theta'):
@@ -352,7 +349,7 @@ class FlowSolver2d(FrozenClass):
             u_test = TestFunction(self.function_spaces.U_2d)
             self.eq_mom = shallowwater_eq.ShallowWaterMomentumEquation(
                 u_test, self.function_spaces.U_2d, self.function_spaces.H_2d,
-                self.fields.bathymetry_2d,
+                self.depth,
                 options=self.options
             )
             self.eq_mom.bnd_functions = self.bnd_functions['shallow_water']
@@ -372,6 +369,8 @@ class FlowSolver2d(FrozenClass):
                 'pc_type': 'fieldsplit',
                 'pc_fieldsplit_type': 'multiplicative',
             }
+        else:
+            kwargs['solver_parameters'] = self.options.timestepper_options.solver_parameters
         return integrator(*args, **kwargs)
 
     def get_tracer_timestepper(self, integrator):


### PR DESCRIPTION
Currently the 2D tracer equation only supports `'CrankNicolson'` timestepping. This PR is a rewrite of PR #197 which attempted to extend to five other schemes, but involved quite a bit of code duplication.

The updated version reduces duplication and provides a `CoupledMatchingTimeIntegrator2D` class which implies matching integrators for both shallow water and tracer solvers. The following additional schemes are considered: ForwardEuler, BackwardEuler, DIRK22, DIRK33, SSPRK33.

Statuses of 2D tracer tests following these changes:
* `test_h-advection_mes_2d.py`: all pass except BackwardEuler
* `test_h-diffusion_2d.py`: all pass
* `test_bcs_2d.py`: all pass
* `test_consistency_2d.py`: all pass if overshoot tol loosened from `1e-12` to `1e-11` and conservation tol loosened from `1e-4` to `1.2e-4`.
* `test_steady_adv-diff_mms_2d.py`: all pass except ForwardEuler and SSPRK33