### PR TITLE
Custom turbine area

### DIFF
--- a/thetis/options.py
+++ b/thetis/options.py
@@ -5,7 +5,7 @@ All options are type-checked and they are stored in traitlets Configurable
 objects.
 """
 from .configuration import *
-from firedrake import Constant
+from firedrake import Constant, pi
 from .sediment_model import SedimentModel
 
 
@@ -351,6 +351,11 @@ class TidalTurbineOptions(FrozenHasTraits):
         0.8, help='Thrust coefficient C_T').tag(config=True)
     diameter = PositiveFloat(
         18., help='Turbine diameter').tag(config=True)
+    area = PositiveFloat(
+        None, allow_none=True, help='Custom turbine area (overrides diameter)').tag(config=True)
+
+    def get_turbine_area(self):
+        return self.area or pi*(0.5*self.diameter)**2
 
 
 class TidalTurbineFarmOptions(FrozenHasTraits, TraitType):

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -728,7 +728,7 @@ class TurbineDragTerm(ShallowWaterMomentumTerm):
         for subdomain_id, farm_options in self.options.tidal_turbine_farms.items():
             density = farm_options.turbine_density
             C_T = farm_options.turbine_options.thrust_coefficient
-            A_T = pi * (farm_options.turbine_options.diameter/2.)**2
+            A_T = farm_options.turbine_options.get_turbine_area()
             C_D = (C_T * A_T * density)/2.
             unorm = sqrt(dot(uv_old, uv_old))
             f += C_D * unorm * inner(self.u_test, uv) / total_h * self.dx(subdomain_id)

--- a/thetis/turbines.py
+++ b/thetis/turbines.py
@@ -40,7 +40,7 @@ class TurbineFarm(object):
         :arg float dt: used for time-integration."""
         turbine_density = farm_options.turbine_density
         C_T = farm_options.turbine_options.thrust_coefficient
-        A_T = pi*(farm_options.turbine_options.diameter/2.)**2
+        A_T = farm_options.turbine_options.get_turbine_area()
         C_D = C_T*A_T/2.*turbine_density
         self.power_integral = C_D * (u*u + v*v)**1.5 * dx(subdomain_id)
         # cost integral is n/o turbines = \int turbine_density


### PR DESCRIPTION
I noticed that the tidal turbine formulation assumes circular turbine footprints. This PR keeps that as default, but allows a user provided area. (A test case I'm considering uses rectangular turbine footprints.)