### PR TITLE
Revised interior penalty coefficient

### DIFF
--- a/test/momentumEq/test_h-viscosity_mes.py
+++ b/test/momentumEq/test_h-viscosity_mes.py
@@ -186,8 +186,8 @@ def run_convergence(ref_list, expected_rate=None, saveplot=False, **options):
 @pytest.mark.parametrize(
     ('stepper', 'family', 'polynomial_degree', 'warped', 'expected_rate'),
     [
-        ('SSPRK22', 'dg-dg', 1, False, 1.6),
-        ('SSPRK22', 'dg-dg', 1, True, 1.6),
+        ('SSPRK22', 'dg-dg', 1, False, 1.55),
+        ('SSPRK22', 'dg-dg', 1, True, 1.55),
         ('SSPRK22', 'rt-dg', 1, False, 1.7),
         ('SSPRK22', 'rt-dg', 1, True, 1.7),
         ('SSPRK22', 'bdm-dg', 1, False, 1.9),
@@ -212,4 +212,5 @@ if __name__ == '__main__':
                     warped_mesh=True,
                     element_family='dg-dg',
                     timestepper_type='SSPRK22',
+                    expected_rate=1.55,
                     no_exports=False, saveplot=True)

--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -11,10 +11,6 @@ of [1]. The main contributions of [1] are the derivation of a goal-oriented erro
 shallow water modelling and subsequent implementation of mesh adaptation algorithms. An adapted mesh
 resulting from this process is used in this test. The mesh is anisotropic in the flow direction.
 
-If the default SIPG parameter is used, this steady state problem fails to converge under some
-finite element pairs. The automatic SIPG parameter functionality provided by Thetis should ensure
-converge where it was not attained and reduce the number of nonlinear solver iterations otherwise.
-
 [1] J.G. Wallwork, N. Barral, S.C. Kramer, D.A. Ham, M.D. Piggott, "Goal-Oriented Error Estimation
     and Mesh Adaptation in Shallow Water Modelling" (2020), Springer Nature Applied Sciences (to
     appear).
@@ -137,16 +133,10 @@ def family(request):
 
 def test_sipg(family):
     options = {'element_family': family}
-    snes_it_auto = run(use_automatic_sipg_parameter=True, **options)
-    try:
-        snes_it_default = run(use_automatic_sipg_parameter=False, **options)
-        msg = "auto-sipg: snes iterations was not reduced, expected {:d} < {:d}"
-        assert snes_it_auto < snes_it_default, msg.format(snes_it_auto, snes_it_default)
-        msg = "auto-sipg: snes iterations reduced from {:d} to {:d} for {:s} PASSED"
-        print_output(msg.format(snes_it_default, snes_it_auto, family))
-    except ConvergenceError:
-        msg = "auto-sipg: snes converged where it diverged under default for {:s} PASSED"
-        print_output(msg.format(family))
+    snes_it = run(**options)
+    expected = 3
+    msg = f'snes iterations exceed expected: {snes_it} > {expected}'
+    assert snes_it <= expected, msg
 
 # ---------------------------
 # run individual setup for debugging
@@ -154,4 +144,4 @@ def test_sipg(family):
 
 
 if __name__ == '__main__':
-    print_output(run(use_automatic_sipg_parameter=False, no_exports=False, element_family='rt-dg'))
+    print_output(run(no_exports=False, element_family='rt-dg'))

