### PR TITLE
Fixes in two swe2d tests

### DIFF
--- a/docs/source/model_formulation_2d.rst
+++ b/docs/source/model_formulation_2d.rst
@@ -26,13 +26,14 @@ table below.
 .. |uu| replace:: :math:`\bar{\mathbf{u}}`
 .. |eta| replace:: :math:`\eta`
 
-================== ============ =========== ========== ===========
-Element Family     Name         Degree *n*  |uu| space |eta| space
-================== ============ =========== ========== ===========
-Equal order DG     ``'dg-dg'``  1, 2        P(n)DG     P(n)DG
-Raviart-Thomas DG  ``'rt-dg'``  1, 2        RT(n+1)    P(n)DG
-P1DG-P2            ``'dg-cg'``  1           P(n)DG     P(n+1)
-================== ============ =========== ========== ===========
+======================== ============ =========== ========== ===========
+Element Family           Name         Degree *n*  |uu| space |eta| space
+======================== ============ =========== ========== ===========
+Equal order DG           ``'dg-dg'``  1, 2        P(n)DG     P(n)DG
+Raviart-Thomas DG        ``'rt-dg'``  1, 2        RT(n+1)    P(n)DG
+P1DG-P2                  ``'dg-cg'``  1           P(n)DG     P(n+1)
+Brezzi-Douglas-Marini DG ``'bdm-dg'`` 1, 2        BDM(n+1)   P(n)DG
+======================== ============ =========== ========== ===========
 
 Table 1. *Finite element families for polynomial degree n.*
 

--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -59,7 +59,6 @@ def run(**model_options):
     options.output_directory = 'outputs'
     options.fields_to_export = ['uv_2d', 'elev_2d']
     options.use_grad_div_viscosity_term = False
-    options.element_family = 'dg-cg'
     options.horizontal_viscosity = viscosity
     options.quadratic_drag_coefficient = drag_coefficient
     options.use_lax_friedrichs_velocity = True

--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -83,7 +83,7 @@ def run(**model_options):
     S = 8            # turbine separation in x-direction
 
     # turbine locations
-    locs = [(L/2-S*D, W/2, D/2), (L/2+S*D, W/2, D/2)]
+    locs = [(L/2-S*D, W/2-D, D/2), (L/2+S*D, W/2+D, D/2)]
 
     def bump(mesh, locs, scale=1.0):
         """

--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -12,11 +12,10 @@ shallow water modelling and subsequent implementation of mesh adaptation algorit
 resulting from this process is used in this test. The mesh is anisotropic in the flow direction.
 
 [1] J.G. Wallwork, N. Barral, S.C. Kramer, D.A. Ham, M.D. Piggott, "Goal-Oriented Error Estimation
-    and Mesh Adaptation in Shallow Water Modelling" (2020), Springer Nature Applied Sciences (to
-    appear).
+    and Mesh Adaptation in Shallow Water Modelling", Springer Nature Applied Sciences, volume 2,
+    pp.1053--1063 (2020), DOI: 10.1007/s42452-020-2745-9, URL: https://rdcu.be/b35wZ.
 """
 from thetis import *
-from firedrake.petsc import PETSc
 import pytest
 import os
 

--- a/test/swe2d/test_rossby_wave.py
+++ b/test/swe2d/test_rossby_wave.py
@@ -267,4 +267,4 @@ def test_convergence(stepper, family):
 # ---------------------------
 
 if __name__ == '__main__':
-    test_convergence('SSPRK33', 'rt-dg')
+    test_convergence('DIRK22', 'bdm-dg')

--- a/test/swe2d/test_rossby_wave.py
+++ b/test/swe2d/test_rossby_wave.py
@@ -15,7 +15,6 @@ compute the error metrics, we project onto the same high resolution mesh used fo
 (2008), Journal of Geophysical Research: Oceans, 113(C7).
 """
 from thetis import *
-import numpy as np
 import pytest
 
 
@@ -208,18 +207,24 @@ def run(refinement_level, **model_options):
 
 
 def run_convergence(ref_list, **options):
-    """Runs test for a list of refinements and computes error convergence rate."""
+    """
+    Runs test for a sequence of refinements and computes the metric
+    convergence rate.
+
+    Note that the metrics should tend to unity, rather than zero. Since
+    this could be from above or from below, we assess the quantity
+
+  ..math::
+        1 - |1 - m|,
+
+    where :math:`m` is the metric. This quantity has its maximum at unity,
+    so must approach from below.
+    """
     setup_name = 'rossby-soliton'
-    stepper = options.get('timestepper_type')
 
     # Compute metrics for each refinement level
     labels = ('h+', 'h-', 'c+', 'c-')
-    metrics = {
-        'dx': [24/r for r in ref_list],
-        'dt': [0.96/r for r in ref_list] if stepper == 'SSPRK33' else [9.6/r for r in ref_list],
-    }
-    for metric in labels:
-        metrics[metric] = []
+    metrics = {metric: [] for metric in labels}
     for r in ref_list:
         msg = "Error metrics:"
         for metric, value in zip(labels, run(r, **options)):
@@ -228,10 +233,10 @@ def run_convergence(ref_list, **options):
         print_output(msg)
 
     # Check convergence of relative mean peak height and phase speed
-    rtol = 0.01
+    rtol = 0.02
     for m in ('h+', 'h-', 'c+', 'c-'):
         for i in range(1, len(ref_list)):
-            slope = metrics[m][i]/metrics[m][i-1]
+            slope = (1 - abs(1 - metrics[m][i]))/(1 - abs(1 - metrics[m][i-1]))
             msg = "{:s}: Divergence of error metric {:s}, expected {:.4f} > 1"
             assert slope > 1.0 - rtol, msg.format(setup_name, m, slope)
             print_output("{:s}: error metric {:s} index {:d} PASSED".format(setup_name, m, i))
@@ -255,3 +260,11 @@ def test_convergence(stepper, family):
     run_convergence([24, 48], timestepper_type=stepper,
                     simulation_end_time=30.0, polynomial_degree=1, element_family=family,
                     no_exports=True, expansion_order=1)
+
+
+# ---------------------------
+# run individual setup for debugging
+# ---------------------------
+
+if __name__ == '__main__':
+    test_convergence('SSPRK33', 'rt-dg')


### PR DESCRIPTION
Couple of things:
* `test_rossby_wave` wasn't always properly assessing convergence, because the error metrics can approach 1 from above or below.
* `test_anisotropic` had turbines which didn't align with the underlying adapted mesh.

The BDM-DG pair is also added to the finite element pair list on the 2D solver doc page.