### PR TITLE
remove geometric boundary mask

### DIFF
--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -17,16 +17,21 @@ def mesh(mesh2d):
     return utility.extrude_mesh_sigma(mesh2d, n_layers, bathymetry_2d)
 
 
-@pytest.fixture(params=["p1xp1", "P2xP2", "p1DGxp1DG", "P2DGxP2DG"])
+@pytest.fixture(params=[
+    "P1xP1", "P2xP2",
+    "P1DGxP1DG", "P2DGxP2DG",
+    "P1xP3", "P1DGxP3DG",
+    "P3xP1DG", "P3DGxP1",
+])
 def spaces(request):
-    if request.param == "p1xp1":
-        return (("CG", 1), ("CG", 1))
-    elif request.param == "P2xP2":
-        return (("CG", 2), ("CG", 2))
-    elif request.param == "p1DGxp1DG":
-        return (("DG", 1), ("DG", 1))
-    elif request.param == "P2DGxP2DG":
-        return (("DG", 2), ("DG", 2))
+    h_name, v_name = request.param.split('x')
+
+    def get_tuple(name):
+        degree = int(name[1:2])
+        family = 'DG' if 'DG' in name else 'CG'
+        return (family, degree)
+
+    return (get_tuple(h_name), get_tuple(v_name))
 
 
 @pytest.fixture

--- a/thetis/forcing.py
+++ b/thetis/forcing.py
@@ -713,7 +713,7 @@ class TidalBoundaryForcing(object):
             # interpolate in the whole domain
             self.nodes = np.arange(self.elev_field.dat.data_with_halos.shape[0])
         else:
-            bc = DirichletBC(fs, 0., boundary_ids, method='geometric')
+            bc = DirichletBC(fs, 0., boundary_ids)
             self.nodes = bc.nodes
         self._empty_set = self.nodes.size == 0
 

--- a/thetis/limiter.py
+++ b/thetis/limiter.py
@@ -146,8 +146,8 @@ class VertexBasedP1DGLimiter(VertexBasedLimiter):
         if not self.is_2d:
             # Add nodal values from surface/bottom boundaries
             # NOTE calling firedrake par_loop with measure=ds_t raises an error
-            bottom_nodes = get_facet_mask(self.P1CG, 'geometric', 'bottom')
-            top_nodes = get_facet_mask(self.P1CG, 'geometric', 'top')
+            bottom_nodes = get_facet_mask(self.P1CG, 'bottom')
+            top_nodes = get_facet_mask(self.P1CG, 'top')
             bottom_idx = op2.Global(len(bottom_nodes), bottom_nodes, dtype=np.int32, name='node_idx')
             top_idx = op2.Global(len(top_nodes), top_nodes, dtype=np.int32, name='node_idx')
             code = """


### PR DESCRIPTION
Firedrake boundary method `'geometric'` has been removed in firedrakeproject/firedrake#2007

~For most (all?) Thetis use cases there's actually no difference between _geometric_ and _topological_ boundary masks (e.g. P1DG).~

The top/bottom facet mask indices have now been implemented manually.