--- a/test/swe2d/test_steady_state_channel_mms.py
+++ b/test/swe2d/test_steady_state_channel_mms.py
@@ -9,13 +9,7 @@ def element_family(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def automatic_sipg(request):
-    return request.param
-
-
-def test_steady_state_channel_mms(element_family, automatic_sipg,
-                                  do_exports=False):
+def test_steady_state_channel_mms(element_family, do_exports=False):
     lx = 5e3
     ly = 1e3
 
@@ -57,7 +51,6 @@ def test_steady_state_channel_mms(element_family, automatic_sipg,
         # --- create solver ---
         solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
         solver_obj.options.element_family = element_family
-        solver_obj.options.use_automatic_sipg_parameter = automatic_sipg
         solver_obj.options.polynomial_degree = order
         solver_obj.options.use_nonlinear_equations = True
         solver_obj.options.quadratic_drag_coefficient = Constant(C_D)

--- a/test/tracerEq/test_h-diffusion_mes.py
+++ b/test/tracerEq/test_h-diffusion_mes.py
@@ -134,7 +134,7 @@ def run(refinement, **model_options):
     return l2_err
 
 
-def run_convergence(ref_list, saveplot=False, **options):
+def run_convergence(ref_list, expected_rate=None, saveplot=False, **options):
     """Runs test for a list of refinements and computes error convergence rate"""
     polynomial_degree = options.get('polynomial_degree', 1)
     l2_err = []
@@ -145,7 +145,6 @@ def run_convergence(ref_list, saveplot=False, **options):
     setup_name = 'h-diffusion'
 
     def check_convergence(x_log, y_log, expected_slope, field_str, saveplot):
-        slope_rtol = 0.22
         slope, intercept, r_value, p_value, std_err = stats.linregress(x_log, y_log)
         if saveplot:
             import matplotlib.pyplot as plt
@@ -176,39 +175,36 @@ def run_convergence(ref_list, saveplot=False, **options):
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
-            assert slope > expected_slope*(1 - slope_rtol), err_msg
+            assert slope > expected_slope, err_msg
             print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
             print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
-    check_convergence(x_log, y_log, polynomial_degree+1, 'salt', saveplot)
+    if expected_rate is None:
+        expected_rate = polynomial_degree+1
+    check_convergence(x_log, y_log, expected_rate, 'salt', saveplot)
 
 # ---------------------------
 # standard tests for pytest
 # ---------------------------
 
 
-@pytest.fixture(params=[0, 1])
-def polynomial_degree(request):
-    return request.param
+@pytest.mark.parametrize(
+    ('stepper', 'polynomial_degree', 'warped', 'expected_rate'),
+    [
+        ('SSPRK22', 0, False, 0.8),
+        ('SSPRK22', 1, False, 1.6),
+        ('SSPRK22', 0, True, 0.7),
+        ('SSPRK22', 1, True, 1.6),
+    ]
+)
+def test_horizontal_diffusion(polynomial_degree, stepper, warped,
+                              expected_rate):
+    run_convergence([1, 2, 3], expected_rate=expected_rate,
+                    polynomial_degree=polynomial_degree,
+                    warped_mesh=warped, timestepper_type=stepper)
 
-
-@pytest.fixture(params=[True, False],
-                ids=['warped', 'regular'])
-def warped(request):
-    return request.param
-
-
-@pytest.fixture(params=['LeapFrog', 'SSPRK22'])
-def stepper(request):
-    return request.param
-
-
-def test_horizontal_diffusion(warped, polynomial_degree, stepper):
-    run_convergence([1, 2, 3], polynomial_degree=polynomial_degree,
-                    warped_mesh=warped,
-                    timestepper_type=stepper)
 
 # ---------------------------
 # run individual setup for debugging
@@ -220,4 +216,5 @@ if __name__ == '__main__':
                     warped_mesh=True,
                     element_family='dg-dg',
                     timestepper_type='SSPRK22',
+                    expected_rate=1.6,
                     no_exports=False, saveplot=True)

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -138,8 +138,6 @@ def run_convergence(ref_list, expected_rate=None, saveplot=False, **options):
             ref_str = 'ref-' + '-'.join([str(r) for r in ref_list])
             degree_str = 'o{:}'.format(polynomial_degree)
             imgfile = '_'.join(['convergence', setup_name, field_str, ref_str, degree_str])
-            if options.get('use_automatic_sipg_parameter', False):
-                imgfile = '_'.join([imgfile, 'sipg_auto'])
             imgfile += '.png'
             imgdir = create_directory('plots')
             imgfile = os.path.join(imgdir, imgfile)

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -104,7 +104,7 @@ def run(refinement, **model_options):
     return l2_err
 
 
-def run_convergence(ref_list, saveplot=False, **options):
+def run_convergence(ref_list, expected_rate=None, saveplot=False, **options):
     """Runs test for a list of refinements and computes error convergence rate"""
     polynomial_degree = options.get('polynomial_degree', 1)
     l2_err = []
@@ -115,7 +115,6 @@ def run_convergence(ref_list, saveplot=False, **options):
     setup_name = 'h-diffusion'
 
     def check_convergence(x_log, y_log, expected_slope, field_str, saveplot):
-        slope_rtol = 0.20
         slope, intercept, r_value, p_value, std_err = stats.linregress(x_log, y_log)
         if saveplot:
             import matplotlib.pyplot as plt
@@ -148,33 +147,35 @@ def run_convergence(ref_list, saveplot=False, **options):
             plt.savefig(imgfile, dpi=200, bbox_inches='tight')
         if expected_slope is not None:
             err_msg = '{:}: Wrong convergence rate {:.4f}, expected {:.4f}'.format(setup_name, slope, expected_slope)
-            assert slope > expected_slope*(1 - slope_rtol), err_msg
+            assert slope > expected_slope, err_msg
             print_output('{:}: convergence rate {:.4f} PASSED'.format(setup_name, slope))
         else:
             print_output('{:}: {:} convergence rate {:.4f}'.format(setup_name, field_str, slope))
         return slope
 
-    check_convergence(x_log, y_log, polynomial_degree+1, 'tracer', saveplot)
+    if expected_rate is None:
+        expected_rate = polynomial_degree+1
+    check_convergence(x_log, y_log, expected_rate, 'tracer', saveplot)
 
 # ---------------------------
 # standard tests for pytest
 # ---------------------------
 
 
-@pytest.fixture(params=[True, False])
-def auto_sipg(request):
-    return request.param
-
-
-@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'BackwardEuler', 'DIRK22', 'DIRK33'])
-def stepper(request):
-    return request.param
-
-
-def test_horizontal_diffusion(auto_sipg, stepper):
-    run_convergence([1, 2, 3], polynomial_degree=1,
-                    timestepper_type=stepper,
-                    use_automatic_sipg_parameter=auto_sipg,
+@pytest.mark.parametrize(
+    ('stepper', 'polynomial_degree', 'expected_rate'),
+    [
+        ('CrankNicolson', 1, 1.8),
+        ('SSPRK33', 1, 1.8),
+        ('ForwardEuler', 1, 1.8),
+        ('BackwardEuler', 1, 1.8),
+        ('DIRK22', 1, 1.8),
+        ('DIRK33', 1, 1.8),
+    ]
+)
+def test_horizontal_diffusion(polynomial_degree, stepper, expected_rate):
+    run_convergence([1, 2, 3], polynomial_degree=polynomial_degree,
+                    timestepper_type=stepper, expected_rate=expected_rate,
                     )
 
 # ---------------------------
@@ -185,4 +186,5 @@ def test_horizontal_diffusion(auto_sipg, stepper):
 if __name__ == '__main__':
     run_convergence([1, 2, 4, 6, 8], polynomial_degree=1,
                     timestepper_type='CrankNicolson',
+                    expected_rate=1.8,
                     no_exports=False, saveplot=True)

--- a/test/tracerEq/test_steady_adv-diff_mms.py
+++ b/test/tracerEq/test_steady_adv-diff_mms.py
@@ -316,14 +316,9 @@ def setup(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
-def auto_sipg(request):
-    return request.param
-
-
-def test_convergence(setup, timestepper_type, auto_sipg):
-    run_convergence(setup, [1, 2, 3], 1, save_plot=False, timestepper_type=timestepper_type,
-                    use_automatic_sipg_parameter=auto_sipg)
+def test_convergence(setup, timestepper_type):
+    run_convergence(setup, [1, 2, 3], 1, save_plot=False,
+                    timestepper_type=timestepper_type)
 
 
 if __name__ == '__main__':

--- a/test/tracerEq/test_steady_adv-diff_mms_2d.py
+++ b/test/tracerEq/test_steady_adv-diff_mms_2d.py
@@ -273,21 +273,12 @@ def conservative_form(request):
 
 def test_convergence(setup, timestepper_type, conservative_form):
     run_convergence(setup, [1, 2, 3], save_plot=False, timestepper_type=timestepper_type,
-                    use_automatic_sipg_parameter=False,
-                    use_tracer_conservative_form=conservative_form)
-
-
-# only setup2 has nonzero diffusion:
-def test_convergence_auto_sipg(timestepper_type, conservative_form):
-    run_convergence(Setup2, [1, 2, 3], save_plot=False, timestepper_type=timestepper_type,
-                    use_automatic_sipg_parameter=True,
                     use_tracer_conservative_form=conservative_form)
 
 
 # setup4 is valid for conservative only
 def test_convergence_conservative_only(timestepper_type):
     run_convergence(Setup4, [1, 2, 3], save_plot=False, timestepper_type=timestepper_type,
-                    use_automatic_sipg_parameter=False,
                     use_tracer_conservative_form=True)
 
 

--- a/test/tracerEq/test_v-diffusion_mes.py
+++ b/test/tracerEq/test_v-diffusion_mes.py
@@ -53,7 +53,6 @@ def run(refinement, **model_options):
     solverobj = solver.FlowSolver(mesh2d, bathymetry_2d, n_layers)
     options = solverobj.options
     options.use_nonlinear_equations = False
-    options.use_ale_moving_mesh = False
     options.use_limiter_for_tracers = False
     options.horizontal_velocity_scale = Constant(1.0)
     options.no_exports = True
@@ -82,18 +81,11 @@ def run(refinement, **model_options):
     x, y, z = SpatialCoordinate(solverobj.mesh)
     ana_salt_expr = 0.5*(u_max + u_min) - 0.5*(u_max - u_min)*erf((z - z0)/sqrt(4*vertical_diffusivity*t_const))
 
-    salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
-    salt_ana_p1 = Function(solverobj.function_spaces.P1, name='salt analytical')
-
-    p1dg_ho = get_functionspace(solverobj.mesh, 'DG',
-                                options.polynomial_degree + 2, vfamily='DG',
-                                vdegree=options.polynomial_degree + 2)
-    salt_ana_ho = Function(p1dg_ho, name='salt analytical')
-
     solverobj.assign_initial_conditions(salt=ana_salt_expr)
 
     # export analytical solution
     if not options.no_exports:
+        salt_ana = Function(solverobj.function_spaces.H, name='salt analytical')
         out_salt_ana = File(os.path.join(options.output_directory, 'salt_ana.pvd'))
 
     def export_func():
@@ -102,7 +94,7 @@ def run(refinement, **model_options):
             # update analytical solution to correct time
             t_const.assign(t)
             salt_ana.project(ana_salt_expr)
-            out_salt_ana.write(salt_ana_p1.project(salt_ana))
+            out_salt_ana.write(salt_ana)
 
     # export initial conditions
     export_func()
@@ -127,9 +119,8 @@ def run(refinement, **model_options):
 
     # project analytical solultion on high order mesh
     t_const.assign(t)
-    salt_ana_ho.project(ana_salt_expr)
     # compute L2 norm
-    l2_err = errornorm(salt_ana_ho, solverobj.fields.salt_3d)/numpy.sqrt(area)
+    l2_err = errornorm(ana_salt_expr, solverobj.fields.salt_3d)/numpy.sqrt(area)
     print_output('L2 error {:.12f}'.format(l2_err))
 
     return l2_err
@@ -146,7 +137,7 @@ def run_convergence(ref_list, saveplot=False, **options):
     setup_name = 'v-diffusion'
 
     def check_convergence(x_log, y_log, expected_slope, field_str, saveplot):
-        slope_rtol = 0.07
+        slope_rtol = 0.14
         slope, intercept, r_value, p_value, std_err = stats.linregress(x_log, y_log)
         if saveplot:
             import matplotlib.pyplot as plt
@@ -200,13 +191,14 @@ def implicit(request):
     return request.param
 
 
-@pytest.mark.parametrize(('stepper', 'use_ale'),
-                         [('LeapFrog', True),
-                          ('SSPRK22', True)])
-def test_vertical_diffusion(polynomial_degree, implicit, stepper, use_ale):
-    run_convergence([1, 2, 4], polynomial_degree=polynomial_degree, implicit=implicit,
-                    timestepper_type=stepper,
-                    use_ale_moving_mesh=use_ale)
+@pytest.fixture(params=['LeapFrog', 'SSPRK22'])
+def stepper(request):
+    return request.param
+
+
+def test_vertical_diffusion(polynomial_degree, implicit, stepper):
+    run_convergence([1, 2, 4], polynomial_degree=polynomial_degree,
+                    implicit=implicit, timestepper_type=stepper)
 
 # ---------------------------
 # run individual setup for debugging
@@ -218,5 +210,4 @@ if __name__ == '__main__':
                     implicit=False,
                     element_family='dg-dg',
                     timestepper_type='SSPRK22',
-                    use_ale_moving_mesh=True,
                     no_exports=False, saveplot=True)

--- a/thetis/conservative_tracer_eq_2d.py
+++ b/thetis/conservative_tracer_eq_2d.py
@@ -30,16 +30,16 @@ class ConservativeTracerTerm(TracerTerm):
     """
     def __init__(self, function_space, depth,
                  use_lax_friedrichs=False,
-                 sipg_parameter=Constant(10.0)):
+                 sipg_factor=Constant(1.0)):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class: `DepthExpression` containing depth info
         :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_parameter: :class: `Constant` or :class: `Function` penalty parameter for SIPG
+        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
         """
         super().__init__(function_space, depth,
                          use_lax_friedrichs=use_lax_friedrichs,
-                         sipg_parameter=sipg_parameter)
+                         sipg_factor=sipg_factor)
 
     # TODO: at the moment this is the same as TracerTerm, but we probably want to overload its
     # get_bnd_functions method
