### PR TITLE
P1+SUPG for 2D tracer model

### DIFF
--- a/docs/source/model_formulation_2d.rst
+++ b/docs/source/model_formulation_2d.rst
@@ -22,7 +22,7 @@ associated with the wetting and drying scheme can be specified by the
 :ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.wetting_and_drying_alpha`
 option. It can also be computed automatically, by setting the
 :ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.use_automatic_wetting_and_drying_alpha`
-to ``True``.
+option to ``True``.
 
 Spatial discretization
 ----------------------

--- a/docs/source/tracer_formulation_2d.rst
+++ b/docs/source/tracer_formulation_2d.rst
@@ -63,7 +63,12 @@ option.
 If the ``'cg'`` element family is chosen, then SUPG stabilization is used by
 default. It can be controlled using the
 :ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.use_supg_tracer`
-option.
+option. In that case, it is advisable to set characteristic velocities and
+diffusivities for your problem using the
+:ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.horizontal_velocity_scale`
+and
+:ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.horizontal_diffusivity_scale`
+options.
 
 Temporal discretization
 -----------------------

--- a/docs/source/tracer_formulation_2d.rst
+++ b/docs/source/tracer_formulation_2d.rst
@@ -36,15 +36,33 @@ imposed by the user.
 Spatial discretization
 ----------------------
 
-Thetis' 2D model formulation currently only supports tracers in
-P1DG space.
+Thetis supports two different tracer finite element discretizations
+and associated stabilization methods, summarised in the table below.
+
+=============== ========= ======= ===============
+Element Family  Name      Space   Stabilization
+=============== ========= ======= ===============
+DG              ``'dg'``  P1DG    Lax-Friedrichs
+CG              ``'cg'``  P1      SUPG
+=============== ========= ======= ===============
+
+Table 1. *Finite element families and stabilization methods.*
+
+The element family is set by the
+:ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.tracer_element_family`
+option. Polynomial degrees other than one are not currently supported.
 
 Lax-Friedrichs stabilization is used by default and may be
 controlled using the
 :ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.use_lax_friedrichs_tracer`
-option. The scaling parameter used by this scheme may be controlled
-using the
+option. Note that it is only a valid choice for the ``'dg'`` element family.
+The scaling parameter used by this scheme may be controlled using the
 :ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.lax_friedrichs_tracer_scaling_factor`
+option.
+
+If the ``'cg'`` element family is chosen, then SUPG stabilization is used by
+default. It can be controlled using the
+:ref:`ModelOptions2d<model_options_2d>`.\ :py:attr:`.use_supg_tracer`
 option.
 
 Temporal discretization
@@ -55,16 +73,16 @@ Thetis supports different time integration methods, set by the
 Note that the same time integration method will be used for both the shallow
 water equations and the 2D tracer model.
 
-=============================== ====================================== ====================== ============
-Time integrator                 Thetis class                           Unconditionally stable Description
-=============================== ====================================== ====================== ============
-``'ForwardEuler'``              :py:class:`~.ForwardEuler`             No                     Forward Euler method
-``'BackwardEuler'``             :py:class:`~.BackwardEuler`            Yes                    Backward Euler method
-``'CrankNicolson'``             :py:class:`~.CrankNicolson`            Yes                    Crank-Nicolson method
-``'DIRK22'``                    :py:class:`~.DIRK22`                   Yes                    DIRK(2,3,2) method
-``'DIRK33'``                    :py:class:`~.DIRK33`                   Yes                    DIRK(3,4,3) method
-``'SSPRK33'``                   :py:class:`~.SSPRK33`                  No                     SSPRK(3,3) method
-``'SteadyState'``               :py:class:`~.SteadyState`              --                     Solves equations in steady state
-=============================== ====================================== ====================== ============
+==================== ============================ ====================== ============
+Time integrator      Thetis class                 Unconditionally stable Description
+==================== ============================ ====================== ============
+``'ForwardEuler'``   :py:class:`~.ForwardEuler`   No                     Forward Euler method
+``'BackwardEuler'``  :py:class:`~.BackwardEuler`  Yes                    Backward Euler method
+``'CrankNicolson'``  :py:class:`~.CrankNicolson`  Yes                    Crank-Nicolson method
+``'DIRK22'``         :py:class:`~.DIRK22`         Yes                    DIRK(2,3,2) method
+``'DIRK33'``         :py:class:`~.DIRK33`         Yes                    DIRK(3,4,3) method
+``'SSPRK33'``        :py:class:`~.SSPRK33`        No                     SSPRK(3,3) method
+``'SteadyState'``    :py:class:`~.SteadyState`    --                     Solves equations in steady state
+==================== ============================ ====================== ============
 
