### PR TITLE
BDM function space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ lint:
 	@python -m flake8 thetis
 	@echo "    Linting thetis test suite"
 	@python -m flake8 test
+	@python -m flake8 test_adjoint
 	@echo "    Linting thetis scripts"
 	@python -m flake8 scripts --filename=*
 	@echo "    Linting thetis examples"

--- a/test/bottomFriction/test_bottom_friction.py
+++ b/test/bottomFriction/test_bottom_friction.py
@@ -122,7 +122,7 @@ def run_bottom_friction(do_assert=True, do_export=False, **model_options):
         print_output('L2 error {:.4f} PASSED'.format(uv_l2_err))
 
 
-@pytest.fixture(params=['rt-dg', 'dg-dg'])
+@pytest.fixture(params=['rt-dg', 'dg-dg', 'bdm-dg'])
 def element_family(request):
     return request.param
 

--- a/test/bottomFriction/test_ekman_bottom.py
+++ b/test/bottomFriction/test_ekman_bottom.py
@@ -96,7 +96,7 @@ def run_test(layers=25, tolerance=0.05, verify=True, **model_options):
     return solver_obj
 
 
-@pytest.fixture(params=['dg-dg', 'rt-dg'])
+@pytest.fixture(params=['dg-dg', 'rt-dg', 'bdm-dg'])
 def element_family(request):
     return request.param
 

--- a/test/bottomFriction/test_ekman_surface.py
+++ b/test/bottomFriction/test_ekman_surface.py
@@ -95,7 +95,7 @@ def run_test(layers=25, tolerance=0.05, verify=True, **model_options):
     return solver_obj
 
 
-@pytest.fixture(params=['dg-dg', 'rt-dg'])
+@pytest.fixture(params=['dg-dg', 'rt-dg', 'bdm-dg'])
 def element_family(request):
     return request.param
 

--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -197,7 +197,9 @@ def warped(request):
                          [('dg-dg', 0),
                           ('dg-dg', 1),
                           pytest.param('rt-dg', 0, marks=pytest.mark.skip(reason='rt-0 still broken')),
-                          ('rt-dg', 1)])
+                          ('rt-dg', 1),
+                          ('bdm-dg', 1)],
+                         )
 def test_horizontal_viscosity(warped, polynomial_degree, family, stepper, use_ale):
     run_convergence([1, 2, 3], polynomial_degree=polynomial_degree, warped_mesh=warped,
                     element_family=family, timestepper_type=stepper,

--- a/test/momentumEq/test_v-viscosity_mes.py
+++ b/test/momentumEq/test_v-viscosity_mes.py
@@ -201,7 +201,7 @@ def run_convergence(ref_list, saveplot=False, **options):
 # ---------------------------
 
 
-@pytest.fixture(params=['rt-dg', 'dg-dg'])
+@pytest.fixture(params=['rt-dg', 'dg-dg', 'bdm-dg'])
 def element_family(request):
     return request.param
 

--- a/test/pressure_grad/test_int_pg_mes.py
+++ b/test/pressure_grad/test_int_pg_mes.py
@@ -94,12 +94,10 @@ def compute_l2_error(refinement=1, quadratic=False, no_exports=True):
     fields = FieldDict()
     fields.baroc_head_3d = baroc_head_3d
     fields.int_pg_3d = int_pg_3d
-    options = None
     bnd_functions = {}
     int_pg_solver = InternalPressureGradientCalculator(
         fields,
         bathymetry_3d,
-        options,
         bnd_functions,
         solver_parameters=None)
     int_pg_solver.solve()

--- a/test/pressure_grad/test_int_pg_zero.py
+++ b/test/pressure_grad/test_int_pg_zero.py
@@ -311,6 +311,24 @@ def test_int_pg(pg_test_setup):
         'geometry': 'warped',
         'target': 5e-4,
     },
+    {
+        'element_family': 'bdm-dg',
+        'use_quadratic_pressure': True,
+        'use_quadratic_density': True,
+        'lin_strat': False,
+        'equation_of_state_type': 'full',
+        'geometry': 'warped',
+        'target': 80e3,
+    },
+    {
+        'element_family': 'bdm-dg',
+        'use_quadratic_pressure': True,
+        'use_quadratic_density': False,
+        'lin_strat': True,
+        'equation_of_state_type': 'linear',
+        'geometry': 'warped',
+        'target': 5e-4,
+    },
 ],)
 def stability_setup(request):
     return request.param

--- a/test/pressure_grad/test_int_pg_zero.py
+++ b/test/pressure_grad/test_int_pg_zero.py
@@ -131,216 +131,117 @@ def compute_pg_error(**kwargs):
     return res
 
 