@@ -173,15 +173,15 @@ class ConservativeTracerEquation2D(Equation):
     """
     def __init__(self, function_space, depth,
                  use_lax_friedrichs=False,
-                 sipg_parameter=Constant(10.0)):
+                 sipg_factor=Constant(1.0)):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class: `DepthExpression` containing depth info
         :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_parameter: :class: `Constant` or :class: `Function` penalty parameter for SIPG
+        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
         """
         super(ConservativeTracerEquation2D, self).__init__(function_space)
-        args = (function_space, depth, use_lax_friedrichs, sipg_parameter)
+        args = (function_space, depth, use_lax_friedrichs, sipg_factor)
         self.add_term(ConservativeHorizontalAdvectionTerm(*args), 'explicit')
         self.add_term(ConservativeHorizontalDiffusionTerm(*args), 'explicit')
         self.add_term(ConservativeSourceTerm(*args), 'source')

--- a/thetis/conservative_tracer_eq_2d.py
+++ b/thetis/conservative_tracer_eq_2d.py
@@ -134,13 +134,12 @@ class ConservativeHorizontalDiffusionTerm(ConservativeTracerTerm, HorizontalDiff
             \text{jump}(\phi \textbf{n}_h) dS \\
         &- \int_\Gamma \mu_h (\nabla_h \phi) \cdot \textbf{n}_h ds
 
-    where :math:`\sigma` is a penalty parameter,
-    see Epshteyn and Riviere (2007).
+    where :math:`\sigma` is a penalty parameter, see Hillewaert (2013).
 
-    Epshteyn and Riviere (2007). Estimation of penalty parameters for symmetric
-    interior penalty Galerkin methods. Journal of Computational and Applied
-    Mathematics, 206(2):843-872. http://dx.doi.org/10.1016/j.cam.2006.08.029
-
+    Hillewaert, Koen (2013). Development of the discontinuous Galerkin method
+    for high-resolution, large scale CFD and acoustics in industrial
+    geometries. PhD Thesis. Université catholique de Louvain.
+    https://dial.uclouvain.be/pr/boreal/object/boreal:128254/
     """
     # TODO: at the moment the same as HorizontalDiffusionTerm
     # do we need additional H-derivative term?

--- a/thetis/momentum_eq.py
+++ b/thetis/momentum_eq.py
@@ -325,12 +325,12 @@ class HorizontalViscosityTerm(MomentumTerm):
         + \int_{\mathcal{I}_h \cup \mathcal{I}_v} \text{jump}(\textbf{u} \textbf{n}_h) \cdot \text{avg}( \nu_h \nabla_h \boldsymbol{\psi}) dS \\
         &- \int_{\mathcal{I}_h \cup \mathcal{I}_v} \sigma \text{avg}(\nu_h) \text{jump}(\textbf{u} \textbf{n}_h) \cdot \text{jump}(\boldsymbol{\psi} \textbf{n}_h) dS
 
-    where :math:`\sigma` is a penalty parameter,
-    see Epshteyn and Riviere (2007).
+    where :math:`\sigma` is a penalty parameter, see Hillewaert (2013).
 
-    Epshteyn and Riviere (2007). Estimation of penalty parameters for symmetric
-    interior penalty Galerkin methods. Journal of Computational and Applied
-    Mathematics, 206(2):843-872. http://dx.doi.org/10.1016/j.cam.2006.08.029
+    Hillewaert, Koen (2013). Development of the discontinuous Galerkin method
+    for high-resolution, large scale CFD and acoustics in industrial
+    geometries. PhD Thesis. Université catholique de Louvain.
+    https://dial.uclouvain.be/pr/boreal/object/boreal:128254/
     """
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         viscosity_h = fields_old.get('viscosity_h')
@@ -358,18 +358,19 @@ class HorizontalViscosityTerm(MomentumTerm):
         f += inner(grad_test, stress)*self.dx
 
         if self.horizontal_continuity in ['dg', 'hdiv']:
-            assert self.h_elem_size is not None, 'h_elem_size must be defined'
-            assert self.v_elem_size is not None, 'v_elem_size must be defined'
-            # TODO compute elemsize as CellVolume/FacetArea
-            # h = n.D.n where D = diag(h_h, h_h, h_v)
-            elemsize = (self.h_elem_size*(self.normal[0]**2 + self.normal[1]**2)
-                        + self.v_elem_size*self.normal[2]**2)
-            alpha = self.sipg_parameter
-            assert alpha is not None
-            sigma = avg(alpha/elemsize)
+            h_cell = self.mesh.ufl_cell().sub_cells()[0]
+            p, q = self.function_space.ufl_element().degree()
+            cp = (p + 1) * (p + 2) / 2 if h_cell == triangle else (p + 1)**2
+            # by default the factor is multiplied by 2 to ensure convergence
+            sigma = cp * FacetArea(self.mesh) / CellVolume(self.mesh)
+            sp = sigma('+')
+            sm = sigma('-')
+            sigma_max = conditional(sp > sm, sp, sm)
             ds_interior = (self.dS_h + self.dS_v)
-            f += sigma*inner(tensor_jump(self.normal, self.test),
-                             dot(avg(visc_tensor), tensor_jump(self.normal, uv)))*ds_interior
+            f += sigma_max*inner(
+                tensor_jump(self.normal, self.test),
+                dot(avg(visc_tensor), tensor_jump(self.normal, uv))
+            )*ds_interior
             f += -inner(avg(dot(visc_tensor, nabla_grad(self.test))),
                         tensor_jump(self.normal, uv))*ds_interior
             f += -inner(tensor_jump(self.normal, self.test),
@@ -398,12 +399,12 @@ class VerticalViscosityTerm(MomentumTerm):
         + \int_{\mathcal{I}_h} \text{jump}(\textbf{u} n_z) \cdot \text{avg}\left(\nu \frac{\partial \boldsymbol{\psi}}{\partial z}\right) dS \\
         &- \int_{\mathcal{I}_h} \sigma \text{avg}(\nu) \text{jump}(\textbf{u} n_z) \cdot \text{jump}(\boldsymbol{\psi} n_z) dS
 
-    where :math:`\sigma` is a penalty parameter,
-    see Epshteyn and Riviere (2007).
+    where :math:`\sigma` is a penalty parameter, see Hillewaert (2013).
 
-    Epshteyn and Riviere (2007). Estimation of penalty parameters for symmetric
-    interior penalty Galerkin methods. Journal of Computational and Applied
-    Mathematics, 206(2):843-872. http://dx.doi.org/10.1016/j.cam.2006.08.029
+    Hillewaert, Koen (2013). Development of the discontinuous Galerkin method
+    for high-resolution, large scale CFD and acoustics in industrial
+    geometries. PhD Thesis. Université catholique de Louvain.
+    https://dial.uclouvain.be/pr/boreal/object/boreal:128254/
     """
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         viscosity_v = fields_old.get('viscosity_v')
@@ -415,19 +416,18 @@ class VerticalViscosityTerm(MomentumTerm):
         f += inner(grad_test, diff_flux)*self.dx
 
         if self.vertical_continuity in ['dg', 'hdiv']:
-            assert self.h_elem_size is not None, 'h_elem_size must be defined'
-            assert self.v_elem_size is not None, 'v_elem_size must be defined'
-            # TODO compute elemsize as CellVolume/FacetArea
-            # h = n.D.n where D = diag(h_h, h_h, h_v)
-            elemsize = (self.h_elem_size*(self.normal[0]**2 + self.normal[1]**2)
-                        + self.v_elem_size*self.normal[2]**2)
-
-            alpha = self.sipg_parameter_vertical
-            assert alpha is not None
-            sigma = avg(alpha/elemsize)
+            p, q = self.function_space.ufl_element().degree()
+            cp = (q + 1)**2
+            # by default the factor is multiplied by 2 to ensure convergence
+            sigma = cp * FacetArea(self.mesh) / CellVolume(self.mesh)
+            sp = sigma('+')
+            sm = sigma('-')
+            sigma_max = conditional(sp > sm, sp, sm)
             ds_interior = (self.dS_h)
-            f += sigma*inner(tensor_jump(self.normal[2], self.test),
-                             avg(viscosity_v)*tensor_jump(self.normal[2], solution))*ds_interior
+            f += sigma_max*inner(
+                tensor_jump(self.normal[2], self.test),
+                avg(viscosity_v)*tensor_jump(self.normal[2], solution)
+            )*ds_interior
             f += -inner(avg(viscosity_v*Dx(self.test, 2)),
                         tensor_jump(self.normal[2], solution))*ds_interior
             f += -inner(tensor_jump(self.normal[2], self.test),

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -503,20 +503,6 @@ class CommonModelOptions(FrozenConfigurable):
         None, allow_none=True, help="Source term for 2D tracer equation").tag(config=True)
     horizontal_diffusivity = FiredrakeCoefficient(
         None, allow_none=True, help="Horizontal diffusivity for tracers and sediment").tag(config=True)
-    use_automatic_sipg_parameter = Bool(False, help=r"""
-        Toggle automatic computation of the SIPG penalty parameter used in viscosity and
-        diffusivity terms.
-
-        By default, this parameter is set to
-
-        ..math::
-            \alpha = 5p(p+1),
-
-        where :math:`p` is the polynomial degree of the velocity space.
-
-        For anisotropic meshes, it is advisable to use the automatic SIPG parameter,
-        rather than the default.
-        """).tag(config=True)
     sipg_parameter = FiredrakeScalarExpression(
         Constant(10.0), help="Penalty parameter used for horizontal viscosity terms.").tag(config=True)
     sipg_parameter_tracer = FiredrakeScalarExpression(

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -503,10 +503,10 @@ class CommonModelOptions(FrozenConfigurable):
         None, allow_none=True, help="Source term for 2D tracer equation").tag(config=True)
     horizontal_diffusivity = FiredrakeCoefficient(
         None, allow_none=True, help="Horizontal diffusivity for tracers and sediment").tag(config=True)
-    sipg_parameter = FiredrakeScalarExpression(
-        Constant(10.0), help="Penalty parameter used for horizontal viscosity terms.").tag(config=True)
-    sipg_parameter_tracer = FiredrakeScalarExpression(
-        Constant(10.0), help="Penalty parameter used for horizontal diffusivity terms.").tag(config=True)
+    sipg_factor = FiredrakeScalarExpression(
+        Constant(1.0), help="Penalty parameter scaling factor for horizontal viscosity terms.").tag(config=True)
+    sipg_factor_tracer = FiredrakeScalarExpression(
+        Constant(1.0), help="Penalty parameter scaling factor for horizontal diffusivity terms.").tag(config=True)
 
 
 class SedimentModelOptions(FrozenHasTraits):
@@ -784,13 +784,13 @@ class ModelOptions3d(CommonModelOptions):
         Constant(10.0), help="Constant temperature if temperature is not solved").tag(config=True)
     constant_salinity = FiredrakeConstantTraitlet(
         Constant(0.0), help="Constant salinity if salinity is not solved").tag(config=True)
-    sipg_parameter_vertical = FiredrakeScalarExpression(
-        Constant(10.0), help="Penalty parameter used for vertical viscosity terms.").tag(config=True)
-    sipg_parameter_vertical_tracer = FiredrakeScalarExpression(
-        Constant(10.0), help="Penalty parameter used for vertical diffusivity terms.").tag(config=True)
-    sipg_parameter_turb = FiredrakeScalarExpression(
-        Constant(1.5), help="Penalty parameter used for horizontal diffusivity terms of the turbulence model.").tag(config=True)
-    sipg_parameter_vertical_turb = FiredrakeScalarExpression(
-        Constant(1.0), help="Penalty parameter used for vertical diffusivity terms of the turbulence model.").tag(config=True)
+    sipg_factor_vertical = FiredrakeScalarExpression(
+        Constant(1.0), help="Penalty parameter scaling factor for vertical viscosity terms.").tag(config=True)
+    sipg_factor_vertical_tracer = FiredrakeScalarExpression(
+        Constant(1.0), help="Penalty parameter scaling factor for vertical diffusivity terms.").tag(config=True)
+    sipg_factor_turb = FiredrakeScalarExpression(
+        Constant(1.0), help="Penalty parameter scaling factor for horizontal diffusivity terms of the turbulence model.").tag(config=True)
+    sipg_factor_vertical_turb = FiredrakeScalarExpression(
+        Constant(1.0), help="Penalty parameter scaling factor for vertical diffusivity terms of the turbulence model.").tag(config=True)
     internal_pg_scalar = FiredrakeConstantTraitlet(
         None, allow_none=True, help="A constant to scale the internal pressure gradient. Used to ramp up the model.").tag(config=True)

--- a/thetis/sediment_eq_2d.py
+++ b/thetis/sediment_eq_2d.py
@@ -35,12 +35,12 @@ class SedimentTerm(TracerTerm):
     Generic sediment term that provides commonly used members.
     """
     def __init__(self, function_space, depth, sediment_model,
-                 use_lax_friedrichs=True, sipg_parameter=Constant(10.0), conservative=False):
+                 use_lax_friedrichs=True, sipg_factor=Constant(1.0), conservative=False):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class:`DepthExpression` containing depth info
         :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_parameter: :class:`Constant` or :class:`Function` penalty parameter for SIPG
+        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
         :kwarg bool conservative: whether to use conservative tracer
         """
         super(SedimentTerm, self).__init__(function_space, depth)
@@ -116,17 +116,17 @@ class SedimentEquation2D(Equation):
     """
     def __init__(self, function_space, depth, sediment_model,
                  use_lax_friedrichs=False,
-                 sipg_parameter=Constant(10.0),
+                 sipg_factor=Constant(1.0),
                  conservative=False):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class:`DepthExpression` containing depth info
         :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_parameter: :class:`Constant` or :class:`Function` penalty parameter for SIPG
+        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
         :kwarg bool conservative: whether to use conservative tracer
         """
         super(SedimentEquation2D, self).__init__(function_space)
-        args = (function_space, depth, sediment_model, use_lax_friedrichs, sipg_parameter, conservative)
+        args = (function_space, depth, sediment_model, use_lax_friedrichs, sipg_factor, conservative)
         if conservative:
             self.add_term(ConservativeSedimentAdvectionTerm(*args), 'explicit')
         else:

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -529,6 +529,7 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
         total_h = self.depth.get_total_depth(eta_old)
 
         nu = fields_old.get('viscosity_h')
+        sipg_factor = self.options.sipg_factor
         if nu is None:
             return 0
 
@@ -547,8 +548,9 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
             cell = self.mesh.ufl_cell()
             p = self.function_space.ufl_element().degree()
             cp = (p + 1) * (p + 2) / 2 if cell == triangle else (p + 1)**2
+            l_normal = CellVolume(self.mesh) / FacetArea(self.mesh)
             # by default the factor is multiplied by 2 to ensure convergence
-            sigma = cp * FacetArea(self.mesh) / CellVolume(self.mesh)
+            sigma = sipg_factor * cp / l_normal
             sp = sigma('+')
             sm = sigma('-')
             sigma_max = conditional(sp > sm, sp, sm)

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -499,8 +499,7 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
         - \int_\Gamma \text{avg}(\nu_h)\big(\text{jump}(\bar{\textbf{u}} \textbf{n}) + \text{jump}(\bar{\textbf{u}} \textbf{n})^T\big) \cdot \text{avg}(\nabla \boldsymbol{\psi}) dS \\
         &+ \int_\Gamma \sigma \text{avg}(\nu_h) \big(\text{jump}(\bar{\textbf{u}} \textbf{n}) + \text{jump}(\bar{\textbf{u}} \textbf{n})^T\big) \cdot \text{jump}(\boldsymbol{\psi} \textbf{n}) dS
 
-    where :math:`\sigma` is a penalty parameter,
-    see Epshteyn and Riviere (2007).
+    where :math:`\sigma` is a penalty parameter, see Hillewaert (2013).
 
     If option :attr:`.ModelOptions.use_grad_div_viscosity_term` is ``False``,
     we use viscous stress :math:`\boldsymbol{\tau}_\nu = \nu_h \nabla \bar{\textbf{u}}`.
@@ -521,9 +520,10 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
 
     as a source term.
 
-    Epshteyn and Riviere (2007). Estimation of penalty parameters for symmetric
-    interior penalty Galerkin methods. Journal of Computational and Applied
-    Mathematics, 206(2):843-872. http://dx.doi.org/10.1016/j.cam.2006.08.029
+    Hillewaert, Koen (2013). Development of the discontinuous Galerkin method
+    for high-resolution, large scale CFD and acoustics in industrial
+    geometries. PhD Thesis. Université catholique de Louvain.
+    https://dial.uclouvain.be/pr/boreal/object/boreal:128254/
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions=None):
         total_h = self.depth.get_total_depth(eta_old)
@@ -533,7 +533,6 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
             return 0
 
         n = self.normal
-        h = self.cellsize
 
         if self.options.use_grad_div_viscosity_term:
             stress = nu*2.*sym(grad(uv))
@@ -545,10 +544,16 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
         f = inner(grad(self.u_test), stress)*self.dx
 
         if self.u_continuity in ['dg', 'hdiv']:
-            alpha = self.options.sipg_parameter
-            assert alpha is not None
+            cell = self.mesh.ufl_cell()
+            p = self.function_space.ufl_element().degree()
+            cp = (p + 1) * (p + 2) / 2 if cell == triangle else (p + 1)**2
+            # by default the factor is multiplied by 2 to ensure convergence
+            sigma = cp * FacetArea(self.mesh) / CellVolume(self.mesh)
+            sp = sigma('+')
+            sm = sigma('-')
+            sigma_max = conditional(sp > sm, sp, sm)
             f += (
-                + avg(alpha/h)*inner(tensor_jump(self.u_test, n), stress_jump)*self.dS
+                + sigma_max*inner(tensor_jump(self.u_test, n), stress_jump)*self.dS
                 - inner(avg(grad(self.u_test)), stress_jump)*self.dS
                 - inner(tensor_jump(self.u_test, n), avg(stress))*self.dS
             )
@@ -572,7 +577,7 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
                         stress_jump = nu*outer(delta_uv, n)
 
                     f += (
-                        alpha/h*inner(outer(self.u_test, n), stress_jump)*ds_bnd
+                        sigma*inner(outer(self.u_test, n), stress_jump)*ds_bnd
                         - inner(grad(self.u_test), stress_jump)*ds_bnd
                         - inner(outer(self.u_test, n), stress)*ds_bnd
                     )

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -622,8 +622,8 @@ class FlowSolver(FrozenClass):
                                                         use_nonlinear_equations=self.options.use_nonlinear_equations,
                                                         use_lax_friedrichs=self.options.use_lax_friedrichs_velocity,
                                                         use_bottom_friction=expl_bottom_friction,
-                                                        sipg_parameter=self.options.sipg_parameter,
-                                                        sipg_parameter_vertical=self.options.sipg_parameter_vertical)
+                                                        sipg_factor=self.options.sipg_factor,
+                                                        sipg_factor_vertical=self.options.sipg_factor_vertical)
         if self.options.use_implicit_vertical_diffusion:
             self.eq_vertmomentum = momentum_eq.MomentumEquation(self.fields.uv_3d.function_space(),
                                                                 bathymetry=self.fields.bathymetry_2d.view_3d,
@@ -632,8 +632,8 @@ class FlowSolver(FrozenClass):
                                                                 use_nonlinear_equations=False,
                                                                 use_lax_friedrichs=self.options.use_lax_friedrichs_velocity,
                                                                 use_bottom_friction=self.options.use_bottom_friction,
-                                                                sipg_parameter=self.options.sipg_parameter,
-                                                                sipg_parameter_vertical=self.options.sipg_parameter_vertical)
+                                                                sipg_factor=self.options.sipg_factor,
+                                                                sipg_factor_vertical=self.options.sipg_factor_vertical)
         if self.options.solve_salinity:
             self.eq_salt = tracer_eq.TracerEquation(self.fields.salt_3d.function_space(),
                                                     bathymetry=self.fields.bathymetry_2d.view_3d,
@@ -641,16 +641,16 @@ class FlowSolver(FrozenClass):
                                                     h_elem_size=self.fields.h_elem_size_3d,
                                                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
                                                     use_symmetric_surf_bnd=self.options.element_family == 'dg-dg',
-                                                    sipg_parameter=self.options.sipg_parameter_tracer,
-                                                    sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
+                                                    sipg_factor=self.options.sipg_factor_tracer,
+                                                    sipg_factor_vertical=self.options.sipg_factor_vertical_tracer)
             if self.options.use_implicit_vertical_diffusion:
                 self.eq_salt_vdff = tracer_eq.TracerEquation(self.fields.salt_3d.function_space(),
                                                              bathymetry=self.fields.bathymetry_2d.view_3d,
                                                              v_elem_size=self.fields.v_elem_size_3d,
                                                              h_elem_size=self.fields.h_elem_size_3d,
                                                              use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                             sipg_parameter=self.options.sipg_parameter_tracer,
-                                                             sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
+                                                             sipg_factor=self.options.sipg_factor_tracer,
+                                                             sipg_factor_vertical=self.options.sipg_factor_vertical_tracer)
 
         if self.options.solve_temperature:
             self.eq_temp = tracer_eq.TracerEquation(self.fields.temp_3d.function_space(),
@@ -659,16 +659,16 @@ class FlowSolver(FrozenClass):
                                                     h_elem_size=self.fields.h_elem_size_3d,
                                                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
                                                     use_symmetric_surf_bnd=self.options.element_family == 'dg-dg',
-                                                    sipg_parameter=self.options.sipg_parameter_tracer,
-                                                    sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
+                                                    sipg_factor=self.options.sipg_factor_tracer,
+                                                    sipg_factor_vertical=self.options.sipg_factor_vertical_tracer)
             if self.options.use_implicit_vertical_diffusion:
                 self.eq_temp_vdff = tracer_eq.TracerEquation(self.fields.temp_3d.function_space(),
                                                              bathymetry=self.fields.bathymetry_2d.view_3d,
                                                              v_elem_size=self.fields.v_elem_size_3d,
                                                              h_elem_size=self.fields.h_elem_size_3d,
                                                              use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                             sipg_parameter=self.options.sipg_parameter_tracer,
-                                                             sipg_parameter_vertical=self.options.sipg_parameter_vertical_tracer)
+                                                             sipg_factor=self.options.sipg_factor_tracer,
+                                                             sipg_factor_vertical=self.options.sipg_factor_vertical_tracer)
 
         self.eq_sw.bnd_functions = self.bnd_functions['shallow_water']
         self.eq_momentum.bnd_functions = self.bnd_functions['momentum']
@@ -684,15 +684,15 @@ class FlowSolver(FrozenClass):
                                                            v_elem_size=self.fields.v_elem_size_3d,
                                                            h_elem_size=self.fields.h_elem_size_3d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                           sipg_parameter=self.options.sipg_parameter_turb,
-                                                           sipg_parameter_vertical=self.options.sipg_parameter_vertical_turb)
+                                                           sipg_factor=self.options.sipg_factor_turb,
+                                                           sipg_factor_vertical=self.options.sipg_factor_vertical_turb)
                 self.eq_psi_adv = tracer_eq.TracerEquation(self.fields.psi_3d.function_space(),
                                                            bathymetry=self.fields.bathymetry_2d.view_3d,
                                                            v_elem_size=self.fields.v_elem_size_3d,
                                                            h_elem_size=self.fields.h_elem_size_3d,
                                                            use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                                                           sipg_parameter=self.options.sipg_parameter_turb,
-                                                           sipg_parameter_vertical=self.options.sipg_parameter_vertical_turb)
+                                                           sipg_factor=self.options.sipg_factor_turb,
+                                                           sipg_factor_vertical=self.options.sipg_factor_vertical_turb)
             # implicit vertical diffusion eqn with production terms
             self.eq_tke_diff = turbulence.TKEEquation(self.fields.tke_3d.function_space(),
                                                       self.turbulence_model,

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -445,97 +445,6 @@ class FlowSolver(FrozenClass):
 
         self._isfrozen = True
 
-    def set_sipg_parameter(self):
-        r"""
-        Compute a penalty parameter which ensures stability of the Interior Penalty method
-        used for viscosity and diffusivity terms, from Epshteyn et al. 2007
-        (http://dx.doi.org/10.1016/j.cam.2006.08.029).
-
-        The scheme is stable if
-
-        ..math::
-            \alpha|_K > 3*X*p*(p+1)*\cot(\theta_K),
-
-        for all elements :math:`K`, where
-
-        ..math::
-            X = \frac{\max_{x\in K}(\nu(x))}{\min_{x\in K}(\nu(x))},
-
-        :math:`p` the degree, and :math:`\theta_K` is the minimum angle in the element.
-        """
-        degree_h, degree_v = self.function_spaces.U.ufl_element().degree()
-        alpha_h = Constant(5.0*degree_h*(degree_h+1) if degree_h != 0 else 1.5)
-        alpha_v = Constant(5.0*degree_v*(degree_v+1) if degree_v != 0 else 1.0)
-        degree_h_tracer, degree_v_tracer = self.function_spaces.H.ufl_element().degree()
-        alpha_h_tracer = Constant(5.0*degree_h_tracer*(degree_h_tracer+1) if degree_h_tracer != 0 else 1.5)
-        alpha_v_tracer = Constant(5.0*degree_v_tracer*(degree_v_tracer+1) if degree_v_tracer != 0 else 1.0)
-        degree_h_turb, degree_v_turb = self.function_spaces.turb_space.ufl_element().degree()
-        alpha_h_turb = Constant(5.0*degree_h_turb*(degree_h_turb+1) if degree_h_turb != 0 else 1.5)
-        alpha_v_turb = Constant(5.0*degree_v_turb*(degree_v_turb+1) if degree_v_turb != 0 else 1.0)
-
-        if self.options.use_automatic_sipg_parameter:
-
-            # Compute minimum angle in 2d mesh
-            theta2d = get_minimum_angles_2d(self.mesh2d)
-            min_angle = theta2d.vector().gather().min()
-            print_output("Minimum angle in 2D mesh: {:.2f} degrees".format(np.rad2deg(min_angle)))
-
-            # Expand minimum angle field to extruded mesh
-            P0 = self.function_spaces.P0
-            theta = Function(P0)
-            ExpandFunctionTo3d(theta2d, theta).solve()
-            cot_theta = 1.0/tan(theta)
-
-            # Horizontal component
-            nu = self.options.horizontal_viscosity
-            if nu is not None:
-                self.options.sipg_parameter = Function(P0)
-                self.options.sipg_parameter.interpolate(alpha_h*get_sipg_ratio(nu)*cot_theta)
-                max_sipg = self.options.sipg_parameter.vector().gather().max()
-                print_output("Maximum SIPG value in horizontal: {:.2f}".format(max_sipg))
-            else:
-                print_output("SIPG parameter in horizontal: {:.2f}".format(alpha_h.values()[0]))
-
-            # Vertical component
-            print_output("SIPG parameter in vertical: {:.2f}".format(alpha_v.values()[0]))
-
-            # Penalty parameter for tracers / turbulence model
-            if self.options.solve_salinity or self.options.solve_temperature or self.options.use_turbulence:
-
-                # Horizontal component
-                nu = self.options.horizontal_diffusivity
-                if nu is not None:
-                    scaling = get_sipg_ratio(nu)*cot_theta
-                    if self.options.solve_salinity or self.options.solve_temperature:
-                        self.options.sipg_parameter_tracer = Function(P0)
-                        self.options.sipg_parameter_tracer.interpolate(alpha_h_tracer*scaling)
-                        max_sipg = self.options.sipg_parameter_tracer.vector().gather().max()
-                        print_output("Maximum tracer SIPG value in horizontal: {:.2f}".format(max_sipg))
-                    if self.options.use_turbulence:
-                        self.options.sipg_parameter_turb = Function(P0)
-                        self.options.sipg_parameter_turb.interpolate(alpha_h_turb*scaling)
-                        max_sipg = self.options.sipg_parameter_turb.vector().gather().max()
-                        print_output("Maximum turbulence SIPG value in horizontal: {:.2f}".format(max_sipg))
-                else:
-                    if self.options.solve_salinity or self.options.solve_temperature:
-                        print_output("Tracer SIPG parameter in horizontal: {:.2f}".format(alpha_h_tracer.values()[0]))
-                    if self.options.use_turbulence:
-                        print_output("Turbulence SIPG parameter in horizontal: {:.2f}".format(alpha_h_turb.values()[0]))
-
-                # Vertical component
-                if self.options.solve_salinity or self.options.solve_temperature:
-                    print_output("Tracer SIPG parameter in vertical: {:.2f}".format(alpha_v_tracer.values()[0]))
-                if self.options.use_turbulence:
-                    print_output("Turbulence SIPG parameter in vertical: {:.2f}".format(alpha_v_turb.values()[0]))
-        else:
-            print_output("Using default SIPG parameters")
-            self.options.sipg_parameter.assign(alpha_h)
-            self.options.sipg_parameter_tracer.assign(alpha_h_tracer)
-            self.options.sipg_parameter_turb.assign(alpha_h_turb)
-        self.options.sipg_parameter_vertical.assign(alpha_v)
-        self.options.sipg_parameter_vertical_tracer.assign(alpha_v_tracer)
-        self.options.sipg_parameter_vertical_turb.assign(alpha_v_turb)
-
     def create_fields(self):
         """
         Creates all fields
@@ -697,7 +606,6 @@ class FlowSolver(FrozenClass):
             filehandler = logging.logging.FileHandler(logfile, mode='w')
             filehandler.setFormatter(logging.logging.Formatter('%(message)s'))
             output_logger.addHandler(filehandler)
-        self.set_sipg_parameter()
 
         self.depth = DepthExpression(self.fields.bathymetry_2d,
                                      use_nonlinear_equations=self.options.use_nonlinear_equations)

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -312,7 +312,7 @@ class FlowSolver2d(FrozenClass):
         self.eq_sw = shallowwater_eq.ShallowWaterEquations(
             self.fields.solution_2d.function_space(),
             self.depth,
-            self.options
+            self.options,
         )
         self.eq_sw.bnd_functions = self.bnd_functions['shallow_water']
         if self.options.solve_tracer:
@@ -321,12 +321,12 @@ class FlowSolver2d(FrozenClass):
                 self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(
                     self.function_spaces.Q_2d, self.depth,
                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                    sipg_parameter=self.options.sipg_parameter_tracer)
+                    sipg_factor=self.options.sipg_factor_tracer)
             else:
                 self.eq_tracer = tracer_eq_2d.TracerEquation2D(
                     self.function_spaces.Q_2d, self.depth,
                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                    sipg_parameter=self.options.sipg_parameter_tracer)
+                    sipg_factor=self.options.sipg_factor_tracer)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:
@@ -343,7 +343,7 @@ class FlowSolver2d(FrozenClass):
             self.eq_sediment = sediment_eq_2d.SedimentEquation2D(
                 self.function_spaces.Q_2d, self.depth, self.sediment_model,
                 use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                sipg_parameter=self.options.sipg_parameter_tracer,
+                sipg_factor=self.options.sipg_factor_tracer,
                 conservative=sediment_options.use_sediment_conservative_form)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)