-Table 1. *Time integration methods for 2D tracer model.*
+Table 2. *Time integration methods for 2D tracer model.*

--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -178,24 +178,6 @@ def test_copy_2d_field_to_3d_vec(uv_2d, uv_3d):
     assert np.allclose(uv_3d.dat.data_ro[:, 1], 8.0)
 
 
-def test_sipg_ratio_constant(c2d):
-    if c2d.ufl_element().degree() > 1:
-        pytest.xfail("Only currently implemented for constant or linear elements")
-    with utility.get_sipg_ratio(c2d).dat.vec_ro as v:
-        assert np.allclose(v.max()[1], 1.0)
-        assert np.allclose(v.min()[1], 1.0)
-
-
-def test_sipg_ratio_scalar(c2d_x):
-    c = c2d_x.copy()
-    c += 1.0
-    if c.ufl_element().degree() > 1:
-        pytest.xfail("Only currently implemented for constant or linear elements")
-    with utility.get_sipg_ratio(c).dat.vec_ro as v:
-        assert np.allclose(v.max()[1], 1.4/1.0)
-        assert np.allclose(v.min()[1], 3.0/2.6)
-
-
 def test_minimum_angle(mesh2d):
     min_angle = utility.get_minimum_angles_2d(mesh2d).vector().gather().min()
     assert np.allclose(min_angle, pi/4)

--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -120,9 +120,10 @@ def run(refinement, **model_options):
     options.horizontal_diffusivity = nu
     options.horizontal_diffusivity_scale = nu
     options.horizontal_velocity_scale = Constant(0.0)
-    options.use_limiter_for_tracers = True
     options.fields_to_export = ['tracer_2d']
     options.update(model_options)
+    options.use_limiter_for_tracers = options.tracer_element_family == 'dg'
+    options.use_supg_tracer = options.tracer_element_family == 'cg'
     options.simulation_end_time = t_end - 0.5*dt
 
     # Boundary conditions

--- a/test/tracerEq/test_point_discharge.py
+++ b/test/tracerEq/test_point_discharge.py
@@ -68,10 +68,9 @@ class PointDischargeParameters(object):
     """
     Problem parameter class, including point source representation.
 
-    Delta functions are not in H1 and hence do not live in the FunctionSpaces we
-    seek to use. Here we use a Gaussian approximation with a small radius. The
-    small radius has been calibrated against the analytical solution. See [2]
-    for details.
+    Delta functions are difficult to represent in numerical models. Here we
+    use a Gaussian approximation with a small radius. The small radius has
+    been calibrated against the analytical solution. See [2] for details.
     """
     def __init__(self, offset, tracer_family):
         self.offset = offset

--- a/thetis/conservative_tracer_eq_2d.py
+++ b/thetis/conservative_tracer_eq_2d.py
@@ -28,18 +28,13 @@ class ConservativeTracerTerm(TracerTerm):
     Generic depth-integrated tracer term that provides commonly used members and mapping for
     boundary functions.
     """
-    def __init__(self, function_space, depth,
-                 use_lax_friedrichs=False,
-                 sipg_factor=Constant(1.0)):
+    def __init__(self, function_space, depth, options):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class: `DepthExpression` containing depth info
-        :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
+        :arg options: :class`ModelOptions2d` containing parameters
         """
-        super().__init__(function_space, depth,
-                         use_lax_friedrichs=use_lax_friedrichs,
-                         sipg_factor=sipg_factor)
+        super().__init__(function_space, depth, options)
 
     # TODO: at the moment this is the same as TracerTerm, but we probably want to overload its
     # get_bnd_functions method
@@ -88,7 +83,7 @@ class ConservativeHorizontalAdvectionTerm(ConservativeTracerTerm):
             f += (flux_up[0] * jump(self.test, self.normal[0])
                   + flux_up[1] * jump(self.test, self.normal[1])) * self.dS
             # Lax-Friedrichs stabilization