-@pytest.fixture(params=[
-    {
-        'element_family': 'dg-dg',
+options_dict = {
+    'setup1': {
         'use_quadratic_pressure': True,
         'use_quadratic_density': True,
         'lin_strat': False,
         'equation_of_state_type': 'full',
         'geometry': 'seamount',
-        'target': 2e-6,
     },
-    {
-        'element_family': 'dg-dg',
+    'setup2': {
         'use_quadratic_pressure': False,
         'use_quadratic_density': False,
         'lin_strat': True,
         'equation_of_state_type': 'linear',
         'geometry': 'warped',
-        'target': 7e-4,
     },
-    {
-        'element_family': 'dg-dg',
+    'setup3': {
         'use_quadratic_pressure': True,
         'use_quadratic_density': False,
         'lin_strat': True,
         'equation_of_state_type': 'linear',
         'geometry': 'warped',
-        'target': 1e-13,
     },
-    {
-        'element_family': 'dg-dg',
+    'setup4': {
         'use_quadratic_pressure': True,
         'use_quadratic_density': False,
         'lin_strat': True,
         'equation_of_state_type': 'full',
         'geometry': 'warped',
-        'target': 7e-6,
     },
-    {
-        'element_family': 'dg-dg',
+    'setup5': {
         'use_quadratic_pressure': True,
         'use_quadratic_density': True,
         'lin_strat': True,
         'equation_of_state_type': 'full',
         'geometry': 'warped',
-        'target': 1e-6,
     },
-    {
-        'element_family': 'dg-dg',
+    'setup6': {
         'use_quadratic_pressure': True,
         'use_quadratic_density': False,
         'lin_strat': False,
         'equation_of_state_type': 'full',
         'geometry': 'warped',
-        'target': 3e-5,
     },
-    {
-        'element_family': 'dg-dg',
+    'setup7': {
         'use_quadratic_pressure': True,
         'use_quadratic_density': True,
         'lin_strat': False,
         'equation_of_state_type': 'full',
         'geometry': 'warped',
-        'target': 1e-5,
     },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': True,
-        'lin_strat': False,
-        'equation_of_state_type': 'full',
-        'geometry': 'seamount',
-        'target': 9.0,
-    },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': False,
-        'use_quadratic_density': False,
-        'lin_strat': True,
-        'equation_of_state_type': 'linear',
-        'geometry': 'warped',
-        'target': 850.,
-    },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': False,
-        'lin_strat': True,
-        'equation_of_state_type': 'linear',
-        'geometry': 'warped',
-        'target': 1e-7,
-    },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': False,
-        'lin_strat': True,
-        'equation_of_state_type': 'full',
-        'geometry': 'warped',
-        'target': 30.,
-    },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': True,
-        'lin_strat': True,
-        'equation_of_state_type': 'full',
-        'geometry': 'warped',
-        'target': 9.,
-    },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': False,
-        'lin_strat': False,
-        'equation_of_state_type': 'full',
-        'geometry': 'warped',
-        'target': 60.,
-    },
-    {
-        'element_family': 'rt-dg',
+    'setup8': {
         'use_quadratic_pressure': True,
         'use_quadratic_density': True,
         'lin_strat': False,
         'equation_of_state_type': 'full',
         'geometry': 'warped',
-        'target': 40.,
     },
+}
+
+
+@pytest.mark.parametrize('setup,element_family,target', [
+    ('setup1', 'dg-dg', 2e-6,),
+    ('setup2', 'dg-dg', 7e-4,),
+    ('setup3', 'dg-dg', 1e-13,),
+    ('setup4', 'dg-dg', 7e-6,),
+    ('setup5', 'dg-dg', 1e-6,),
+    ('setup6', 'dg-dg', 3e-5,),
+    ('setup7', 'dg-dg', 1e-5,),
+    ('setup1', 'rt-dg', 9.0,),
+    ('setup2', 'rt-dg', 850.,),
+    ('setup3', 'rt-dg', 1e-7,),
+    ('setup4', 'rt-dg', 30.,),
+    ('setup5', 'rt-dg', 9.,),
+    ('setup6', 'rt-dg', 60.,),
+    ('setup7', 'rt-dg', 40.,),
+    ('setup1', 'bdm-dg', 9.0,),
+    ('setup2', 'bdm-dg', 950.,),
+    ('setup3', 'bdm-dg', 1e-7,),
+    ('setup4', 'bdm-dg', 40.,),
+    ('setup5', 'bdm-dg', 8.,),
+    ('setup6', 'bdm-dg', 80.,),
+    ('setup7', 'bdm-dg', 60.,),
 ],)
-def pg_test_setup(request):
-    return request.param
-
-
-def test_int_pg(pg_test_setup):
+def test_int_pg(setup, element_family, target):
     """
     Initialize model and check magnitude of internal pressure gradient error
 
     Correct pressure gradient is zero.
     """
-    target = pg_test_setup.pop('target')
-    error = compute_pg_error(**pg_test_setup)
+    options = options_dict[setup]
+    options['element_family'] = element_family
+    error = compute_pg_error(**options)
     assert error['int_pg_3d'] < target
 
 
-@pytest.fixture(params=[
-    {
-        'element_family': 'dg-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': True,
-        'lin_strat': False,
-        'equation_of_state_type': 'full',
-        'geometry': 'warped',
-        'target': 0.02,
-    },
-    {
-        'element_family': 'dg-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': False,
-        'lin_strat': True,
-        'equation_of_state_type': 'linear',
-        'geometry': 'warped',
-        'target': 1e-11,
-    },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': True,
-        'lin_strat': False,
-        'equation_of_state_type': 'full',
-        'geometry': 'warped',
-        'target': 80e3,
-    },
-    {
-        'element_family': 'rt-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': False,
-        'lin_strat': True,
-        'equation_of_state_type': 'linear',
-        'geometry': 'warped',
-        'target': 5e-4,
-    },
-    {
-        'element_family': 'bdm-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': True,
-        'lin_strat': False,
-        'equation_of_state_type': 'full',
-        'geometry': 'warped',
-        'target': 80e3,
-    },
-    {
-        'element_family': 'bdm-dg',
-        'use_quadratic_pressure': True,
-        'use_quadratic_density': False,
-        'lin_strat': True,
-        'equation_of_state_type': 'linear',
-        'geometry': 'warped',
-        'target': 5e-4,
-    },
+@pytest.mark.parametrize('setup,element_family,target', [
+    ('setup8', 'dg-dg', 0.005),
+    ('setup3', 'dg-dg', 1e-12),
+    ('setup8', 'rt-dg', 80e3),
+    ('setup3', 'rt-dg', 1e-4),
+    ('setup8', 'bdm-dg', 90e3),
+    ('setup3', 'bdm-dg', 5e-4),
 ],)
-def stability_setup(request):
-    return request.param
-
-
-def test_stability(stability_setup):
+def test_stability(setup, element_family, target):
     """
     Run model for a few time steps, check magnitude of the velocity field.
     """
-    target = stability_setup.pop('target')
-    stability_setup['iterate'] = True
-    error = compute_pg_error(**stability_setup)
+    options = options_dict[setup]
+    options['element_family'] = element_family
+    options['iterate'] = True
+    error = compute_pg_error(**options)
     assert error['uv_3d'] < target
 
 

--- a/test/pressure_grad/test_pg-stack_mes.py
+++ b/test/pressure_grad/test_pg-stack_mes.py
@@ -130,12 +130,10 @@ def compute_l2_error(refinement=1, quadratic_pressure=False, quadratic_density=F
     fields = FieldDict()
     fields.baroc_head_3d = baroc_head_3d
     fields.int_pg_3d = int_pg_3d
-    options = None
     bnd_functions = {}
     int_pg_solver = InternalPressureGradientCalculator(
         fields,
         bathymetry_3d,
-        options,
         bnd_functions,
         solver_parameters=None)
     int_pg_solver.solve()

--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -129,7 +129,7 @@ def run(**model_options):
 # standard tests for pytest
 # ---------------------------
 
-@pytest.fixture(params=['dg-cg', 'dg-dg', 'rt-dg'])
+@pytest.fixture(params=['dg-cg', 'dg-dg', 'rt-dg', 'bdm-dg'])
 def family(request):
     return request.param
 

--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -69,6 +69,7 @@ def run(**model_options):
     options.use_lax_friedrichs_velocity = True
     options.lax_friedrichs_velocity_scaling_factor = Constant(1.0)
     options.use_grad_depth_viscosity_term = False
+    options.no_exports = True
     options.update(model_options)
     solver_obj.create_equations()
 
@@ -135,7 +136,7 @@ def family(request):
 
 
 def test_sipg(family):
-    options = {'element_family': family, 'no_exports': True}
+    options = {'element_family': family}
     snes_it_auto = run(use_automatic_sipg_parameter=True, **options)
     try:
         snes_it_default = run(use_automatic_sipg_parameter=False, **options)

--- a/test/swe2d/test_atmospheric_pressure.py
+++ b/test/swe2d/test_atmospheric_pressure.py
@@ -16,7 +16,7 @@ import numpy as np
 
 
 @pytest.mark.parametrize("element_family", [
-    'dg-dg', 'rt-dg', 'dg-cg', ])
+    'dg-dg', 'rt-dg', 'dg-cg', 'bdm-dg'])
 @pytest.mark.parametrize("timestepper", [
     'CrankNicolson', 'SSPRK33', ])
 def test_pressure_forcing(element_family, timestepper):

--- a/test/swe2d/test_rossby_wave.py
+++ b/test/swe2d/test_rossby_wave.py
@@ -168,10 +168,11 @@ def run(refinement_level, **model_options):
     options.horizontal_viscosity = None
     solver_obj.create_function_spaces()
     options.coriolis_frequency = interpolate(y, solver_obj.function_spaces.P1_2d)
-    options.update(model_options)
     options.timestepper_options.solver_parameters['ksp_rtol'] = 1.0e-04
     if hasattr(options.timestepper_options, 'use_automatic_timestep'):
         options.timestepper_options.use_automatic_timestep = False
+    options.no_exports = True
+    options.update(model_options)
 
     # Apply boundary conditions
     for tag in mesh2d.exterior_facets.unique_markers:

--- a/test/swe2d/test_rossby_wave.py
+++ b/test/swe2d/test_rossby_wave.py
@@ -245,7 +245,7 @@ def stepper(request):
     return request.param
 
 
-@pytest.fixture(params=['dg-dg', 'dg-cg', 'rt-dg'])
+@pytest.fixture(params=['dg-dg', 'dg-cg', 'rt-dg', 'bdm-dg'])
 def family(request):
     return request.param
 

--- a/test/swe2d/test_steady_state_basin_mms.py
+++ b/test/swe2d/test_steady_state_basin_mms.py
@@ -326,21 +326,22 @@ def setup(request):
     return request.param
 
 
-@pytest.fixture(params=[
-    {'element_family': 'dg-dg',
-     'timestepper_type': 'CrankNicolson'},
-    {'element_family': 'rt-dg',
-     'timestepper_type': 'CrankNicolson'},
-    {'element_family': 'dg-cg',
-     'timestepper_type': 'CrankNicolson'}],
-    ids=["dg-dg", "rt-dg", "dg-cg"]
-)
-def options(request):
+@pytest.fixture(params=['rt-dg', 'dg-dg', 'dg-cg', 'bdm-dg'])
+def element_family(request):
     return request.param
 
 
-def test_steady_state_basin_convergence(setup, options):
+@pytest.fixture(params=['CrankNicolson'])
+def timestepper_type(request):
+    return request.param
+
+
+def test_steady_state_basin_convergence(setup, element_family, timestepper_type):
     sp = {'ksp_type': 'preonly', 'pc_type': 'lu', 'snes_monitor': None,
           'mat_type': 'aij'}
+    options = {
+        'element_family': element_family,
+        'timestepper_type': timestepper_type
+    }
     run_convergence(setup, [1, 2, 4, 6], 1, options=options,
                     solver_parameters=sp, save_plot=False)

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -21,7 +21,7 @@ def test_steady_state_channel_mms(element_family, automatic_sipg,
 
     order = 1
     # minimum resolution
-    min_cells = 16
+    min_cells = 48
     n = 1  # number of timesteps
     dt = 1.
     g = physical_constants['g_grav'].dat.data[0]
@@ -37,7 +37,7 @@ def test_steady_state_channel_mms(element_family, automatic_sipg,
 
     eta_errs = []
     u_errs = []
-    for i in range(5):
+    for i in range(4):
         mesh2d = RectangleMesh(min_cells*2**i, 1, lx, ly)
         x = mesh2d.coordinates
         eta_expr = eta0*cos(k*x[0])

--- a/test/tracerEq/test_consistency.py
+++ b/test/tracerEq/test_consistency.py
@@ -144,7 +144,7 @@ def run_tracer_consistency(**model_options):
         assert max_abs_overshoot < overshoot_tol, msg
 
 
-@pytest.mark.parametrize('element_family', ['dg-dg', 'rt-dg'])
+@pytest.mark.parametrize('element_family', ['dg-dg', 'rt-dg', 'bdm-dg'])
 @pytest.mark.parametrize('meshtype', ['regular', 'sloped', 'warped'])
 @pytest.mark.parametrize('timestepper_type', ['LeapFrog', 'SSPRK22'])
 def test_ale_const_tracer(element_family, meshtype, timestepper_type):
@@ -162,7 +162,7 @@ def test_ale_const_tracer(element_family, meshtype, timestepper_type):
                            no_exports=True)
 
 
-@pytest.mark.parametrize('element_family', ['dg-dg', 'rt-dg'])
+@pytest.mark.parametrize('element_family', ['dg-dg', 'rt-dg', 'bdm-dg'])
 @pytest.mark.parametrize('meshtype', ['regular', 'sloped', 'warped'])
 @pytest.mark.parametrize('timestepper_type', ['LeapFrog', 'SSPRK22'])
 def test_ale_nonconst_tracer(element_family, meshtype, timestepper_type):

--- a/test/turbulence/test_katophillips.py
+++ b/test/turbulence/test_katophillips.py
@@ -131,7 +131,7 @@ def run_katophillips(**model_options):
     print_output('Mixed layer depth: {:.2f} (target: {:.2f}) PASSED'.format(ml_depth, target))
 
 
-@pytest.fixture(params=['rt-dg', 'dg-dg'])
+@pytest.fixture(params=['rt-dg', 'dg-dg', 'bdm-dg'])
 def element_family(request):
     return request.param
 

--- a/test_adjoint/conftest.py
+++ b/test_adjoint/conftest.py
@@ -1,4 +1,3 @@
-import pytest
 
 
 def pytest_runtest_teardown(item, nextitem):

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -13,6 +13,7 @@ op2.init(log_level=INFO)
 
 velocity_u = 2.0
 
+
 def basic_setup():
     lx = 100.0
     ly = 50.0
@@ -40,6 +41,7 @@ def basic_setup():
     options.timestepper_type = 'CrankNicolson'
     options.timestep = timestep
     options.horizontal_viscosity = Constant(2.0)
+    options.no_exports = True
 
     # create function spaces
     solver_obj.create_function_spaces()

--- a/thetis/implicitexplicit.py
+++ b/thetis/implicitexplicit.py
@@ -31,7 +31,7 @@ class IMEXGeneric(TimeIntegrator):
         pass
 
     def __init__(self, equation, solution, fields, dt, bnd_conditions=None,
-                 solver_parameters={}, solver_parameters_dirk={}):
+                 solver_parameters=None, solver_parameters_dirk=None):
         super(IMEXGeneric, self).__init__(equation, solution, fields, dt, solver_parameters)
         """
         :arg equation: equation to solve

--- a/thetis/momentum_eq.py
+++ b/thetis/momentum_eq.py
@@ -619,7 +619,8 @@ class InternalPressureGradientCalculator(MomentumTerm):
     .. note ::
         Due to the :class:`Term` sign convention this term is assembled on the right-hand-side.
     """
-    def __init__(self, fields, bathymetry, options, bnd_functions, solver_parameters=None):
+    def __init__(self, fields, bathymetry, bnd_functions,
+                 internal_pg_scalar=None, solver_parameters=None):
         """
         :arg solver: `class`FlowSolver` object
         :kwarg dict solver_parameters: PETSc solver options
@@ -627,7 +628,7 @@ class InternalPressureGradientCalculator(MomentumTerm):
         if solver_parameters is None:
             solver_parameters = {}
         self.fields = fields
-        self.options = options
+        self.internal_pg_scalar = internal_pg_scalar
         function_space = self.fields.int_pg_3d.function_space()
         super(InternalPressureGradientCalculator, self).__init__(
             function_space, bathymetry=bathymetry)
@@ -685,7 +686,7 @@ class InternalPressureGradientCalculator(MomentumTerm):
             grad_head_dot_test = (Dx(bhead, 0)*self.test[0]
                                   + Dx(bhead, 1)*self.test[1])
             f = g_grav * grad_head_dot_test * self.dx
-        if self.options.internal_pg_scalar is not None:
-            f = self.options.internal_pg_scalar*f
+        if self.internal_pg_scalar is not None:
+            f = self.internal_pg_scalar*f
 
         return -f

--- a/thetis/momentum_eq.py
+++ b/thetis/momentum_eq.py
@@ -685,5 +685,7 @@ class InternalPressureGradientCalculator(MomentumTerm):
             grad_head_dot_test = (Dx(bhead, 0)*self.test[0]
                                   + Dx(bhead, 1)*self.test[1])
             f = g_grav * grad_head_dot_test * self.dx
+        if self.options.internal_pg_scalar is not None:
+            f = self.options.internal_pg_scalar*f
 
         return -f

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -801,3 +801,5 @@ class ModelOptions3d(CommonModelOptions):
         Constant(1.5), help="Penalty parameter used for horizontal diffusivity terms of the turbulence model.").tag(config=True)
     sipg_parameter_vertical_turb = FiredrakeScalarExpression(
         Constant(1.0), help="Penalty parameter used for vertical diffusivity terms of the turbulence model.").tag(config=True)
+    internal_pg_scalar = FiredrakeConstantTraitlet(
+        None, allow_none=True, help="A constant to scale the internal pressure gradient. Used to ramp up the model.").tag(config=True)

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -366,12 +366,12 @@ class CommonModelOptions(FrozenConfigurable):
     name = 'Model options'
     polynomial_degree = NonNegativeInteger(1, help='Polynomial degree of elements').tag(config=True)
     element_family = Enum(
-        ['dg-dg', 'rt-dg', 'dg-cg'],
+        ['dg-dg', 'rt-dg', 'bdm-dg', 'dg-cg'],
         default_value='dg-dg',
         help="""Finite element family
 
-        2D solver supports 'dg-dg', 'rt-dg', or 'dg-cg' velocity-pressure pairs.
-        3D solver supports 'dg-dg', or 'rt-dg' velocity-pressure pairs.""").tag(config=True)
+        2D solver supports 'dg-dg', 'rt-dg', 'bdm-dg', or 'dg-cg' velocity-pressure pairs.
+        3D solver supports 'dg-dg', 'rt-dg', or 'bdm-dg' velocity-pressure pairs.""").tag(config=True)
 
     use_nonlinear_equations = Bool(True, help='Use nonlinear shallow water equations').tag(config=True)
     use_grad_div_viscosity_term = Bool(

--- a/thetis/rungekutta.py
+++ b/thetis/rungekutta.py
@@ -447,7 +447,7 @@ class DIRKGeneric(RungeKuttaTimeIntegrator):
     :attr:`b`, :attr:`c`.
     """
     def __init__(self, equation, solution, fields, dt,
-                 bnd_conditions=None, solver_parameters={}, terms_to_add='all'):
+                 bnd_conditions=None, solver_parameters=None, terms_to_add='all'):
         """
         :arg equation: the equation to solve
         :type equation: :class:`Equation` object
@@ -562,7 +562,7 @@ class DIRKGenericUForm(RungeKuttaTimeIntegrator):
     cfl_coeff = CFL_UNCONDITIONALLY_STABLE
 
     def __init__(self, equation, solution, fields, dt,
-                 bnd_conditions=None, solver_parameters={}, terms_to_add='all',
+                 bnd_conditions=None, solver_parameters=None, terms_to_add='all',
                  semi_implicit=False):
         """
         :arg equation: the equation to solve
@@ -743,7 +743,7 @@ class ERKGeneric(RungeKuttaTimeIntegrator):
     Implements the Butcher form. All terms in the equation are treated explicitly.
     """
     def __init__(self, equation, solution, fields, dt, bnd_conditions=None,
-                 solver_parameters={}, terms_to_add='all'):
+                 solver_parameters=None, terms_to_add='all'):
         """
         :arg equation: the equation to solve
         :type equation: :class:`Equation` object
@@ -843,7 +843,7 @@ class ERKGenericShuOsher(TimeIntegrator):
 
     Implements the Shu-Osher form.
     """
-    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters={}, terms_to_add='all'):
+    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters=None, terms_to_add='all'):
         """
         :arg equation: the equation to solve
         :type equation: :class:`Equation` object

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -164,7 +164,7 @@ class FlowSolver(FrozenClass):
         degree. It is used to compute maximal stable time steps.
         """
         p = self.options.polynomial_degree
-        if self.options.element_family == 'rt-dg':
+        if self.options.element_family in ['rt-dg', 'bdm-dg']:
             # velocity space is essentially p+1
             p = self.options.polynomial_degree + 1
         # assuming DG basis functions on triangles
@@ -395,13 +395,15 @@ class FlowSolver(FrozenClass):
         self.function_spaces.P1DGv = get_functionspace(self.mesh, 'DG', 1, 'DG', 1, name='P1DGv', vector=True)
 
         # function spaces for (u,v) and w
-        if self.options.element_family == 'rt-dg':
-            h_family_alias = {'triangle': 'RTF', 'quadrilateral': 'RTCF'}
+        if self.options.element_family in ['rt-dg', 'bdm-dg']:
+            h_family_prefix = self.options.element_family.split('-')[0].upper()
+            h_family_suffix = {'triangle': 'F', 'quadrilateral': 'CF'}
             h_cell = self.mesh2d.ufl_cell().cellname()
-            hfam = h_family_alias[h_cell]
-            self.function_spaces.U = get_functionspace(self.mesh, hfam, self.options.polynomial_degree+1, 'DG', self.options.polynomial_degree, name='U', hdiv=True)
+            hfam = h_family_prefix + h_family_suffix[h_cell]
+            h_degree = self.options.polynomial_degree + 1
+            self.function_spaces.U = get_functionspace(self.mesh, hfam, h_degree, 'DG', self.options.polynomial_degree, name='U', hdiv=True)
             self.function_spaces.W = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'CG', self.options.polynomial_degree+1, name='W', hdiv=True)