--- a/thetis/turbulence.py
+++ b/thetis/turbulence.py
@@ -753,7 +753,7 @@ class GLSVerticalDiffusionTerm(VerticalDiffusionTerm):
     """
     def __init__(self, function_space, schmidt_nb,
                  bathymetry=None, v_elem_size=None, h_elem_size=None,
-                 sipg_parameter=Constant(1.0)):
+                 sipg_factor=Constant(1.0)):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg schmidt_nb: the Schmidt number of TKE or Psi
@@ -763,10 +763,12 @@ class GLSVerticalDiffusionTerm(VerticalDiffusionTerm):
             element size
         :kwarg h_elem_size: scalar :class:`Function` that defines the horizontal
             element size
+        :kwarg sipg_factor: :class: `Constant` or :class: `Function` vertical SIPG penalty scaling factor
+
         """
         super(GLSVerticalDiffusionTerm, self).__init__(function_space,
                                                        bathymetry, v_elem_size, h_elem_size,
-                                                       sipg_parameter_vertical=sipg_parameter)
+                                                       sipg_factor_vertical=sipg_factor)
         self.schmidt_nb = schmidt_nb
 
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):


### PR DESCRIPTION
Implement a simpler form for symmetric interior penalty coefficient following Koen Hillewaert's [PhD thesis](https://dial.uclouvain.be/pr/boreal/object/boreal:128254/datastream/PDF_01/view).

In this method the "element size" length scale is defined as `CellVolume(mesh)/FacetArea(mesh)` making it robust for skewed elements as well. Compared to the theoretical bound, the IP penalty term has been multiplied by 2 as it seems to stable in practice.

This PR:
- Removes the now unnecessary `use_automatic_sipg_parameter` option
- Replaces the `sipg_penalty` options by `sipg_factor` which just scales the IP penalty term (defaults to 1.0)