-            if self.use_lax_friedrichs:
+            if self.options.use_lax_friedrichs_tracer:
                 if uv_p1 is not None:
                     gamma = 0.5*abs((avg(uv_p1)[0]*self.normal('-')[0]
                                      + avg(uv_p1)[1]*self.normal('-')[1]))*lax_friedrichs_factor
@@ -171,17 +166,14 @@ class ConservativeTracerEquation2D(Equation):
     """
     2D tracer advection-diffusion equation :eq:`tracer_eq` in conservative form
     """
-    def __init__(self, function_space, depth,
-                 use_lax_friedrichs=False,
-                 sipg_factor=Constant(1.0)):
+    def __init__(self, function_space, depth, options):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class: `DepthExpression` containing depth info
-        :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
+        :arg options: :class`ModelOptions2d` containing parameters
         """
         super(ConservativeTracerEquation2D, self).__init__(function_space)
-        args = (function_space, depth, use_lax_friedrichs, sipg_factor)
+        args = (function_space, depth, options)
         self.add_term(ConservativeHorizontalAdvectionTerm(*args), 'explicit')
         self.add_term(ConservativeHorizontalDiffusionTerm(*args), 'explicit')
         self.add_term(ConservativeSourceTerm(*args), 'source')

--- a/thetis/equation.py
+++ b/thetis/equation.py
@@ -14,14 +14,15 @@ class Term(object):
     .. note::
         Sign convention: all terms are assumed to be on the right hand side of the equation: d(u)/dt = term.
     """
-    def __init__(self, function_space):
+    def __init__(self, function_space, test_function=None):
         """
         :arg function_space: the :class:`FunctionSpace` the solution belongs to
+        :kwarg test_function: custom :class:`TestFunction`.
         """
         # define bunch of members needed to construct forms
         self.function_space = function_space
         self.mesh = self.function_space.mesh()
-        self.test = TestFunction(self.function_space)
+        self.test = test_function or TestFunction(self.function_space)
         self.tri = TrialFunction(self.function_space)
         self.normal = FacetNormal(self.mesh)
         # TODO construct them here from mesh ?

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -654,6 +654,14 @@ class ModelOptions2d(CommonModelOptions):
 
         Advects tracer in the associated (constant) velocity field.
         """).tag(config=True)
+    tracer_element_family = Enum(
+        ['dg', 'cg'],
+        default_value='dg',
+        help="""Finite element family for tracer transport
+
+        2D solver supports 'dg' or 'cg'.""").tag(config=True)
+    use_su_stabilization_tracer = Bool(
+        False, help="Use SU stabilisation in tracer advection").tag(config=True)
 
 
 @attach_paired_options("timestepper_type",

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -441,7 +441,8 @@ class CommonModelOptions(FrozenConfigurable):
         Constant(1.0), help="""
         Maximum horizontal diffusivity
 
-        Used to Peclet number.
+        Used to compute the mesh Peclet number in
+        the 2D tracer SUPG stabilization scheme.
         """).tag(config=True)
     output_directory = Unicode(
         'outputs', help="Directory where model output files are stored").tag(config=True)

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -437,6 +437,12 @@ class CommonModelOptions(FrozenConfigurable):
 
         Used to compute max stable diffusion time step.
         """).tag(config=True)
+    horizontal_diffusivity_scale = FiredrakeConstantTraitlet(
+        Constant(1.0), help="""
+        Maximum horizontal diffusivity
+
+        Used to Peclet number.
+        """).tag(config=True)
     output_directory = Unicode(
         'outputs', help="Directory where model output files are stored").tag(config=True)
     no_exports = Bool(

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -666,8 +666,8 @@ class ModelOptions2d(CommonModelOptions):
         help="""Finite element family for tracer transport
 
         2D solver supports 'dg' or 'cg'.""").tag(config=True)