-            self.function_spaces.U_2d = get_functionspace(self.mesh2d, hfam, self.options.polynomial_degree+1, name='U_2d')
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, hfam, h_degree, name='U_2d')
         elif self.options.element_family == 'dg-dg':
             self.function_spaces.U = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='U', vector=True)
             self.function_spaces.W = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='W', vector=True)
@@ -426,14 +428,12 @@ class FlowSolver(FrozenClass):
         if self.options.use_quadratic_pressure:
             self.function_spaces.P2DGxP2 = get_functionspace(self.mesh, 'DG', 2, 'CG', 2, name='P2DGxP2')
             self.function_spaces.P2DG_2d = get_functionspace(self.mesh2d, 'DG', 2, name='P2DG_2d')
+            self.function_spaces.H_bhead = self.function_spaces.P2DGxP2
+            self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
             if self.options.element_family == 'dg-dg':
                 self.function_spaces.P2DGxP1DGv = get_functionspace(self.mesh, 'DG', 2, 'DG', 1, name='P2DGxP1DGv', vector=True, dim=2)
-                self.function_spaces.H_bhead = self.function_spaces.P2DGxP2
-                self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
                 self.function_spaces.U_int_pg = self.function_spaces.P2DGxP1DGv
-            elif self.options.element_family == 'rt-dg':
-                self.function_spaces.H_bhead = self.function_spaces.P2DGxP2
-                self.function_spaces.H_bhead_2d = self.function_spaces.P2DG_2d
+            else:
                 self.function_spaces.U_int_pg = self.function_spaces.U
         else:
             self.function_spaces.P1DGxP2 = get_functionspace(self.mesh, 'DG', 1, 'CG', 2, name='P1DGxP2')

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -396,11 +396,16 @@ class FlowSolver(FrozenClass):
 
         # function spaces for (u,v) and w
         if self.options.element_family == 'rt-dg':
