### PR TITLE
Use 2D Functions in 3D equations

### DIFF
--- a/examples/baroclinic_channel/baroclinic_channel.py
+++ b/examples/baroclinic_channel/baroclinic_channel.py
@@ -167,7 +167,7 @@ def compute_2d_baroc_head(solver_obj, output):
         tmp_3d,
         bottom_to_top=True,
         average=True,
-        elevation=solver_obj.fields.elev_cg_3d,
+        elevation=solver_obj.fields.elev_cg_2d.view_3d,
         bathymetry=solver_obj.fields.bathymetry_2d.view_3d)
     bhead_surf_extract_op = SubFunctionExtractor(
         tmp_3d,

--- a/examples/baroclinic_channel/baroclinic_channel.py
+++ b/examples/baroclinic_channel/baroclinic_channel.py
@@ -168,7 +168,7 @@ def compute_2d_baroc_head(solver_obj, output):
         bottom_to_top=True,
         average=True,
         elevation=solver_obj.fields.elev_cg_3d,
-        bathymetry=solver_obj.fields.bathymetry_3d)
+        bathymetry=solver_obj.fields.bathymetry_2d.view_3d)
     bhead_surf_extract_op = SubFunctionExtractor(
         tmp_3d,
         output,

--- a/examples/baroclinic_eddies/baroclinic_eddies.py
+++ b/examples/baroclinic_eddies/baroclinic_eddies.py
@@ -222,7 +222,7 @@ def run_problem(reso_dx=10.0, poly_order=1, element_family='dg-dg',
             tmp_3d,
             bottom_to_top=True,
             average=True,
-            elevation=solver_obj.fields.elev_cg_3d,
+            elevation=solver_obj.fields.elev_cg_2d.view_3d,
             bathymetry=solver_obj.fields.bathymetry_2d.view_3d)
         bhead_surf_extract_op = SubFunctionExtractor(
             tmp_3d,

--- a/examples/baroclinic_eddies/baroclinic_eddies.py
+++ b/examples/baroclinic_eddies/baroclinic_eddies.py
@@ -223,7 +223,7 @@ def run_problem(reso_dx=10.0, poly_order=1, element_family='dg-dg',
             bottom_to_top=True,
             average=True,
             elevation=solver_obj.fields.elev_cg_3d,
-            bathymetry=solver_obj.fields.bathymetry_3d)
+            bathymetry=solver_obj.fields.bathymetry_2d.view_3d)
         bhead_surf_extract_op = SubFunctionExtractor(
             tmp_3d,
             output,

--- a/examples/bottomFriction/steadyChannel.py
+++ b/examples/bottomFriction/steadyChannel.py
@@ -76,7 +76,7 @@ def bottom_friction_test(layers=25, gls_closure='k-omega',
     options.timestep = dt
     options.simulation_end_time = t_end
     options.horizontal_velocity_scale = Constant(u_mag)
-    options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
+    options.fields_to_export = ['uv_2d', 'elev_2d', 'uv_3d',
                                 'uv_dav_2d',
                                 'eddy_visc_3d', 'shear_freq_3d',
                                 'tke_3d', 'psi_3d', 'eps_3d', 'len_3d', ]

--- a/examples/channel3d/channel3d.py
+++ b/examples/channel3d/channel3d.py
@@ -56,7 +56,7 @@ options.output_directory = outputdir
 options.horizontal_velocity_scale = Constant(u_max)
 options.vertical_velocity_scale = Constant(w_max)
 options.check_salinity_overshoot = True
-options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
+options.fields_to_export = ['uv_2d', 'elev_2d', 'uv_3d',
                             'w_3d', 'w_mesh_3d', 'salt_3d',
                             'uv_dav_2d']
 

--- a/examples/channel3d/channel3d_closed.py
+++ b/examples/channel3d/channel3d_closed.py
@@ -63,7 +63,7 @@ options.check_volume_conservation_2d = True
 options.check_volume_conservation_3d = True
 options.check_salinity_conservation = True
 options.check_salinity_overshoot = True
-options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
+options.fields_to_export = ['uv_2d', 'elev_2d', 'uv_3d',
                             'w_3d', 'w_mesh_3d', 'salt_3d',
                             'uv_dav_2d']
 

--- a/examples/columbia_plume/cre-plume.py
+++ b/examples/columbia_plume/cre-plume.py
@@ -250,7 +250,7 @@ ramp_t = 12*3600.
 elev_ramp = conditional(le(bnd_time, ramp_t), bnd_time/ramp_t, 1.0)
 bnd_elev_expr_2d = elev_ramp*(elev_tide_2d + elev_bnd_2d)
 depth_2d = solver_obj.fields.bathymetry_2d + solver_obj.fields.elev_cg_2d
-depth_3d = solver_obj.fields.bathymetry_3d + solver_obj.fields.elev_cg_3d
+depth_3d = solver_obj.fields.bathymetry_3d + solver_obj.fields.elev_cg_2d.view_3d
 tide_uv_expr_2d = elev_ramp*UV_tide_2d/depth_2d
 tide_uv_expr_3d = elev_ramp*UV_tide_3d/depth_3d
 
@@ -391,7 +391,7 @@ uv_bnd_averager = VerticalIntegrator(uv_bnd_3d,
                                      bnd_value=Constant((0.0, 0.0, 0.0)),
                                      average=True,
                                      bathymetry=solver_obj.fields.bathymetry_3d,
-                                     elevation=solver_obj.fields.elev_cg_3d)
+                                     elevation=solver_obj.fields.elev_cg_2d.view_3d)
 extract_uv_bnd = SubFunctionExtractor(uv_bnd_dav_3d, uv_bnd_2d)
 copy_uv_bnd_dav_to_3d = ExpandFunctionTo3d(uv_bnd_2d, uv_bnd_dav_3d)
 copy_uv_tide_to_3d = ExpandFunctionTo3d(UV_tide_2d, UV_tide_3d)
@@ -414,7 +414,7 @@ bnd_rho_integrator = VerticalIntegrator(density_bnd_3d,
                                         bottom_to_top=False,
                                         average=False,
                                         bathymetry=solver_obj.fields.bathymetry_3d,
-                                        elevation=solver_obj.fields.elev_cg_3d)
+                                        elevation=solver_obj.fields.elev_cg_2d.view_3d)
 
 
 def compute_bnd_baroclinicity():

--- a/examples/dome/dome.py
+++ b/examples/dome/dome.py
@@ -179,7 +179,7 @@ def compute_depth_av_inflow(uv_inflow_3d, uv_inflow_2d):
                                          bnd_value=Constant((0.0, 0.0, 0.0)),
                                          average=True,
                                          bathymetry=solver_obj.fields.bathymetry_2d.view_3d,
-                                         elevation=solver_obj.fields.elev_cg_3d)
+                                         elevation=solver_obj.fields.elev_cg_2d.view_3d)
     inflow_extract = SubFunctionExtractor(tmp_inflow_3d,
                                           uv_inflow_2d,
                                           boundary='top', elem_facet='top')

--- a/examples/dome/dome.py
+++ b/examples/dome/dome.py
@@ -178,7 +178,7 @@ def compute_depth_av_inflow(uv_inflow_3d, uv_inflow_2d):
                                          bottom_to_top=True,
                                          bnd_value=Constant((0.0, 0.0, 0.0)),
                                          average=True,