-    use_su_stabilization_tracer = Bool(
-        False, help="Use SU stabilisation in tracer advection").tag(config=True)
+    use_supg_tracer = Bool(
+        False, help="Use SUPG stabilisation in tracer advection").tag(config=True)
 
 
 @attach_paired_options("timestepper_type",

--- a/thetis/sediment_eq_2d.py
+++ b/thetis/sediment_eq_2d.py
@@ -15,7 +15,6 @@ where :math:`S` is :math:`q` for conservative and :math:`T` for non-conservative
 velocities, and :math:`\mu_h` denotes horizontal diffusivity.
 """
 from __future__ import absolute_import
-from .utility import *
 from .equation import Equation
 from .tracer_eq_2d import HorizontalDiffusionTerm, HorizontalAdvectionTerm, TracerTerm
 from .conservative_tracer_eq_2d import ConservativeHorizontalAdvectionTerm
@@ -34,16 +33,14 @@ class SedimentTerm(TracerTerm):
     """
     Generic sediment term that provides commonly used members.
     """
-    def __init__(self, function_space, depth, sediment_model,
-                 use_lax_friedrichs=True, sipg_factor=Constant(1.0), conservative=False):
+    def __init__(self, function_space, depth, options, sediment_model, conservative=False):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class:`DepthExpression` containing depth info
-        :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
+        :arg options: :class`ModelOptions2d` containing parameters
         :kwarg bool conservative: whether to use conservative tracer
         """
-        super(SedimentTerm, self).__init__(function_space, depth)
+        super(SedimentTerm, self).__init__(function_space, depth, options)
         self.sediment_model = sediment_model
         self.conservative = conservative
 
@@ -114,19 +111,15 @@ class SedimentEquation2D(Equation):
     2D sediment advection-diffusion equation: :eq:`tracer_eq_2d` or :eq:`conservative_tracer_eq_2d`
     with sediment source and sink term
     """
-    def __init__(self, function_space, depth, sediment_model,
-                 use_lax_friedrichs=False,
-                 sipg_factor=Constant(1.0),
-                 conservative=False):
+    def __init__(self, function_space, depth, options, sediment_model, conservative=False):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class:`DepthExpression` containing depth info
-        :kwarg bool use_lax_friedrichs: whether to use Lax Friedrichs stabilisation
-        :kwarg sipg_factor: :class:`Constant` or :class:`Function` SIPG penalty scaling factor
+        :arg options: :class`ModelOptions2d` containing parameters
         :kwarg bool conservative: whether to use conservative tracer
         """
         super(SedimentEquation2D, self).__init__(function_space)
-        args = (function_space, depth, sediment_model, use_lax_friedrichs, sipg_factor, conservative)
+        args = (function_space, depth, options, sediment_model, conservative)
         if conservative:
             self.add_term(ConservativeSedimentAdvectionTerm(*args), 'explicit')
         else:

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -321,12 +321,6 @@ class FlowSolver2d(FrozenClass):
         )
         self.eq_sw.bnd_functions = self.bnd_functions['shallow_water']
         if self.options.solve_tracer:
-            self.options.use_limiter_for_tracers &= self.options.tracer_element_family == 'dg'
-            self.options.use_lax_friedrichs_tracer &= self.options.tracer_element_family == 'dg'
-            self.options.use_supg_tracer &= self.options.tracer_element_family == 'cg'
-            if self.options.tracer_element_family == 'cg':
-                self.options.use_supg_tracer = True
-
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             if self.options.use_tracer_conservative_form:
                 self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(
@@ -349,9 +343,7 @@ class FlowSolver2d(FrozenClass):
         if sediment_options.solve_suspended_sediment:
             self.fields.sediment_2d = Function(self.function_spaces.Q_2d, name='sediment_2d')
             self.eq_sediment = sediment_eq_2d.SedimentEquation2D(
-                self.function_spaces.Q_2d, self.depth, self.sediment_model,
-                use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                sipg_factor=self.options.sipg_factor_tracer,
+                self.function_spaces.Q_2d, self.depth, self.options, self.sediment_model,
                 conservative=sediment_options.use_sediment_conservative_form)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -330,16 +330,10 @@ class FlowSolver2d(FrozenClass):
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             if self.options.use_tracer_conservative_form:
                 self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(
-                    self.function_spaces.Q_2d, self.depth,
-                    use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                    sipg_factor=self.options.sipg_factor_tracer,
-                    use_su=self.options.use_su_stabilization_tracer)
+                    self.function_spaces.Q_2d, self.depth, self.options)
             else:
                 self.eq_tracer = tracer_eq_2d.TracerEquation2D(
-                    self.function_spaces.Q_2d, self.depth,
-                    use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                    sipg_factor=self.options.sipg_factor_tracer,
-                    use_su=self.options.use_su_stabilization_tracer)
+                    self.function_spaces.Q_2d, self.depth, self.options)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -323,17 +323,18 @@ class FlowSolver2d(FrozenClass):
         if self.options.solve_tracer:
             self.options.use_limiter_for_tracers &= self.options.tracer_element_family == 'dg'
             self.options.use_lax_friedrichs_tracer &= self.options.tracer_element_family == 'dg'