-            self.function_spaces.U = get_functionspace(self.mesh, 'RT', self.options.polynomial_degree+1, 'DG', self.options.polynomial_degree, name='U', hdiv=True)
+            h_family_alias = {'triangle': 'RTF', 'quadrilateral': 'RTCF'}
+            h_cell = self.mesh2d.ufl_cell().cellname()
+            hfam = h_family_alias[h_cell]
+            self.function_spaces.U = get_functionspace(self.mesh, hfam, self.options.polynomial_degree+1, 'DG', self.options.polynomial_degree, name='U', hdiv=True)
             self.function_spaces.W = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'CG', self.options.polynomial_degree+1, name='W', hdiv=True)
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, hfam, self.options.polynomial_degree+1, name='U_2d')
         elif self.options.element_family == 'dg-dg':
             self.function_spaces.U = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='U', vector=True)
             self.function_spaces.W = get_functionspace(self.mesh, 'DG', self.options.polynomial_degree, 'DG', self.options.polynomial_degree, name='W', vector=True)
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d', vector=True)
         else:
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
 
@@ -414,11 +419,6 @@ class FlowSolver(FrozenClass):
         self.function_spaces.P1v_2d = get_functionspace(self.mesh2d, 'CG', 1, name='P1v_2d', vector=True)
         self.function_spaces.P1DG_2d = get_functionspace(self.mesh2d, 'DG', 1, name='P1DG_2d')
         self.function_spaces.P1DGv_2d = get_functionspace(self.mesh2d, 'DG', 1, name='P1DGv_2d', vector=True)