-                                         bathymetry=solver_obj.fields.bathymetry_3d,
+                                         bathymetry=solver_obj.fields.bathymetry_2d.view_3d,
                                          elevation=solver_obj.fields.elev_cg_3d)
     inflow_extract = SubFunctionExtractor(tmp_inflow_3d,
                                           uv_inflow_2d,

--- a/examples/katophillips/katophillips.py
+++ b/examples/katophillips/katophillips.py
@@ -94,7 +94,7 @@ def katophillips_test(layers=25, gls_closure='k-omega',
     options.output_directory = outputdir
     options.horizontal_velocity_scale = Constant(u_mag)
     options.check_salinity_overshoot = False
-    options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
+    options.fields_to_export = ['uv_2d', 'elev_2d', 'uv_3d',
                                 'w_3d', 'w_mesh_3d', 'salt_3d',
                                 'baroc_head_3d', 'uv_dav_2d', 'eddy_visc_3d',
                                 'shear_freq_3d', 'buoy_freq_3d',

--- a/examples/tracerBox/tracerBox3d.py
+++ b/examples/tracerBox/tracerBox3d.py
@@ -95,7 +95,7 @@ options.check_salinity_overshoot = True
 options.check_temperature_conservation = True
 options.check_temperature_overshoot = True
 options.output_directory = outputdir
-options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
+options.fields_to_export = ['uv_2d', 'elev_2d', 'uv_3d',
                             'w_3d', 'w_mesh_3d', 'salt_3d', 'temp_3d',
                             'uv_dav_2d']
 

--- a/examples/waveEq3d/channel3d_waveEq.py
+++ b/examples/waveEq3d/channel3d_waveEq.py
@@ -59,10 +59,10 @@ options.simulation_end_time = t_end
 options.horizontal_velocity_scale = u_mag
 options.check_volume_conservation_2d = True
 options.check_volume_conservation_3d = True
-options.fields_to_export = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
+options.fields_to_export = ['uv_2d', 'elev_2d', 'uv_3d',
                             'w_3d', 'w_mesh_3d', 'salt_3d',
                             'uv_dav_2d']
-options.fields_to_export_hdf5 = ['uv_2d', 'elev_2d', 'elev_3d', 'uv_3d',
+options.fields_to_export_hdf5 = ['uv_2d', 'elev_2d', 'uv_3d',
                                  'w_3d', 'salt_3d']
 
 # need to call creator to create the function spaces

--- a/test/pressure_grad/test_int_pg_mes.py
+++ b/test/pressure_grad/test_int_pg_mes.py
@@ -94,11 +94,11 @@ def compute_l2_error(refinement=1, quadratic=False, no_exports=True):
     fields = FieldDict()
     fields.baroc_head_3d = baroc_head_3d
     fields.int_pg_3d = int_pg_3d
-    fields.bathymetry_3d = bathymetry_3d
     options = None
     bnd_functions = {}
     int_pg_solver = InternalPressureGradientCalculator(
         fields,
+        bathymetry_3d,
         options,
         bnd_functions,
         solver_parameters=None)

--- a/test/pressure_grad/test_pg-stack_mes.py
+++ b/test/pressure_grad/test_pg-stack_mes.py
@@ -130,11 +130,11 @@ def compute_l2_error(refinement=1, quadratic_pressure=False, quadratic_density=F
     fields = FieldDict()
     fields.baroc_head_3d = baroc_head_3d
     fields.int_pg_3d = int_pg_3d
-    fields.bathymetry_3d = bathymetry_3d
     options = None
     bnd_functions = {}
     int_pg_solver = InternalPressureGradientCalculator(
         fields,
+        bathymetry_3d,
         options,
         bnd_functions,
         solver_parameters=None)

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -27,7 +27,7 @@ class CoupledTimeIntegratorBase(timeintegrator.TimeIntegratorBase):
     def _update_3d_elevation(self):
         """Projects elevation to 3D"""
         with timed_stage('aux_elev_3d'):
-            self.solver.copy_elev_to_3d.solve()  # at t_{n+1}
+            self.solver.fields.elev_3d.source.assign(self.solver.fields.elev_2d)
 
     def _update_vertical_velocity(self):
         """Solve vertical velocity"""
@@ -500,7 +500,7 @@ class CoupledLeapFrogAM3(CoupledTimeIntegrator):
         # set 3D elevation to half step
         gamma = self.timesteppers.mom_expl.gamma
         self.elev_old_3d.assign(self.fields.elev_3d)
-        self.solver.copy_elev_to_3d.solve()
+        self.solver.fields.elev_3d.source.assign(self.solver.fields.elev_2d)
         self.fields.elev_3d *= (0.5 + 2*gamma)
         self.fields.elev_3d += (0.5 - 2*gamma)*self.elev_old_3d
 

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -629,14 +629,8 @@ class CoupledTwoStageRK(CoupledTimeIntegrator):
             else:
                 # compute w_mesh at surface as (2*elev^{n+1} - elev^{(1)} - elev^{n})/dt
                 w_s = (2*current_elev - self.elev_fields[1] - self.elev_fields[0])/self.solver.dt
-            self.fields.w_mesh_surf_2d.assign(w_s)
-            # use that to compute w_mesh in whole domain
-            self.solver.mesh_updater.cp_w_mesh_surf_2d_to_3d.solve()
-            # solve w_mesh at nodes
-            w_mesh_surf = self.fields.w_mesh_surf_3d.dat.data[:]
-            z_ref = self.fields.z_coord_ref_3d.dat.data[:]
-            h = self.fields.bathymetry_3d.dat.data[:]
-            self.fields.w_mesh_3d.dat.data[:] = w_mesh_surf * (z_ref + h)/h
+            self.solver.mesh_updater.compute_mesh_velocity_finalize(
+                w_mesh_surf_expr=w_s)
 
     def advance(self, t, update_forcings=None, update_forcings3d=None):
         """

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -211,7 +211,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
         solver = self.solver
         impl_v_visc, expl_v_visc, impl_v_diff, expl_v_diff = self._get_vert_diffusivity_functions()
 
-        fields = {'eta': self.fields.elev_domain_3d,  # FIXME rename elev
+        fields = {'eta': self.fields.elev_domain_2d.view_3d,  # FIXME rename elev
                   'int_pg': self.fields.get('int_pg_3d'),
                   'uv_depth_av': self.fields.get('uv_dav_3d'),
                   'w': self.fields.w_3d,
@@ -254,7 +254,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
         impl_v_visc, expl_v_visc, impl_v_diff, expl_v_diff = self._get_vert_diffusivity_functions()
 
         if self.solver.options.solve_salinity:
-            fields = {'elev_3d': self.fields.elev_domain_3d,
+            fields = {'elev_3d': self.fields.elev_domain_2d.view_3d,
                       'uv_3d': self.fields.uv_3d,
                       'uv_depth_av': self.fields.get('uv_dav_3d'),
                       'w': self.fields.w_3d,
@@ -271,7 +271,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                 bnd_conditions=solver.bnd_functions['salt'],
                 solver_parameters=self.options.timestepper_options.solver_parameters_tracer_explicit)
             if self.solver.options.use_implicit_vertical_diffusion:
-                fields = {'elev_3d': self.fields.elev_domain_3d,
+                fields = {'elev_3d': self.fields.elev_domain_2d.view_3d,
                           'diffusivity_v': impl_v_diff,
                           }
                 self.timesteppers.salt_impl = self.integrator_vert_3d(
@@ -287,7 +287,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
         impl_v_visc, expl_v_visc, impl_v_diff, expl_v_diff = self._get_vert_diffusivity_functions()
 
         if self.solver.options.solve_temperature:
-            fields = {'elev_3d': self.fields.elev_domain_3d,
+            fields = {'elev_3d': self.fields.elev_domain_2d.view_3d,
                       'uv_3d': self.fields.uv_3d,
                       'uv_depth_av': self.fields.get('uv_dav_3d'),
                       'w': self.fields.w_3d,
@@ -304,7 +304,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                 bnd_conditions=solver.bnd_functions['temp'],
                 solver_parameters=self.options.timestepper_options.solver_parameters_tracer_explicit)
             if self.solver.options.use_implicit_vertical_diffusion:
-                fields = {'elev_3d': self.fields.elev_domain_3d,
+                fields = {'elev_3d': self.fields.elev_domain_2d.view_3d,
                           'diffusivity_v': impl_v_diff,
                           }
                 self.timesteppers.temp_impl = self.integrator_vert_3d(
@@ -340,7 +340,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                 eq_psi_diff, solver.fields.psi_3d, fields, solver.dt,
                 solver_parameters=self.options.timestepper_options.solver_parameters_tracer_implicit)
             if eq_tke_adv is not None and eq_psi_adv is not None:
-                fields = {'elev_3d': self.fields.elev_domain_3d,
+                fields = {'elev_3d': self.fields.elev_domain_2d.view_3d,
                           'uv_3d': self.fields.uv_3d,
                           'uv_depth_av': self.fields.get('uv_dav_3d'),
                           'w': self.fields.w_3d,
@@ -434,7 +434,7 @@ class CoupledLeapFrogAM3(CoupledTimeIntegrator):
 
     def __init__(self, solver):
         super(CoupledLeapFrogAM3, self).__init__(solver)
-        self.elev_old_3d = Function(self.fields.elev_domain_3d)
+        self.elev_domain_old_2d = Function(self.fields.elev_domain_2d)
         self.uv_old_2d = Function(self.fields.uv_2d)
         self.uv_new_2d = Function(self.fields.uv_2d)
 
@@ -499,10 +499,10 @@ class CoupledLeapFrogAM3(CoupledTimeIntegrator):
 
         # set 3D elevation to half step
         gamma = self.timesteppers.mom_expl.gamma
-        self.elev_old_3d.assign(self.fields.elev_domain_3d)
-        self.solver.fields.elev_domain_3d.source.assign(self.solver.fields.elev_2d)
-        self.fields.elev_domain_3d *= (0.5 + 2*gamma)
-        self.fields.elev_domain_3d += (0.5 - 2*gamma)*self.elev_old_3d
+        self.elev_domain_old_2d.assign(self.fields.elev_domain_2d)
+        self.solver.fields.elev_domain_2d.assign(self.solver.fields.elev_2d)
+        self.fields.elev_domain_2d *= (0.5 + 2*gamma)
+        self.fields.elev_domain_2d += (0.5 - 2*gamma)*self.elev_domain_old_2d
 
         # correct uv_3d to uv_2d at t_{n+1/2}
         self.fields.uv_2d *= (0.5 + 2*gamma)

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -95,9 +95,6 @@ class CoupledTimeIntegratorBase(timeintegrator.TimeIntegratorBase):
         Computes Smagorinsky viscosity etc fields
         """
         with timed_stage('aux_stability'):
-            self.solver.uv_mag_solver.solve()
-            # update P1 velocity field
-            self.solver.uv_p1_projector.project()
             if self.options.use_smagorinsky_viscosity:
                 self.solver.smagorinsky_diff_solver.solve()
 
@@ -219,8 +216,6 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                   'viscosity_v': expl_v_visc,
                   'viscosity_h': self.solver.tot_h_visc.get_sum(),
                   'source': self.options.momentum_source_3d,
-                  # uv_mag': self.fields.uv_mag_3d,
-                  'uv_p1': self.fields.get('uv_p1_3d'),
                   'lax_friedrichs_velocity_scaling_factor': self.options.lax_friedrichs_velocity_scaling_factor,
                   'coriolis': self.fields.get('coriolis_3d'),
                   }
@@ -262,8 +257,6 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                       'diffusivity_h': self.solver.tot_h_diff.get_sum(),
                       'diffusivity_v': expl_v_diff,
                       'source': self.options.salinity_source_3d,
-                      # uv_mag': self.fields.uv_mag_3d,
-                      'uv_p1': self.fields.get('uv_p1_3d'),
                       'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
                       }
             self.timesteppers.salt_expl = self.integrator_3d(
@@ -295,8 +288,6 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                       'diffusivity_h': self.solver.tot_h_diff.get_sum(),
                       'diffusivity_v': expl_v_diff,
                       'source': self.options.temperature_source_3d,
-                      # uv_mag': self.fields.uv_mag_3d,
-                      'uv_p1': self.fields.get('uv_p1_3d'),
                       'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
                       }
             self.timesteppers.temp_expl = self.integrator_3d(
@@ -345,8 +336,6 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                           'uv_depth_av': self.fields.get('uv_dav_3d'),
                           'w': self.fields.w_3d,
                           'w_mesh': self.fields.get('w_mesh_3d'),
-                          # uv_mag': self.fields.uv_mag_3d,
-                          'uv_p1': self.fields.get('uv_p1_3d'),
                           'lax_friedrichs_tracer_scaling_factor': self.options.lax_friedrichs_tracer_scaling_factor,
                           }
                 self.timesteppers.tke_expl = self.integrator_3d(

--- a/thetis/coupled_timeintegrator.py
+++ b/thetis/coupled_timeintegrator.py
@@ -27,7 +27,7 @@ class CoupledTimeIntegratorBase(timeintegrator.TimeIntegratorBase):
     def _update_3d_elevation(self):
         """Projects elevation to 3D"""
         with timed_stage('aux_elev_3d'):
-            self.solver.fields.elev_3d.source.assign(self.solver.fields.elev_2d)
+            self.solver.fields.elev_domain_2d.assign(self.solver.fields.elev_2d)
 
     def _update_vertical_velocity(self):
         """Solve vertical velocity"""
@@ -211,7 +211,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
         solver = self.solver
         impl_v_visc, expl_v_visc, impl_v_diff, expl_v_diff = self._get_vert_diffusivity_functions()
 
-        fields = {'eta': self.fields.elev_3d,  # FIXME rename elev
+        fields = {'eta': self.fields.elev_domain_3d,  # FIXME rename elev
                   'int_pg': self.fields.get('int_pg_3d'),
                   'uv_depth_av': self.fields.get('uv_dav_3d'),
                   'w': self.fields.w_3d,
@@ -254,7 +254,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
         impl_v_visc, expl_v_visc, impl_v_diff, expl_v_diff = self._get_vert_diffusivity_functions()
 
         if self.solver.options.solve_salinity:
-            fields = {'elev_3d': self.fields.elev_3d,
+            fields = {'elev_3d': self.fields.elev_domain_3d,
                       'uv_3d': self.fields.uv_3d,
                       'uv_depth_av': self.fields.get('uv_dav_3d'),
                       'w': self.fields.w_3d,
@@ -271,7 +271,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                 bnd_conditions=solver.bnd_functions['salt'],
                 solver_parameters=self.options.timestepper_options.solver_parameters_tracer_explicit)
             if self.solver.options.use_implicit_vertical_diffusion:
-                fields = {'elev_3d': self.fields.elev_3d,
+                fields = {'elev_3d': self.fields.elev_domain_3d,
                           'diffusivity_v': impl_v_diff,
                           }
                 self.timesteppers.salt_impl = self.integrator_vert_3d(
@@ -287,7 +287,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
         impl_v_visc, expl_v_visc, impl_v_diff, expl_v_diff = self._get_vert_diffusivity_functions()
 
         if self.solver.options.solve_temperature:
-            fields = {'elev_3d': self.fields.elev_3d,
+            fields = {'elev_3d': self.fields.elev_domain_3d,
                       'uv_3d': self.fields.uv_3d,
                       'uv_depth_av': self.fields.get('uv_dav_3d'),
                       'w': self.fields.w_3d,
@@ -304,7 +304,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                 bnd_conditions=solver.bnd_functions['temp'],
                 solver_parameters=self.options.timestepper_options.solver_parameters_tracer_explicit)
             if self.solver.options.use_implicit_vertical_diffusion:
-                fields = {'elev_3d': self.fields.elev_3d,
+                fields = {'elev_3d': self.fields.elev_domain_3d,
                           'diffusivity_v': impl_v_diff,
                           }
                 self.timesteppers.temp_impl = self.integrator_vert_3d(
@@ -340,7 +340,7 @@ class CoupledTimeIntegrator(CoupledTimeIntegratorBase):
                 eq_psi_diff, solver.fields.psi_3d, fields, solver.dt,
                 solver_parameters=self.options.timestepper_options.solver_parameters_tracer_implicit)
             if eq_tke_adv is not None and eq_psi_adv is not None:
-                fields = {'elev_3d': self.fields.elev_3d,
+                fields = {'elev_3d': self.fields.elev_domain_3d,
                           'uv_3d': self.fields.uv_3d,
                           'uv_depth_av': self.fields.get('uv_dav_3d'),
                           'w': self.fields.w_3d,
@@ -434,7 +434,7 @@ class CoupledLeapFrogAM3(CoupledTimeIntegrator):
 
     def __init__(self, solver):
         super(CoupledLeapFrogAM3, self).__init__(solver)
-        self.elev_old_3d = Function(self.fields.elev_3d)
+        self.elev_old_3d = Function(self.fields.elev_domain_3d)
         self.uv_old_2d = Function(self.fields.uv_2d)
         self.uv_new_2d = Function(self.fields.uv_2d)
 
@@ -499,10 +499,10 @@ class CoupledLeapFrogAM3(CoupledTimeIntegrator):
 
         # set 3D elevation to half step
         gamma = self.timesteppers.mom_expl.gamma
-        self.elev_old_3d.assign(self.fields.elev_3d)
-        self.solver.fields.elev_3d.source.assign(self.solver.fields.elev_2d)
-        self.fields.elev_3d *= (0.5 + 2*gamma)
-        self.fields.elev_3d += (0.5 - 2*gamma)*self.elev_old_3d
+        self.elev_old_3d.assign(self.fields.elev_domain_3d)
+        self.solver.fields.elev_domain_3d.source.assign(self.solver.fields.elev_2d)
+        self.fields.elev_domain_3d *= (0.5 + 2*gamma)
+        self.fields.elev_domain_3d += (0.5 - 2*gamma)*self.elev_old_3d
 
         # correct uv_3d to uv_2d at t_{n+1/2}
         self.fields.uv_2d *= (0.5 + 2*gamma)

--- a/thetis/field_defs.py
+++ b/thetis/field_defs.py
@@ -88,12 +88,6 @@ field_metadata['elev_domain_2d'] = {
     'unit': 'm',
     'filename': 'ElevationDomain2d',
 }
-field_metadata['elev_domain_3d'] = {
-    'name': 'Surface elevation of domain',
-    'shortname': 'Elevation',
-    'unit': 'm',
-    'filename': 'ElevationDomain3d',
-}
 field_metadata['elev_cg_3d'] = {
     'name': 'Water elevation CG',
     'shortname': 'Elevation',

--- a/thetis/field_defs.py
+++ b/thetis/field_defs.py
@@ -82,11 +82,17 @@ field_metadata['elev_2d'] = {
     'unit': 'm',
     'filename': 'Elevation2d',
 }
-field_metadata['elev_3d'] = {
-    'name': 'Water elevation',
+field_metadata['elev_domain_2d'] = {
+    'name': 'Surface elevation of domain',
     'shortname': 'Elevation',
     'unit': 'm',
-    'filename': 'Elevation3d',
+    'filename': 'ElevationDomain2d',
+}
+field_metadata['elev_domain_3d'] = {
+    'name': 'Surface elevation of domain',
+    'shortname': 'Elevation',
+    'unit': 'm',
+    'filename': 'ElevationDomain3d',
 }
 field_metadata['elev_cg_3d'] = {
     'name': 'Water elevation CG',

--- a/thetis/field_defs.py
+++ b/thetis/field_defs.py
@@ -64,18 +64,6 @@ field_metadata['uv_dav_3d'] = {
     'unit': 'm s-1',
     'filename': 'DAVelocity3d',
 }
-field_metadata['uv_mag_3d'] = {
-    'name': 'Magnitude of horizontal velocity',
-    'shortname': 'Velocity magnitude',
-    'unit': 'm s-1',
-    'filename': 'VeloMag3d',
-}
-field_metadata['uv_p1_3d'] = {
-    'name': 'P1 projection of horizontal velocity',
-    'shortname': 'P1 Velocity',
-    'unit': 'm s-1',
-    'filename': 'VeloCG3d',
-}
 field_metadata['elev_2d'] = {
     'name': 'Water elevation',
     'shortname': 'Elevation',

--- a/thetis/field_defs.py
+++ b/thetis/field_defs.py
@@ -22,12 +22,6 @@ field_metadata['bathymetry_2d'] = {
     'unit': 'm',
     'filename': 'bathymetry2d',
 }
-field_metadata['bathymetry_3d'] = {
-    'name': 'Bathymetry',
-    'shortname': 'Bathymetry',
-    'unit': 'm',
-    'filename': 'bathymetry3d',
-}
 field_metadata['z_coord_3d'] = {
     'name': 'Mesh z coordinates',
     'shortname': 'Z coordinates',

--- a/thetis/field_defs.py
+++ b/thetis/field_defs.py
@@ -88,12 +88,6 @@ field_metadata['elev_domain_2d'] = {
     'unit': 'm',
     'filename': 'ElevationDomain2d',
 }
-field_metadata['elev_cg_3d'] = {
-    'name': 'Water elevation CG',
-    'shortname': 'Elevation',
-    'unit': 'm',
-    'filename': 'ElevationCG3d',
-}
 field_metadata['elev_cg_2d'] = {
     'name': 'Water elevation CG',
     'shortname': 'Elevation',

--- a/thetis/field_defs.py
+++ b/thetis/field_defs.py
@@ -124,18 +124,6 @@ field_metadata['w_mesh_3d'] = {
     'unit': 'm s-1',
     'filename': 'MeshVelo3d',
 }
-field_metadata['w_mesh_surf_3d'] = {
-    'name': 'Surface mesh velocity',
-    'shortname': 'Surface mesh velocity',
-    'unit': 'm s-1',
-    'filename': 'SurfMeshVelo3d',
-}
-field_metadata['w_mesh_surf_2d'] = {
-    'name': 'Surface mesh velocity',
-    'shortname': 'Surface mesh velocity',
-    'unit': 'm s-1',
-    'filename': 'SurfMeshVelo3d',
-}
 field_metadata['salt_3d'] = {
     'name': 'Water salinity',
     'shortname': 'Salinity',

--- a/thetis/momentum_eq.py
+++ b/thetis/momentum_eq.py
@@ -179,8 +179,6 @@ class HorizontalAdvectionTerm(MomentumTerm):
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         if not self.use_nonlinear_equations:
             return 0
-        uv_p1 = fields_old.get('uv_p1')
-        uv_mag = fields_old.get('uv_mag')
         lax_friedrichs_factor = fields_old.get('lax_friedrichs_velocity_scaling_factor')
 
         uv_depth_av = fields_old.get('uv_depth_av')
@@ -207,13 +205,7 @@ class HorizontalAdvectionTerm(MomentumTerm):
                   + uv_up[1]*uv_av[1]*jump(self.test[1], self.normal[1]))*(self.dS_v + self.dS_h)
             # Lax-Friedrichs stabilization
             if self.use_lax_friedrichs:
-                if uv_p1 is not None:
-                    gamma = 0.5*abs((avg(uv_p1)[0]*self.normal('-')[0]
-                                     + avg(uv_p1)[1]*self.normal('-')[1]))*lax_friedrichs_factor
-                elif uv_mag is not None:
-                    gamma = 0.5*avg(uv_mag)*lax_friedrichs_factor
-                else:
-                    raise Exception('either uv_p1 or uv_mag must be given')
+                gamma = 0.5*abs(un_av)*lax_friedrichs_factor
                 f += gamma*(jump(self.test[0])*jump(uv[0])
                             + jump(self.test[1])*jump(uv[1]))*(self.dS_v + self.dS_h)
             for bnd_marker in self.boundary_markers:

--- a/thetis/momentum_eq.py
+++ b/thetis/momentum_eq.py
@@ -627,7 +627,7 @@ class InternalPressureGradientCalculator(MomentumTerm):
     .. note ::
         Due to the :class:`Term` sign convention this term is assembled on the right-hand-side.
     """
-    def __init__(self, fields, options, bnd_functions, solver_parameters=None):
+    def __init__(self, fields, bathymetry, options, bnd_functions, solver_parameters=None):
         """
         :arg solver: `class`FlowSolver` object
         :kwarg dict solver_parameters: PETSc solver options
@@ -637,7 +637,6 @@ class InternalPressureGradientCalculator(MomentumTerm):
         self.fields = fields
         self.options = options
         function_space = self.fields.int_pg_3d.function_space()
-        bathymetry = self.fields.bathymetry_3d
         super(InternalPressureGradientCalculator, self).__init__(
             function_space, bathymetry=bathymetry)
 

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -570,7 +570,7 @@ class FlowSolver(FrozenClass):
         self.fields.elev_cg_3d = ExtrudedFunction(self.fields.elev_cg_2d, self.mesh)
         self.fields.uv_3d = Function(self.function_spaces.U)
         self.fields.bathymetry_2d = Function(coord_fs_2d)
-        self.fields.bathymetry_3d = Function(coord_fs)
+        self.bathymetry_3d = ExtrudedFunction(self.fields.bathymetry_2d, self.mesh)
         # z coordinate in the strecthed mesh
         self.fields.z_coord_3d = Function(coord_fs)
         # z coordinate in the reference mesh (eta=0)
@@ -710,7 +710,7 @@ class FlowSolver(FrozenClass):
 
         expl_bottom_friction = self.options.use_bottom_friction and not self.options.use_implicit_vertical_diffusion
         self.eq_momentum = momentum_eq.MomentumEquation(self.fields.uv_3d.function_space(),
-                                                        bathymetry=self.fields.bathymetry_3d,
+                                                        bathymetry=self.bathymetry_3d,
                                                         v_elem_size=self.fields.v_elem_size_3d,
                                                         h_elem_size=self.fields.h_elem_size_3d,
                                                         use_nonlinear_equations=self.options.use_nonlinear_equations,
@@ -720,7 +720,7 @@ class FlowSolver(FrozenClass):
                                                         sipg_parameter_vertical=self.options.sipg_parameter_vertical)
         if self.options.use_implicit_vertical_diffusion:
             self.eq_vertmomentum = momentum_eq.MomentumEquation(self.fields.uv_3d.function_space(),
-                                                                bathymetry=self.fields.bathymetry_3d,
+                                                                bathymetry=self.bathymetry_3d,
                                                                 v_elem_size=self.fields.v_elem_size_3d,
                                                                 h_elem_size=self.fields.h_elem_size_3d,
                                                                 use_nonlinear_equations=False,
@@ -730,7 +730,7 @@ class FlowSolver(FrozenClass):
                                                                 sipg_parameter_vertical=self.options.sipg_parameter_vertical)
         if self.options.solve_salinity:
             self.eq_salt = tracer_eq.TracerEquation(self.fields.salt_3d.function_space(),
-                                                    bathymetry=self.fields.bathymetry_3d,
+                                                    bathymetry=self.bathymetry_3d,
                                                     v_elem_size=self.fields.v_elem_size_3d,
                                                     h_elem_size=self.fields.h_elem_size_3d,
                                                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -739,7 +739,7 @@ class FlowSolver(FrozenClass):
                                                     sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
             if self.options.use_implicit_vertical_diffusion:
                 self.eq_salt_vdff = tracer_eq.TracerEquation(self.fields.salt_3d.function_space(),
-                                                             bathymetry=self.fields.bathymetry_3d,
+                                                             bathymetry=self.bathymetry_3d,
                                                              v_elem_size=self.fields.v_elem_size_3d,
                                                              h_elem_size=self.fields.h_elem_size_3d,
                                                              use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -748,7 +748,7 @@ class FlowSolver(FrozenClass):
 
         if self.options.solve_temperature:
             self.eq_temp = tracer_eq.TracerEquation(self.fields.temp_3d.function_space(),
-                                                    bathymetry=self.fields.bathymetry_3d,
+                                                    bathymetry=self.bathymetry_3d,
                                                     v_elem_size=self.fields.v_elem_size_3d,
                                                     h_elem_size=self.fields.h_elem_size_3d,
                                                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -757,7 +757,7 @@ class FlowSolver(FrozenClass):
                                                     sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
             if self.options.use_implicit_vertical_diffusion:
                 self.eq_temp_vdff = tracer_eq.TracerEquation(self.fields.temp_3d.function_space(),
-                                                             bathymetry=self.fields.bathymetry_3d,
+                                                             bathymetry=self.bathymetry_3d,
                                                              v_elem_size=self.fields.v_elem_size_3d,
                                                              h_elem_size=self.fields.h_elem_size_3d,
                                                              use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -774,14 +774,14 @@ class FlowSolver(FrozenClass):
             if self.options.use_turbulence_advection:
                 # explicit advection equations
                 self.eq_tke_adv = tracer_eq.TracerEquation(self.fields.tke_3d.function_space(),
-                                                           bathymetry=self.fields.bathymetry_3d,
+                                                           bathymetry=self.bathymetry_3d,
                                                            v_elem_size=self.fields.v_elem_size_3d,
                                                            h_elem_size=self.fields.h_elem_size_3d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
                                                            sipg_parameter=self.options.sipg_parameter_turb,
                                                            sipg_parameter_vertical=self.options.sipg_parameter_vertical_turb)
                 self.eq_psi_adv = tracer_eq.TracerEquation(self.fields.psi_3d.function_space(),
-                                                           bathymetry=self.fields.bathymetry_3d,
+                                                           bathymetry=self.bathymetry_3d,
                                                            v_elem_size=self.fields.v_elem_size_3d,
                                                            h_elem_size=self.fields.h_elem_size_3d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -790,12 +790,12 @@ class FlowSolver(FrozenClass):
             # implicit vertical diffusion eqn with production terms
             self.eq_tke_diff = turbulence.TKEEquation(self.fields.tke_3d.function_space(),
                                                       self.turbulence_model,
-                                                      bathymetry=self.fields.bathymetry_3d,
+                                                      bathymetry=self.bathymetry_3d,
                                                       v_elem_size=self.fields.v_elem_size_3d,
                                                       h_elem_size=self.fields.h_elem_size_3d)
             self.eq_psi_diff = turbulence.PsiEquation(self.fields.psi_3d.function_space(),
                                                       self.turbulence_model,
-                                                      bathymetry=self.fields.bathymetry_3d,
+                                                      bathymetry=self.bathymetry_3d,
                                                       v_elem_size=self.fields.v_elem_size_3d,
                                                       h_elem_size=self.fields.h_elem_size_3d)
 
@@ -832,14 +832,14 @@ class FlowSolver(FrozenClass):
         tot_uv_3d = self.fields.uv_3d + self.fields.uv_dav_3d
         self.w_solver = VerticalVelocitySolver(self.fields.w_3d,
                                                tot_uv_3d,
-                                               self.fields.bathymetry_3d,
+                                               self.bathymetry_3d,
                                                self.eq_momentum.bnd_functions)
         self.uv_averager = VerticalIntegrator(self.fields.uv_3d,
                                               self.fields.uv_dav_3d,
                                               bottom_to_top=True,
                                               bnd_value=Constant((0.0, 0.0, 0.0)),
                                               average=True,
-                                              bathymetry=self.fields.bathymetry_3d,
+                                              bathymetry=self.bathymetry_3d,
                                               elevation=self.fields.elev_cg_3d)
         if self.options.use_baroclinic_formulation:
             if self.options.solve_salinity:
@@ -869,10 +869,10 @@ class FlowSolver(FrozenClass):
                                                      self.fields.baroc_head_3d,
                                                      bottom_to_top=False,
                                                      average=False,
-                                                     bathymetry=self.fields.bathymetry_3d,
+                                                     bathymetry=self.bathymetry_3d,
                                                      elevation=self.fields.elev_cg_3d)
             self.int_pg_calculator = momentum_eq.InternalPressureGradientCalculator(
-                self.fields, self.options,
+                self.fields, self.bathymetry_3d, self.options,
                 self.bnd_functions['momentum'],
                 solver_parameters=self.options.timestepper_options.solver_parameters_momentum_explicit)
         self.extract_surf_dav_uv = SubFunctionExtractor(self.fields.uv_dav_3d,
@@ -895,7 +895,6 @@ class FlowSolver(FrozenClass):
 
         # ----- set initial values
         self.fields.bathymetry_2d.project(self.bathymetry_cg_2d)
-        ExpandFunctionTo3d(self.fields.bathymetry_2d, self.fields.bathymetry_3d).solve()
         self.mesh_updater.initialize()
         self.compute_mesh_stats()
         self.set_time_step()

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -584,8 +584,6 @@ class FlowSolver(FrozenClass):
         self.fields.hcc_metric_3d = Function(self.function_spaces.P1DG, name='mesh consistency')
         if self.options.use_ale_moving_mesh:
             self.fields.w_mesh_3d = Function(coord_fs)
-            self.fields.w_mesh_surf_3d = Function(coord_fs)
-            self.fields.w_mesh_surf_2d = Function(coord_fs_2d)
         if self.options.solve_salinity:
             self.fields.salt_3d = Function(self.function_spaces.H, name='Salinity')
         if self.options.solve_temperature:

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -563,8 +563,9 @@ class FlowSolver(FrozenClass):
         uv_2d, eta2d = self.fields.solution_2d.split()
         self.fields.uv_2d = uv_2d
         self.fields.elev_2d = eta2d
-        elev_3d_source = Function(self.function_spaces.H_2d)
-        self.fields.elev_3d = ExtrudedFunction(elev_3d_source, self.mesh)
+        # elevation field seen by the 3D mode, different from elev_2d
+        self.fields.elev_domain_2d = Function(self.function_spaces.H_2d)
+        self.fields.elev_domain_3d = ExtrudedFunction(self.fields.elev_domain_2d, self.mesh)
         self.fields.elev_cg_2d = Function(coord_fs_2d)
         # FIXME elev_cg_3d can potentially be removed
         self.fields.elev_cg_3d = ExtrudedFunction(self.fields.elev_cg_2d, self.mesh)
@@ -1113,8 +1114,7 @@ class FlowSolver(FrozenClass):
         """
 
         field_list = [
-            'elev_2d', 'uv_2d', 'elev_cg_2d',
-            'elev_3d', 'uv_3d',
+            'elev_2d', 'uv_2d', 'elev_domain_2d', 'elev_cg_2d', 'uv_3d',
             'w_3d', 'uv_dav_3d', 'w_mesh_3d',
             'salt_3d', 'temp_3d', 'density_3d',
             'baroc_head_3d', 'int_pg_3d',

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -564,14 +564,14 @@ class FlowSolver(FrozenClass):
         self.fields.uv_2d = uv_2d
         self.fields.elev_2d = eta2d
         # elevation field seen by the 3D mode, different from elev_2d
-        self.fields.elev_domain_2d = Function(self.function_spaces.H_2d)
-        self.fields.elev_domain_3d = ExtrudedFunction(self.fields.elev_domain_2d, self.mesh)
-        self.fields.elev_cg_2d = Function(coord_fs_2d)
+        self.fields.elev_domain_2d = ExtrudedFunction(self.function_spaces.H_2d, mesh_3d=self.mesh)
+        self.fields.elev_domain_3d = self.fields.elev_domain_2d.view_3d
+        self.fields.elev_cg_2d = ExtrudedFunction(coord_fs_2d, mesh_3d=self.mesh)
         # FIXME elev_cg_3d can potentially be removed
-        self.fields.elev_cg_3d = ExtrudedFunction(self.fields.elev_cg_2d, self.mesh)
+        self.fields.elev_cg_3d = self.fields.elev_cg_2d.view_3d
         self.fields.uv_3d = Function(self.function_spaces.U)
-        self.fields.bathymetry_2d = Function(coord_fs_2d)
-        self.bathymetry_3d = ExtrudedFunction(self.fields.bathymetry_2d, self.mesh)
+        self.fields.bathymetry_2d = ExtrudedFunction(coord_fs_2d, mesh_3d=self.mesh)
+        self.bathymetry_3d = self.fields.bathymetry_2d.view_3d
         # z coordinate in the strecthed mesh
         self.fields.z_coord_3d = Function(coord_fs)
         # z coordinate in the reference mesh (eta=0)
@@ -600,7 +600,8 @@ class FlowSolver(FrozenClass):
             if isinstance(self.options.coriolis_frequency, Constant):
                 self.fields.coriolis_3d = self.options.coriolis_frequency
             else:
-                self.fields.coriolis_3d = utility.ExtrudedFunction(self.options.coriolis_frequency, self.mesh)
+
+                self.fields.coriolis_3d = extend_function_to_3d(self.options.coriolis_frequency, self.mesh)
         if self.options.wind_stress is not None:
             if isinstance(self.options.wind_stress, Function):
                 assert self.options.wind_stress.function_space().mesh().geometric_dimension() == 3, \

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -885,7 +885,7 @@ class FlowSolver(FrozenClass):
             self.smagorinsky_diff_solver = SmagorinskyViscosity(self.fields.uv_3d, self.fields.smag_visc_3d,
                                                                 self.options.smagorinsky_coefficient, self.fields.h_elem_size_3d,
                                                                 self.fields.max_h_diff,
-                                                                weak_form=self.options.polynomial_degree == 0)
+                                                                weak_form=True)
 
         # ----- set initial values
         self.fields.bathymetry_2d.project(self.bathymetry_cg_2d)

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -570,7 +570,6 @@ class FlowSolver(FrozenClass):
         self.fields.elev_cg_3d = self.fields.elev_cg_2d.view_3d
         self.fields.uv_3d = Function(self.function_spaces.U)
         self.fields.bathymetry_2d = ExtrudedFunction(coord_fs_2d, mesh_3d=self.mesh)
-        self.bathymetry_3d = self.fields.bathymetry_2d.view_3d
         # z coordinate in the strecthed mesh
         self.fields.z_coord_3d = Function(coord_fs)
         # z coordinate in the reference mesh (eta=0)
@@ -711,7 +710,7 @@ class FlowSolver(FrozenClass):
 
         expl_bottom_friction = self.options.use_bottom_friction and not self.options.use_implicit_vertical_diffusion
         self.eq_momentum = momentum_eq.MomentumEquation(self.fields.uv_3d.function_space(),
-                                                        bathymetry=self.bathymetry_3d,
+                                                        bathymetry=self.fields.bathymetry_2d.view_3d,
                                                         v_elem_size=self.fields.v_elem_size_3d,
                                                         h_elem_size=self.fields.h_elem_size_3d,
                                                         use_nonlinear_equations=self.options.use_nonlinear_equations,
@@ -721,7 +720,7 @@ class FlowSolver(FrozenClass):
                                                         sipg_parameter_vertical=self.options.sipg_parameter_vertical)
         if self.options.use_implicit_vertical_diffusion:
             self.eq_vertmomentum = momentum_eq.MomentumEquation(self.fields.uv_3d.function_space(),
-                                                                bathymetry=self.bathymetry_3d,
+                                                                bathymetry=self.fields.bathymetry_2d.view_3d,
                                                                 v_elem_size=self.fields.v_elem_size_3d,
                                                                 h_elem_size=self.fields.h_elem_size_3d,
                                                                 use_nonlinear_equations=False,
@@ -731,7 +730,7 @@ class FlowSolver(FrozenClass):
                                                                 sipg_parameter_vertical=self.options.sipg_parameter_vertical)
         if self.options.solve_salinity:
             self.eq_salt = tracer_eq.TracerEquation(self.fields.salt_3d.function_space(),
-                                                    bathymetry=self.bathymetry_3d,
+                                                    bathymetry=self.fields.bathymetry_2d.view_3d,
                                                     v_elem_size=self.fields.v_elem_size_3d,
                                                     h_elem_size=self.fields.h_elem_size_3d,
                                                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -740,7 +739,7 @@ class FlowSolver(FrozenClass):
                                                     sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
             if self.options.use_implicit_vertical_diffusion:
                 self.eq_salt_vdff = tracer_eq.TracerEquation(self.fields.salt_3d.function_space(),
-                                                             bathymetry=self.bathymetry_3d,
+                                                             bathymetry=self.fields.bathymetry_2d.view_3d,
                                                              v_elem_size=self.fields.v_elem_size_3d,
                                                              h_elem_size=self.fields.h_elem_size_3d,
                                                              use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -749,7 +748,7 @@ class FlowSolver(FrozenClass):
 
         if self.options.solve_temperature:
             self.eq_temp = tracer_eq.TracerEquation(self.fields.temp_3d.function_space(),
-                                                    bathymetry=self.bathymetry_3d,
+                                                    bathymetry=self.fields.bathymetry_2d.view_3d,
                                                     v_elem_size=self.fields.v_elem_size_3d,
                                                     h_elem_size=self.fields.h_elem_size_3d,
                                                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -758,7 +757,7 @@ class FlowSolver(FrozenClass):
                                                     sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
             if self.options.use_implicit_vertical_diffusion:
                 self.eq_temp_vdff = tracer_eq.TracerEquation(self.fields.temp_3d.function_space(),
-                                                             bathymetry=self.bathymetry_3d,
+                                                             bathymetry=self.fields.bathymetry_2d.view_3d,
                                                              v_elem_size=self.fields.v_elem_size_3d,
                                                              h_elem_size=self.fields.h_elem_size_3d,
                                                              use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -775,14 +774,14 @@ class FlowSolver(FrozenClass):
             if self.options.use_turbulence_advection:
                 # explicit advection equations
                 self.eq_tke_adv = tracer_eq.TracerEquation(self.fields.tke_3d.function_space(),
-                                                           bathymetry=self.bathymetry_3d,
+                                                           bathymetry=self.fields.bathymetry_2d.view_3d,
                                                            v_elem_size=self.fields.v_elem_size_3d,
                                                            h_elem_size=self.fields.h_elem_size_3d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
                                                            sipg_parameter=self.options.sipg_parameter_turb,
                                                            sipg_parameter_vertical=self.options.sipg_parameter_vertical_turb)
                 self.eq_psi_adv = tracer_eq.TracerEquation(self.fields.psi_3d.function_space(),
-                                                           bathymetry=self.bathymetry_3d,
+                                                           bathymetry=self.fields.bathymetry_2d.view_3d,
                                                            v_elem_size=self.fields.v_elem_size_3d,
                                                            h_elem_size=self.fields.h_elem_size_3d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
@@ -791,12 +790,12 @@ class FlowSolver(FrozenClass):
             # implicit vertical diffusion eqn with production terms
             self.eq_tke_diff = turbulence.TKEEquation(self.fields.tke_3d.function_space(),
                                                       self.turbulence_model,
-                                                      bathymetry=self.bathymetry_3d,
+                                                      bathymetry=self.fields.bathymetry_2d.view_3d,
                                                       v_elem_size=self.fields.v_elem_size_3d,
                                                       h_elem_size=self.fields.h_elem_size_3d)
             self.eq_psi_diff = turbulence.PsiEquation(self.fields.psi_3d.function_space(),
                                                       self.turbulence_model,
-                                                      bathymetry=self.bathymetry_3d,
+                                                      bathymetry=self.fields.bathymetry_2d.view_3d,
                                                       v_elem_size=self.fields.v_elem_size_3d,
                                                       h_elem_size=self.fields.h_elem_size_3d)
 
@@ -833,14 +832,14 @@ class FlowSolver(FrozenClass):
         tot_uv_3d = self.fields.uv_3d + self.fields.uv_dav_3d
         self.w_solver = VerticalVelocitySolver(self.fields.w_3d,
                                                tot_uv_3d,
-                                               self.bathymetry_3d,
+                                               self.fields.bathymetry_2d.view_3d,
                                                self.eq_momentum.bnd_functions)
         self.uv_averager = VerticalIntegrator(self.fields.uv_3d,
                                               self.fields.uv_dav_3d,
                                               bottom_to_top=True,
                                               bnd_value=Constant((0.0, 0.0, 0.0)),
                                               average=True,
-                                              bathymetry=self.bathymetry_3d,
+                                              bathymetry=self.fields.bathymetry_2d.view_3d,
                                               elevation=self.fields.elev_cg_3d)
         if self.options.use_baroclinic_formulation:
             if self.options.solve_salinity:
@@ -870,10 +869,10 @@ class FlowSolver(FrozenClass):
                                                      self.fields.baroc_head_3d,
                                                      bottom_to_top=False,
                                                      average=False,
-                                                     bathymetry=self.bathymetry_3d,
+                                                     bathymetry=self.fields.bathymetry_2d.view_3d,
                                                      elevation=self.fields.elev_cg_3d)
             self.int_pg_calculator = momentum_eq.InternalPressureGradientCalculator(
-                self.fields, self.bathymetry_3d, self.options,
+                self.fields, self.fields.bathymetry_2d.view_3d, self.options,
                 self.bnd_functions['momentum'],
                 solver_parameters=self.options.timestepper_options.solver_parameters_momentum_explicit)
         self.extract_surf_dav_uv = SubFunctionExtractor(self.fields.uv_dav_3d,

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -575,8 +575,6 @@ class FlowSolver(FrozenClass):
         self.fields.uv_dav_3d = Function(self.function_spaces.U)
         self.fields.uv_dav_2d = Function(self.function_spaces.U_2d)
         self.fields.split_residual_2d = Function(self.function_spaces.U_2d)
-        self.fields.uv_mag_3d = Function(self.function_spaces.P0)
-        self.fields.uv_p1_3d = Function(self.function_spaces.P1v)
         self.fields.w_3d = Function(self.function_spaces.W)
         self.fields.hcc_metric_3d = Function(self.function_spaces.P1DG, name='mesh consistency')
         if self.options.use_ale_moving_mesh:
@@ -881,15 +879,13 @@ class FlowSolver(FrozenClass):
                                                            elem_height=self.fields.v_elem_size_3d)
         self.copy_uv_to_uv_dav_3d = ExpandFunctionTo3d(self.fields.uv_2d, self.fields.uv_dav_3d,
                                                        elem_height=self.fields.v_elem_size_3d)
-        self.uv_mag_solver = VelocityMagnitudeSolver(self.fields.uv_mag_3d, u=self.fields.uv_3d)
         self.mesh_updater = ALEMeshUpdater(self)
 
         if self.options.use_smagorinsky_viscosity:
-            self.smagorinsky_diff_solver = SmagorinskyViscosity(self.fields.uv_p1_3d, self.fields.smag_visc_3d,
+            self.smagorinsky_diff_solver = SmagorinskyViscosity(self.fields.uv_3d, self.fields.smag_visc_3d,
                                                                 self.options.smagorinsky_coefficient, self.fields.h_elem_size_3d,
                                                                 self.fields.max_h_diff,
                                                                 weak_form=self.options.polynomial_degree == 0)
-        self.uv_p1_projector = Projector(self.fields.uv_3d, self.fields.uv_p1_3d)
 
         # ----- set initial values
         self.fields.bathymetry_2d.project(self.bathymetry_cg_2d)

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -566,8 +566,6 @@ class FlowSolver(FrozenClass):
         # elevation field seen by the 3D mode, different from elev_2d
         self.fields.elev_domain_2d = ExtrudedFunction(self.function_spaces.H_2d, mesh_3d=self.mesh)
         self.fields.elev_cg_2d = ExtrudedFunction(coord_fs_2d, mesh_3d=self.mesh)
-        # FIXME elev_cg_3d can potentially be removed
-        self.fields.elev_cg_3d = self.fields.elev_cg_2d.view_3d
         self.fields.uv_3d = Function(self.function_spaces.U)
         self.fields.bathymetry_2d = ExtrudedFunction(coord_fs_2d, mesh_3d=self.mesh)
         # z coordinate in the strecthed mesh
@@ -840,7 +838,7 @@ class FlowSolver(FrozenClass):
                                               bnd_value=Constant((0.0, 0.0, 0.0)),
                                               average=True,
                                               bathymetry=self.fields.bathymetry_2d.view_3d,
-                                              elevation=self.fields.elev_cg_3d)
+                                              elevation=self.fields.elev_cg_2d.view_3d)
         if self.options.use_baroclinic_formulation:
             if self.options.solve_salinity:
                 s = self.fields.salt_3d
@@ -870,7 +868,7 @@ class FlowSolver(FrozenClass):
                                                      bottom_to_top=False,
                                                      average=False,
                                                      bathymetry=self.fields.bathymetry_2d.view_3d,
-                                                     elevation=self.fields.elev_cg_3d)
+                                                     elevation=self.fields.elev_cg_2d.view_3d)
             self.int_pg_calculator = momentum_eq.InternalPressureGradientCalculator(
                 self.fields, self.fields.bathymetry_2d.view_3d, self.options,
                 self.bnd_functions['momentum'],

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -565,7 +565,6 @@ class FlowSolver(FrozenClass):
         self.fields.elev_2d = eta2d
         # elevation field seen by the 3D mode, different from elev_2d
         self.fields.elev_domain_2d = ExtrudedFunction(self.function_spaces.H_2d, mesh_3d=self.mesh)
-        self.fields.elev_domain_3d = self.fields.elev_domain_2d.view_3d
         self.fields.elev_cg_2d = ExtrudedFunction(coord_fs_2d, mesh_3d=self.mesh)
         # FIXME elev_cg_3d can potentially be removed
         self.fields.elev_cg_3d = self.fields.elev_cg_2d.view_3d

--- a/thetis/tracer_eq.py
+++ b/thetis/tracer_eq.py
@@ -143,8 +143,6 @@ class HorizontalAdvectionTerm(TracerTerm):
         if uv_depth_av is not None:
             uv = uv + uv_depth_av
 
-        uv_p1 = fields_old.get('uv_p1')
-        uv_mag = fields_old.get('uv_mag')
         # FIXME is this an option?
         lax_friedrichs_factor = fields_old.get('lax_friedrichs_tracer_scaling_factor')
 
@@ -165,13 +163,7 @@ class HorizontalAdvectionTerm(TracerTerm):
                        + uv_av[2]*jump(self.test, self.normal[2]))*(self.dS_h)
             # Lax-Friedrichs stabilization
             if self.use_lax_friedrichs:
-                if uv_p1 is not None:
-                    gamma = 0.5*abs((avg(uv_p1)[0]*self.normal('-')[0]
-                                     + avg(uv_p1)[1]*self.normal('-')[1]))*lax_friedrichs_factor
-                elif uv_mag is not None:
-                    gamma = 0.5*avg(uv_mag)*lax_friedrichs_factor
-                else:
-                    raise Exception('either uv_p1 or uv_mag must be given')
+                gamma = 0.5*abs(un_av)*lax_friedrichs_factor
                 f += gamma*dot(jump(self.test), jump(solution))*(self.dS_v + self.dS_h)
             if bnd_conditions is not None:
                 for bnd_marker in self.boundary_markers:

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -118,8 +118,6 @@ class HorizontalAdvectionTerm(TracerTerm):
         self.corr_factor = fields_old.get('tracer_advective_velocity_factor')
 
         uv = self.corr_factor * fields_old['uv_2d']
-        uv_p1 = fields_old.get('uv_p1')
-        uv_mag = fields_old.get('uv_mag')
         # FIXME is this an option?
         lax_friedrichs_factor = fields_old.get('lax_friedrichs_tracer_scaling_factor')
 
@@ -139,13 +137,7 @@ class HorizontalAdvectionTerm(TracerTerm):
                        + jump(self.test, uv[1] * self.normal[1])) * self.dS
             # Lax-Friedrichs stabilization
             if self.use_lax_friedrichs:
-                if uv_p1 is not None:
-                    gamma = 0.5*abs((avg(uv_p1)[0]*self.normal('-')[0]
-                                     + avg(uv_p1)[1]*self.normal('-')[1]))*lax_friedrichs_factor
-                elif uv_mag is not None:
-                    gamma = 0.5*avg(uv_mag)*lax_friedrichs_factor
-                else:
-                    gamma = 0.5*abs(un_av)*lax_friedrichs_factor
+                gamma = 0.5*abs(un_av)*lax_friedrichs_factor
                 f += gamma*dot(jump(self.test), jump(solution))*self.dS
             if bnd_conditions is not None:
                 for bnd_marker in self.boundary_markers:

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -845,7 +845,7 @@ class ExpandFunctionTo3d(object):
             # a normal tensorproduct element
             family_3dh = ufl_elem.sub_elements()[0].family()
             if family_2d != family_3dh:
-                raise Exception('2D and 3D spaces do not match: {0:s} {1:s}'.format(family_2d, family_3dh))
+                raise Exception('2D and 3D spaces do not match: "{0:s}" != "{1:s}"'.format(family_2d, family_3dh))
         if family_2d == 'Raviart-Thomas' and elem_height is None:
             raise Exception('elem_height must be provided for Raviart-Thomas spaces')
         self.do_rt_scaling = family_2d == 'Raviart-Thomas'
@@ -1282,7 +1282,7 @@ class ALEMeshUpdater(object):
                                                 self.elev_cg_2d)
             self.proj_elev_cg_to_coords_2d = Projector(self.elev_cg_2d,
                                                        self.fields.elev_cg_2d)
-            self.cp_elev_2d_to_3d = ExpandFunctionTo3d(self.fields.elev_cg_2d,
+            self.cp_elev_2d_to_3d = ExpandFunctionTo3d(self.elev_cg_2d,
                                                        self.elev_cg_3d)
             self.cp_w_mesh_surf_2d_to_3d = ExpandFunctionTo3d(self.fields.w_mesh_surf_2d,
                                                               self.fields.w_mesh_surf_3d)

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -788,8 +788,13 @@ def extend_function_to_3d(func, mesh_extruded):
     family = ufl_elem.family()
     degree = ufl_elem.degree()
     name = func.name()
-    fs_extended = FunctionSpace(mesh_extruded, family, degree, vfamily='R', vdegree=0)
-    func_extended = Function(fs_extended, name=name, val=func.dat)
+    if isinstance(ufl_elem, ufl.VectorElement):
+        # vector function space
+        fs_extended = get_functionspace(mesh_extruded, family, degree, 'R', 0,
+                                        dim=2, vector=True)
+    else:
+        fs_extended = get_functionspace(mesh_extruded, family, degree, 'R', 0)
+    func_extended = Function(fs_extended, name=name, val=func.dat._data)
     func_extended.source = func
     return func_extended
 
@@ -1534,7 +1539,7 @@ class SmagorinskyViscosity(object):
         if self.weak_form:
             # solve grad(u) weakly
             mesh = output.function_space().mesh()
-            fs_grad = FunctionSpace(mesh, 'DP', 1, vfamily='DP', vdegree=1)
+            fs_grad = get_functionspace(mesh, 'DP', 1, 'DP', 1)
             self.grad = []
             for icomp in range(2):
                 self.grad[icomp] = []
@@ -1755,7 +1760,7 @@ def compute_boundary_length(mesh2d):
     """
     Computes the length of the boundary segments in given 2d mesh
     """
-    p1 = FunctionSpace(mesh2d, 'CG', 1)
+    p1 = get_functionspace(mesh2d, 'CG', 1)
     boundary_markers = sorted(mesh2d.exterior_facets.unique_markers)
     boundary_len = OrderedDict()
     for i in boundary_markers:


### PR DESCRIPTION
Adds `ExtrudedFunction` class which allows using 2D fields in extruded 3D mesh:

```python
mesh2d = ...
mesh3d = ExtrudedMesh(mesh2d, ...)
fs_2d = FunctionSpace(mesh2d, ...)
f_2d = ExtrudedFunction(fs_2d, mesh_3d=mesh3d)  # this behaves like a 2D Function
f_3d = f_2d.view_3d  # this can be used in 3D equations, shares the data with f_2d
```
The 3D function lives in Foo x R extruded function space.

Under the hood there's `extend_function_to_3d` function:
```python
f_3d = extend_function_to_3d(f_2d, mesh_3d)
```
In this PR, `ExtrudedFunction` is used for elevation and bathymetry fields, reducing the total memory footprint of the 3D solver.

The following auxiliary fields are removed:
- `bathymetry_3d`
- `elev_3d`
- `uv_p1_3d`
- `uv_mag_3d`
- `w_mesh_surf_2d`
- `w_mesh_surf_3d`
- `elev_cg_3d` is renamed to `elev_domain_3d`