-            self.options.use_su_stabilization_tracer &= self.options.tracer_element_family == 'cg'
+            self.options.use_supg_tracer &= self.options.tracer_element_family == 'cg'
             if self.options.tracer_element_family == 'cg':
-                self.options.use_su_stabilization_tracer = True
+                self.options.use_supg_tracer = True
 
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             if self.options.use_tracer_conservative_form:
                 self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(
                     self.function_spaces.Q_2d, self.depth, self.options)
             else:
+                uv_2d, elev_2d = self.fields.solution_2d.split()
                 self.eq_tracer = tracer_eq_2d.TracerEquation2D(
-                    self.function_spaces.Q_2d, self.depth, self.options)
+                    self.function_spaces.Q_2d, self.depth, self.options, uv_2d)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -287,7 +287,12 @@ class FlowSolver2d(FrozenClass):
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d])
 
-        self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'DG', 1, name='Q_2d')
+        if self.options.tracer_element_family == 'dg':
+            self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'DG', 1, name='Q_2d')
+        elif self.options.tracer_element_family == 'cg':
+            self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'CG', 1, name='Q_2d')
+        else:
+            raise Exception('Unsupported finite element family {:}'.format(self.options.tracer_element_family))
 
         self._isfrozen = True
 
@@ -316,17 +321,25 @@ class FlowSolver2d(FrozenClass):
         )
         self.eq_sw.bnd_functions = self.bnd_functions['shallow_water']
         if self.options.solve_tracer:
+            self.options.use_limiter_for_tracers &= self.options.tracer_element_family == 'dg'
+            self.options.use_lax_friedrichs_tracer &= self.options.tracer_element_family == 'dg'
+            self.options.use_su_stabilization_tracer &= self.options.tracer_element_family == 'cg'
+            if self.options.tracer_element_family == 'cg':
+                self.options.use_su_stabilization_tracer = True
+
             self.fields.tracer_2d = Function(self.function_spaces.Q_2d, name='tracer_2d')
             if self.options.use_tracer_conservative_form:
                 self.eq_tracer = conservative_tracer_eq_2d.ConservativeTracerEquation2D(
                     self.function_spaces.Q_2d, self.depth,
                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                    sipg_factor=self.options.sipg_factor_tracer)
+                    sipg_factor=self.options.sipg_factor_tracer,
+                    use_su=self.options.use_su_stabilization_tracer)
             else:
                 self.eq_tracer = tracer_eq_2d.TracerEquation2D(
                     self.function_spaces.Q_2d, self.depth,
                     use_lax_friedrichs=self.options.use_lax_friedrichs_tracer,
-                    sipg_factor=self.options.sipg_factor_tracer)
+                    sipg_factor=self.options.sipg_factor_tracer,
+                    use_su=self.options.use_su_stabilization_tracer)
             if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -32,7 +32,7 @@ class TracerTerm(Term):
     boundary functions.
     """
     def __init__(self, function_space, depth,
-                 use_lax_friedrichs=True, sipg_factor=Constant(1.0)):
+                 use_lax_friedrichs=True, sipg_factor=Constant(1.0), use_su=False):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class: `DepthExpression` containing depth info
@@ -41,11 +41,12 @@ class TracerTerm(Term):
         """
         super(TracerTerm, self).__init__(function_space)
         self.depth = depth
-        self.cellsize = CellSize(self.mesh)
+        self.cellsize = CellSize(self.mesh)  # TODO: Account for anisotropy
         continuity = element_continuity(self.function_space.ufl_element())
         self.horizontal_dg = continuity.horizontal == 'dg'
         self.use_lax_friedrichs = use_lax_friedrichs
         self.sipg_factor = sipg_factor
+        self.use_su = use_su
 
         # define measures with a reasonable quadrature degree
         p = self.function_space.ufl_element().degree()
@@ -110,6 +111,12 @@ class HorizontalAdvectionTerm(TracerTerm):
     :math:`\textbf{n}` is the unit normal of
     the element interfaces, and :math:`\text{jump}` and :math:`\text{avg}` denote the
     jump and average operators across the interface.