-        # 2D velocity space
-        if self.options.element_family == 'rt-dg':
-            self.function_spaces.U_2d = get_functionspace(self.mesh2d, 'RT', self.options.polynomial_degree+1, name='U_2d')
-        elif self.options.element_family == 'dg-dg':
-            self.function_spaces.U_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d', vector=True)
         self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d], name='V_2d')
 

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -868,8 +868,9 @@ class FlowSolver(FrozenClass):
                                                      bathymetry=self.fields.bathymetry_2d.view_3d,
                                                      elevation=self.fields.elev_cg_2d.view_3d)
             self.int_pg_calculator = momentum_eq.InternalPressureGradientCalculator(
-                self.fields, self.fields.bathymetry_2d.view_3d, self.options,
+                self.fields, self.fields.bathymetry_2d.view_3d,
                 self.bnd_functions['momentum'],
+                internal_pg_scalar=self.options.internal_pg_scalar,
                 solver_parameters=self.options.timestepper_options.solver_parameters_momentum_explicit)
         self.extract_surf_dav_uv = SubFunctionExtractor(self.fields.uv_dav_3d,
                                                         self.fields.uv_dav_2d,

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -274,8 +274,10 @@ class FlowSolver(FrozenClass):
             nu = nu_scale.dat.data[0]
         min_dx = self.fields.h_elem_size_2d.dat.data.min()
         factor = 2.0
+        if self.options.element_family == 'bdm-dg':
+            factor = 1.8
         if self.options.timestepper_type == 'LeapFrog':
-            factor = 1.2
+            factor *= 0.6
         min_dx *= factor*self.compute_dx_factor()
         dt = (min_dx)**2/nu
         dt = self.comm.allreduce(dt, op=MPI.MIN)

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -324,11 +324,13 @@ class FlowSolver2d(FrozenClass):
         self.function_spaces.P1DG_2d = get_functionspace(self.mesh2d, 'DG', 1, name='P1DG_2d')
         self.function_spaces.P1DGv_2d = VectorFunctionSpace(self.mesh2d, 'DG', 1, name='P1DGv_2d')
         # 2D velocity space
-        if self.options.element_family == 'rt-dg':
-            h_family_alias = {'triangle': 'RTF', 'quadrilateral': 'RTCF'}
-            h_cell = self.mesh2d.ufl_cell().cellname()
-            hfam = h_family_alias[h_cell]
-            self.function_spaces.U_2d = get_functionspace(self.mesh2d, hfam, self.options.polynomial_degree+1, name='U_2d')
+        if self.options.element_family in ['rt-dg', 'bdm-dg']:
+            family_prefix = self.options.element_family.split('-')[0].upper()
+            family_suffix = {'triangle': 'F', 'quadrilateral': 'CF'}
+            cell = self.mesh2d.ufl_cell().cellname()
+            fam = family_prefix + family_suffix[cell]
+            degree = self.options.polynomial_degree + 1
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, fam, degree, name='U_2d')
             self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
         elif self.options.element_family == 'dg-cg':
             self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d')

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -325,7 +325,10 @@ class FlowSolver2d(FrozenClass):
         self.function_spaces.P1DGv_2d = VectorFunctionSpace(self.mesh2d, 'DG', 1, name='P1DGv_2d')
         # 2D velocity space
         if self.options.element_family == 'rt-dg':
