### PR TITLE
Fix rt variant

### DIFF
--- a/examples/lockExchange/plotting.py
+++ b/examples/lockExchange/plotting.py
@@ -6,7 +6,7 @@ import itertools
 
 try:
     import matplotlib
-    matplotlib.use('Agg', warn=False)
+    matplotlib.use('Agg')
     import matplotlib.pyplot as plt
     from mpl_toolkits.axes_grid1 import make_axes_locatable
     MATPLOTLIB_INSTALLED = True

--- a/test/firedrake/test_implicit_friction.py
+++ b/test/firedrake/test_implicit_friction.py
@@ -38,7 +38,7 @@ def test_implicit_friction(do_export=False, do_assert=True):
     deg = 1
     p1dg = get_functionspace(mesh, 'DG', 1)
     p1dgv = get_functionspace(mesh, 'DG', 1, vector=True)
-    u_h_elt = FiniteElement('RT', triangle, deg + 1, variant='equispaced')
+    u_h_elt = FiniteElement('RT', triangle, deg + 1, variant='point')
     u_v_elt = FiniteElement('DG', interval, deg, variant='equispaced')
     u_elt = HDiv(TensorProductElement(u_h_elt, u_v_elt))
     # for vertical velocity component

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -111,9 +111,17 @@ class FieldDict(AttrDict):
 
 
 def get_functionspace(mesh, h_family, h_degree, v_family=None, v_degree=None,
-                      vector=False, hdiv=False, variant='equispaced', **kwargs):
+                      vector=False, hdiv=False, variant=None, **kwargs):
     gdim = mesh.geometric_dimension()
     assert gdim in [2, 3]
+    if variant is None:
+        if h_family.upper() == 'RT' or h_family.lower() == 'raviart-thomas':
+            variant = 'point'
+        else:
+            variant = 'equispaced'
+        v_variant = 'equispaced'
+    else:
+        v_variant = variant
     if gdim == 3:
         if v_family is None:
             v_family = h_family
@@ -121,7 +129,7 @@ def get_functionspace(mesh, h_family, h_degree, v_family=None, v_degree=None,
             v_degree = h_degree
         h_cell, v_cell = mesh.ufl_cell().sub_cells()
         h_elt = FiniteElement(h_family, h_cell, h_degree, variant=variant)
-        v_elt = FiniteElement(v_family, v_cell, v_degree, variant=variant)
+        v_elt = FiniteElement(v_family, v_cell, v_degree, variant=v_variant)
         elt = TensorProductElement(h_elt, v_elt)
         if hdiv:
             elt = HDiv(elt)


### PR DESCRIPTION
variant='equispaced' is no longer allowed with Hdiv elements (previously ignored). Should be variant='point' (old default, which under-integrates) or variant='integral' (soon to be new default). For the moment I've fixed the variant to 'point' for RT.

FWIW, I've locally run all tests that mention 'rt-dg' with variant='integral', and I get 3 failures:

2 failures in test/bottomFriction/test_ekman_bottom.py that look like they might just be a tolerance tweak

1 failure in test/swe2d/test_atmospheric_pressure.py where I get a DIVERGED_LINEAR_SOLVE