+
+    For the continuous Galerkin method we use
+
+    .. math::
+        \int_\Omega \bar{\textbf{u}} \cdot \boldsymbol{\psi} \cdot \nabla T  dx
+        = - \int_\Omega \nabla_h \cdot (\bar{\textbf{u}} \boldsymbol{\psi}) \cdot T dx.
     """
     def residual(self, solution, solution_old, fields, fields_old, bnd_conditions=None):
         if fields_old.get('uv_2d') is None:
@@ -139,22 +146,32 @@ class HorizontalAdvectionTerm(TracerTerm):
             if self.use_lax_friedrichs:
                 gamma = 0.5*abs(un_av)*lax_friedrichs_factor
                 f += gamma*dot(jump(self.test), jump(solution))*self.dS
-            if bnd_conditions is not None:
-                for bnd_marker in self.boundary_markers:
-                    funcs = bnd_conditions.get(bnd_marker)
-                    ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                    c_in = solution
-                    if funcs is not None:
-                        c_ext, uv_ext, eta_ext = self.get_bnd_functions(c_in, uv, elev, bnd_marker, bnd_conditions)
-                        uv_av = 0.5*(uv + uv_ext)
-                        un_av = self.normal[0]*uv_av[0] + self.normal[1]*uv_av[1]
-                        s = 0.5*(sign(un_av) + 1.0)
-                        c_up = c_in*s + c_ext*(1-s)
-                        f += c_up*(uv_av[0]*self.normal[0]
-                                   + uv_av[1]*self.normal[1])*self.test*ds_bnd
-                    else:
-                        f += c_in * (uv[0]*self.normal[0]
-                                     + uv[1]*self.normal[1])*self.test*ds_bnd
+
+        elif self.use_su:
+            # SU stabilization
+            unorm = sqrt(inner(uv, uv))
+            tau = 0.5*self.cellsize/unorm
+            if fields_old.get('diffusivity_h') is not None:
+                Pe = 0.5*unorm*self.cellsize/fields_old['diffusivity_h']
+                tau = min_value(tau, Pe/3)
+            f += tau*inner(uv, grad(self.test))*dot(uv, grad(solution))*dx
+
+        if bnd_conditions is not None:
+            for bnd_marker in self.boundary_markers:
+                funcs = bnd_conditions.get(bnd_marker)
+                ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
+                c_in = solution
+                if funcs is not None:
+                    c_ext, uv_ext, eta_ext = self.get_bnd_functions(c_in, uv, elev, bnd_marker, bnd_conditions)
+                    uv_av = 0.5*(uv + uv_ext)
+                    un_av = self.normal[0]*uv_av[0] + self.normal[1]*uv_av[1]
+                    s = 0.5*(sign(un_av) + 1.0)
+                    c_up = c_in*s + c_ext*(1-s)
+                    f += c_up*(uv_av[0]*self.normal[0]
+                               + uv_av[1]*self.normal[1])*self.test*ds_bnd
+                else:
+                    f += c_in * (uv[0]*self.normal[0]
+                                 + uv[1]*self.normal[1])*self.test*ds_bnd
 
         return -f
 
@@ -177,6 +194,11 @@ class HorizontalDiffusionTerm(TracerTerm):
         &- \int_\Gamma \mu_h (\nabla_h \phi) \cdot \textbf{n}_h ds
 
     where :math:`\sigma` is a penalty parameter, see Hillewaert (2013).
+
+    For the continuous Galerkin method we use
+    .. math::
+        -\int_\Omega \nabla_h \cdot (\mu_h \nabla_h T) \phi dx
+        = \int_\Omega \mu_h (\nabla_h \phi) \cdot (\nabla_h T) dx.
 
     Hillewaert, Koen (2013). Development of the discontinuous Galerkin method
     for high-resolution, large scale CFD and acoustics in industrial
@@ -264,7 +286,8 @@ class TracerEquation2D(Equation):
     """
     def __init__(self, function_space, depth,
                  use_lax_friedrichs=False,
-                 sipg_factor=Constant(1.0)):
+                 sipg_factor=Constant(1.0),
+                 use_su=False):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class: `DepthExpression` containing depth info
@@ -273,7 +296,7 @@ class TracerEquation2D(Equation):
         """
         super(TracerEquation2D, self).__init__(function_space)
 
-        args = (function_space, depth, use_lax_friedrichs, sipg_factor)
+        args = (function_space, depth, use_lax_friedrichs, sipg_factor, use_su)
         self.add_term(HorizontalAdvectionTerm(*args), 'explicit')
         self.add_term(HorizontalDiffusionTerm(*args), 'explicit')
         self.add_term(SourceTerm(*args), 'source')

--- a/thetis/tracer_eq_2d.py
+++ b/thetis/tracer_eq_2d.py
@@ -31,13 +31,15 @@ class TracerTerm(Term):
     Generic tracer term that provides commonly used members and mapping for
     boundary functions.
     """