-            self.function_spaces.U_2d = get_functionspace(self.mesh2d, 'RT', self.options.polynomial_degree+1, name='U_2d')
+            h_family_alias = {'triangle': 'RTF', 'quadrilateral': 'RTCF'}
+            h_cell = self.mesh2d.ufl_cell().cellname()
+            hfam = h_family_alias[h_cell]
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, hfam, self.options.polynomial_degree+1, name='U_2d')
             self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'DG', self.options.polynomial_degree, name='H_2d')
         elif self.options.element_family == 'dg-cg':
             self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, 'DG', self.options.polynomial_degree, name='U_2d')

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -44,7 +44,7 @@ class TimeIntegrator(TimeIntegratorBase):
     """
     Base class for all time integrator objects that march a single equation
     """
-    def __init__(self, equation, solution, fields, dt, solver_parameters={}):
+    def __init__(self, equation, solution, fields, dt, solver_parameters=None):
         """
         :arg equation: the equation to solve
         :type equation: :class:`Equation` object
@@ -66,7 +66,8 @@ class TimeIntegrator(TimeIntegratorBase):
         self.name = '-'.join([self.__class__.__name__,
                               self.equation.__class__.__name__])
         self.solver_parameters = {}
-        self.solver_parameters.update(solver_parameters)
+        if solver_parameters is not None:
+            self.solver_parameters.update(solver_parameters)
 
     def set_dt(self, dt):
         """Update time step"""
@@ -78,7 +79,7 @@ class ForwardEuler(TimeIntegrator):
     """Standard forward Euler time integration scheme."""
     cfl_coeff = 1.0
 
-    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters={}):
+    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters=None):
         """
         :arg equation: the equation to solve
         :type equation: :class:`Equation` object
