### PR TITLE
Update accumulator callback

### DIFF
--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -558,6 +558,30 @@ class AccumulatorCallback(DiagnosticCallback):
         return '{:s} value {:11.4e}'.format(self.name, args[0])
 
 
+class TimeIntegralCallback(AccumulatorCallback):
+    # TODO: doc
+    name = 'time integral'
+    variable_names = ['value']
+
+    def __init__(self, spatial_integral, solver_obj, timestepper, **kwargs):
+        """
+        :arg spatial_integral: Python function that returns an integral in space only
+        :arg solver_obj: Thetis solver object
+        :arg timestepper: Thetis timeintegrator object
+        :arg kwargs: any additional keyword arguments, see DiagnosticCallback
+        """
+
+        def time_integral_callback():  # FIXME: Generalise
+            dt = timestepper.dt
+            solution_old = timestepper.solution_old
+            solution = timestepper.solution
+            time_integral = 0.5*dt*spatial_integral(solution_old)
+            time_integral += 0.5*dt*spatial_integral(solution)
+            return time_integral
+
+        super(TimeIntegralCallback, self).__init__(time_integral_callback, solver_obj, **kwargs)
+
+
 class TimeSeriesCallback2D(DiagnosticCallback):
     """
     Extract a time series of a 2D field at a given (x,y) location

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -632,7 +632,13 @@ class TimeIntegralCallback(AccumulatorCallback):
 
         def time_integral_callback():
             """Time integrate spatial integral over a single timestep"""
-            return dt*sum(weights[i]*spatial_integral(updates[i]) for i in range(num_weights))
+            integral = 0
+            for i in range(num_weights):
+                stored = i == 0 and hasattr(self, 'previous_update')
+                update_integral = self.previous_update if stored else spatial_integral(updates[i])
+                integral += weights[i]*update_integral
+            self.previous_update = update_integral
+            return dt*integral
 
         super(TimeIntegralCallback, self).__init__(time_integral_callback, solver_obj, **kwargs)
 

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -48,6 +48,8 @@ class CallbackManager(defaultdict):
         :arg str mode: register callback under this mode
         """
         key = callback.name
+        if isinstance(callback, TimeIntegralCallback):
+            assert mode == 'timestep'
         self[mode][key] = callback
 
     def evaluate(self, mode, index=None):
@@ -525,7 +527,7 @@ class DetectorsCallback(DiagnosticCallback):
 
 class AccumulatorCallback(DiagnosticCallback):
     """
-    Callback that performs sums values of time-dependent functionals
+    Callback that sums values of time-dependent functionals
     contributed at each timestep.
 
     This callback can also be used to express time-dependent objective
@@ -560,7 +562,6 @@ class AccumulatorCallback(DiagnosticCallback):
         return '{:s} value {:11.4e}'.format(self.name, args[0])
 
 
-# TODO: Enforce 'timestep' rather than 'export'
 class TimeIntegralCallback(AccumulatorCallback):
     """
     Callback that evaluates time-dependent functionals on a single timestep using the appropriate


### PR DESCRIPTION
As it currently stands, `AccumulatorCallback` time integrates a user-provided scalar callback using the trapezium rule. If the timestepper is `'CrankNicolson'` with theta being a half then this is the right thing to do. In other cases, it would be better to use the quadrature routine which matches the timestepper.

In this PR, the original `AccumulatorCallback` becomes a more general tool for summing quantities evaluated at each timestep (or export). A new callback. `TimeIntegratorCallback`, is introduced which does the quadrature for most currently implemented timesteppers.