-    def __init__(self, function_space, depth, options):
+    def __init__(self, function_space, depth, options, test_function=None):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class:`DepthExpression` containing depth info
         :arg options: :class`ModelOptions2d` containing parameters
+        :kwarg test_function: custom :class:`TestFunction`.
         """
-        super(TracerTerm, self).__init__(function_space)
+        super(TracerTerm, self).__init__(function_space,
+                                         test_function=test_function)
         self.depth = depth
         self.options = options
         self.cellsize = CellSize(self.mesh)
@@ -281,6 +283,7 @@ class TracerEquation2D(Equation):
         super(TracerEquation2D, self).__init__(function_space)
 
         # Apply SUPG stabilisation
+        kwargs = {}
         if options.use_supg_tracer:
             unorm = options.horizontal_velocity_scale
             if unorm.values()[0] > 0:
@@ -291,13 +294,9 @@ class TracerEquation2D(Equation):
                     Pe = 0.5*unorm*cellsize/D
                     tau = min_value(tau, Pe/3)
                 self.test = self.test + tau*dot(velocity, grad(self.test))
+                kwargs['test_function'] = self.test
 
         args = (function_space, depth, options)
-        self.add_term(HorizontalAdvectionTerm(*args), 'explicit')
-        self.add_term(HorizontalDiffusionTerm(*args), 'explicit')
-        self.add_term(SourceTerm(*args), 'source')
-
-    def add_term(self, term, label):
-        super(TracerEquation2D, self).add_term(term, label)
-        key = term.__class__.__name__
-        self.terms[key].test = self.test  # Carry over modified test function
+        self.add_term(HorizontalAdvectionTerm(*args, **kwargs), 'explicit')
+        self.add_term(HorizontalDiffusionTerm(*args, **kwargs), 'explicit')
+        self.add_term(SourceTerm(*args, **kwargs), 'source')

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -1276,8 +1276,15 @@ def get_cell_widths_2d(mesh2d):
 
 def anisotropic_cell_size(mesh):
     """
-    Measure of cell size for anisotropic meshes, as described in [Micheletti, Perotto & Picasso 2003].
+    Measure of cell size for anisotropic meshes, as described in
+    Micheletti et al. (2003).
+
     This is used in the SUPG formulation for the 2D tracer model.
+
+    Micheletti, Perotto and Picasso (2003). Stabilized finite
+    elements on anisotropic meshes: a priori error estimates for
+    the advection-diffusion and the Stokes problems. SIAM Journal
+    on Numerical Analysis 41.3: 1131-1162.
     """
     try:
         from firedrake.slate.slac.compiler import PETSC_ARCH


### PR DESCRIPTION
I've been using P1+SUPG for various things in my PhD work, with the SUPG parameter advocated in [Micheletti et al. 2003], which accounts for element anisotropy. I thought maybe this would be useful for other people using Thetis?

This PR allows for CG tracers in 2D. The default is still DG. If SUPG is used then the test function of the tracer equation is modified, including the modified cell size.

In doing this, I thought it made sense to pass `options` to the tracer solver (in the same way as is done for the SW solver), instead of passing individual parameters. Is that okay? Also, I needed to make the tracer equation aware of the SW velocity field.

I didn't want to add too much to the test suite, so am just testing steady state and for BC implementation. Note that the CG tracer equation inherits the same weak BC implementation from the DG one. I also noticed there were some old SIPG parameter tests we can now drop.

[Micheletti et al. 2003] Micheletti, Stefano, Simona Perotto, and Marco Picasso. "Stabilized finite elements on anisotropic meshes: a priori error estimates for the advection-diffusion and the Stokes problems." SIAM Journal on Numerical Analysis 41.3 (2003): 1131-1162.