@@ -138,7 +139,7 @@ class CrankNicolson(TimeIntegrator):
     """Standard Crank-Nicolson time integration scheme."""
     cfl_coeff = CFL_UNCONDITIONALLY_STABLE
 
-    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters={}, theta=0.5, semi_implicit=False):
+    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters=None, theta=0.5, semi_implicit=False):
         """
         :arg equation: the equation to solve
         :type equation: :class:`Equation` object
@@ -225,7 +226,7 @@ class SteadyState(TimeIntegrator):
     """
     cfl_coeff = CFL_UNCONDITIONALLY_STABLE
 
-    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters={}):
+    def __init__(self, equation, solution, fields, dt, bnd_conditions=None, solver_parameters=None):
         """
         :arg equation: the equation to solve
         :type equation: :class:`Equation` object
@@ -273,8 +274,8 @@ class PressureProjectionPicard(TimeIntegrator):
 
     # TODO add more documentation
     def __init__(self, equation, equation_mom, solution, fields, dt,
-                 bnd_conditions=None, solver_parameters={},
-                 solver_parameters_mom={}, theta=0.5, semi_implicit=False,
+                 bnd_conditions=None, solver_parameters=None,
+                 solver_parameters_mom=None, theta=0.5, semi_implicit=False,
                  iterations=2):
         """
         :arg equation: free surface equation
@@ -295,7 +296,9 @@ class PressureProjectionPicard(TimeIntegrator):
         super(PressureProjectionPicard, self).__init__(equation, solution, fields, dt, solver_parameters)
 
         self.equation_mom = equation_mom
-        self.solver_parameters_mom = solver_parameters_mom
+        self.solver_parameters_mom = {}
+        if solver_parameters_mom is not None:
+            self.solver_parameters_mom.update(solver_parameters_mom)
         if semi_implicit:
             # solve a preliminary linearized momentum equation before
             # solving the linearized wave equation terms in a coupled system
@@ -448,7 +451,7 @@ class LeapFrogAM3(TimeIntegrator):
     cfl_coeff = 1.5874
 
     def __init__(self, equation, solution, fields, dt, bnd_conditions=None,
-                 solver_parameters={}, terms_to_add='all'):
+                 solver_parameters=None, terms_to_add='all'):
         """
         :arg equation: equation to solve
         :type equation: :class:`Equation` object
@@ -583,7 +586,7 @@ class SSPRK22ALE(TimeIntegrator):
     cfl_coeff = 1.0
 
     def __init__(self, equation, solution, fields, dt, bnd_conditions=None,
-                 solver_parameters={}, terms_to_add='all'):
+                 solver_parameters=None, terms_to_add='all'):
         """
         :arg equation: equation to solve
         :type equation: :class:`Equation` object

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -166,6 +166,8 @@ def element_continuity(ufl_element):
         'Lagrange': 'cg',
         'Raviart-Thomas': 'hdiv',
         'RTCF': 'hdiv',
