### PR TITLE
Fix compatibility with traitlets 5

### DIFF
--- a/thetis/configuration.py
+++ b/thetis/configuration.py
@@ -204,7 +204,6 @@ class FiredrakeVectorExpression(TraitType):
 
 class PETScSolverParameters(Dict):
     """PETSc solver options dictionary"""
-    default_value = None
     info_text = 'a PETSc solver options dictionary'
 
     def validate(self, obj, value):
@@ -331,8 +330,8 @@ def attach_paired_options(name, name_trait, value_trait):
         if hasattr(name_trait, 'default_value') and name_trait.default_value is not None:
             return name_trait.paired_defaults[name_trait.default_value]()
 
-    obs_handler = ObserveHandler(name, type="change")
-    def_handler = DefaultHandler(name_trait.paired_name)
+    obs_handler = observe(name, type="change")
+    def_handler = default(name_trait.paired_name)
 
     def update_class(cls):
         "Programmatically update the class"

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -84,13 +84,11 @@ class PressureProjectionTimestepperOptions2d(TimeStepperOptions):
             'pc_python_type': 'thetis.AssembledSchurPC',
             'schur_ksp_type': 'gmres',
             'schur_ksp_max_it': 100,
-            'schur_ksp_converged_reason': False,
             'schur_pc_type': 'gamg',
         },
     }).tag(config=True)
     solver_parameters_momentum = PETScSolverParameters({
         'ksp_type': 'gmres',
-        'ksp_converged_reason': False,
         'pc_type': 'bjacobi',
         'sub_ksp_type': 'preonly',
         'sub_pc_type': 'sor',

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -437,8 +437,6 @@ class VerticalVelocitySolver(object):
                                              constant_jacobian=True)
         self.solver = LinearVariationalSolver(self.prob,
                                               solver_parameters=solver_parameters)
-        print('provided:', solver_parameters)
-        print('solver:', self.solver.parameters)
 
     def solve(self):
         """Compute w"""

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -387,6 +387,8 @@ class VerticalVelocitySolver(object):
         solver_parameters.setdefault('pc_type', 'bjacobi')
         solver_parameters.setdefault('sub_ksp_type', 'preonly')
         solver_parameters.setdefault('sub_pc_type', 'ilu')
+        solver_parameters.setdefault('sub_pc_factor_shift_type', 'inblocks')
+
         fs = solution.function_space()
         mesh = fs.mesh()
         test = TestFunction(fs)
@@ -435,6 +437,8 @@ class VerticalVelocitySolver(object):
                                              constant_jacobian=True)
         self.solver = LinearVariationalSolver(self.prob,
                                               solver_parameters=solver_parameters)
+        print('provided:', solver_parameters)
+        print('solver:', self.solver.parameters)
 
     def solve(self):
         """Compute w"""


### PR DESCRIPTION
Change ObserveHandler and DefaultHandler to decorators observe and
default, which seem to do the same.
For some reason we can't overwrite the default_value attribute of
PETScSolverParameters.

Fixes #223