+        'Brezzi-Douglas-Marini': 'hdiv',
+        'BDMCF': 'hdiv',
         'Q': 'cg',
         'DQ': 'dg',
     }

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -474,18 +474,21 @@ class VerticalIntegrator(object):
         :kwarg elevation: 3D field defining the free surface elevation
         :kwarg dict solver_parameters: PETSc solver options
         """
-        if solver_parameters is None:
-            solver_parameters = {}
-        solver_parameters.setdefault('snes_type', 'ksponly')
-        solver_parameters.setdefault('ksp_type', 'preonly')
-        solver_parameters.setdefault('pc_type', 'bjacobi')
-        solver_parameters.setdefault('sub_ksp_type', 'preonly')
-        solver_parameters.setdefault('sub_pc_type', 'ilu')
-
         self.output = output
         space = output.function_space()
         mesh = space.mesh()
-        vertical_is_dg = element_continuity(space.ufl_element()).vertical in ['dg', 'hdiv']
+        e_continuity = element_continuity(space.ufl_element())
+        vertical_is_dg = e_continuity.vertical in ['dg', 'hdiv']
+
+        if solver_parameters is None:
+            solver_parameters = {}
+        solver_parameters.setdefault('snes_type', 'ksponly')
+        if e_continuity.vertical != 'hdiv':
+            solver_parameters.setdefault('ksp_type', 'preonly')
+            solver_parameters.setdefault('pc_type', 'bjacobi')
+            solver_parameters.setdefault('sub_ksp_type', 'preonly')
+            solver_parameters.setdefault('sub_pc_type', 'ilu')
+
         tri = TrialFunction(space)
         phi = TestFunction(space)
         normal = FacetNormal(mesh)

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -165,6 +165,7 @@ def element_continuity(ufl_element):
         'Discontinuous Lagrange': 'dg',
         'Lagrange': 'cg',
         'Raviart-Thomas': 'hdiv',
+        'RTCF': 'hdiv',
         'Q': 'cg',
         'DQ': 'dg',
     }

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -111,17 +111,21 @@ class FieldDict(AttrDict):
 
 
 def get_functionspace(mesh, h_family, h_degree, v_family=None, v_degree=None,
-                      vector=False, hdiv=False, variant=None, **kwargs):
+                      vector=False, hdiv=False, variant=None, v_variant=None,
+                      **kwargs):
     gdim = mesh.geometric_dimension()
     assert gdim in [2, 3]
+    hdiv_families = [
+        'RT', 'RTF', 'RTCF', 'RAVIART-THOMAS',
+        'BDM', 'BDMF', 'BDMCF', 'BREZZI-DOUGLAS-MARINI',
+    ]
     if variant is None:
-        if h_family.upper() == 'RT' or h_family.lower() == 'raviart-thomas':
+        if h_family.upper() in hdiv_families:
             variant = 'point'
         else:
             variant = 'equispaced'
+    if v_variant is None:
         v_variant = 'equispaced'
-    else:
-        v_variant = variant
     if gdim == 3:
         if v_family is None:
             v_family = h_family

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -333,13 +333,15 @@ def comp_tracer_mass_3d(scalar_func):
     return val
 
 
-def get_zcoord_from_mesh(zcoord, solver_parameters={}):
+def get_zcoord_from_mesh(zcoord, solver_parameters=None):
     """
     Evaluates z coordinates from the 3D mesh
 
     :arg zcoord: scalar :class:`Function` where coordinates will be stored
     """
     # TODO coordinates should probably be interpolated instead
+    if solver_parameters is None:
+        solver_parameters = {}
     solver_parameters.setdefault('ksp_atol', 1e-12)
     solver_parameters.setdefault('ksp_rtol', 1e-16)
     fs = zcoord.function_space()
@@ -382,7 +384,7 @@ class VerticalVelocitySolver(object):
     condition.
     """
     def __init__(self, solution, uv, bathymetry, boundary_funcs={},
-                 solver_parameters={}):
+                 solver_parameters=None):
         """
         :arg solution: w :class:`Function`
         :arg uv: horizontal velocity :class:`Function`
@@ -391,6 +393,8 @@ class VerticalVelocitySolver(object):
             equation. Provides external values of uv (if any).
         :kwarg dict solver_parameters: PETSc solver options
         """
+        if solver_parameters is None:
+            solver_parameters = {}
         solver_parameters.setdefault('snes_type', 'ksponly')
         solver_parameters.setdefault('ksp_type', 'preonly')
         solver_parameters.setdefault('pc_type', 'bjacobi')
@@ -459,7 +463,7 @@ class VerticalIntegrator(object):
     """
     def __init__(self, input, output, bottom_to_top=True,
                  bnd_value=Constant(0.0), average=False,
-                 bathymetry=None, elevation=None, solver_parameters={}):
+                 bathymetry=None, elevation=None, solver_parameters=None):
         """
         :arg input: 3D field to integrate
         :arg output: 3D field where the integral is stored
@@ -470,6 +474,8 @@ class VerticalIntegrator(object):
         :kwarg elevation: 3D field defining the free surface elevation
         :kwarg dict solver_parameters: PETSc solver options
         """
+        if solver_parameters is None:
+            solver_parameters = {}
         solver_parameters.setdefault('snes_type', 'ksponly')
         solver_parameters.setdefault('ksp_type', 'preonly')
         solver_parameters.setdefault('pc_type', 'bjacobi')
@@ -661,7 +667,7 @@ class VelocityMagnitudeSolver(object):
     Computes magnitude of (u[0],u[1],w) and stores it in solution
     """
     def __init__(self, solution, u=None, w=None, min_val=1e-6,
-                 solver_parameters={}):
+                 solver_parameters=None):
         """
         :arg solution: scalar field for velocity magnitude scalar :class:`Function`
         :type solution: :class:`Function`
@@ -1547,7 +1553,7 @@ class SmagorinskyViscosity(object):
     http://dx.doi.org/10.1175/1520-0493(2000)128%3C2935:BFWASL%3E2.0.CO;2
     """
     def __init__(self, uv, output, c_s, h_elem_size, max_val, min_val=1e-10,
-                 weak_form=True, solver_parameters={}):
+                 weak_form=True, solver_parameters=None):
         """
         :arg uv_3d: horizontal velocity
         :type uv_3d: 3D vector :class:`Function`
@@ -1565,6 +1571,8 @@ class SmagorinskyViscosity(object):
             Necessary for some function spaces (e.g. P0).
         :kwarg dict solver_parameters: PETSc solver options
         """
+        if solver_parameters is None:
+            solver_parameters = {}
         solver_parameters.setdefault('ksp_atol', 1e-12)
         solver_parameters.setdefault('ksp_rtol', 1e-16)
         assert max_val.function_space() == output.function_space(), \


### PR DESCRIPTION
Adds support for BDM-DG discretization in both 2D and 3D models. Setting `options.element_family` to `bdm-dg` gives the BDM(n+1)-P(n)DG velocity-pressure pair. Supports both triangles and quads. Also the `rt-dg` option now works for quads as well.

In the 3D solver, bottom friction treatment has been revised. Vertical diffusion of momentum is now computed for the full velocity (depth average + deviation) instead of the deviation component only. In addition, the computation of the drag coefficient from the bottom roughness length has been revised: the friction term is now defined for the velocity at the bottom (z=-h), and we use a parametrized value for the drag. These updates ensure positivity of the velocity, i.e. there can be no spurious sign changes in the bottom element due to friction even at low resolution.

The `bdm-dg` option has been added to tests. Some tests were refactored/modified accordingly.