### PR TITLE
Picard iteration for multiple tracers

### DIFF
--- a/docs/source/tracer_formulation_2d.rst
+++ b/docs/source/tracer_formulation_2d.rst
@@ -11,8 +11,10 @@ equation
 :eq:`tracer_eq_2d`.
 If solved in non-conservative form, the prognostic variable
 is the passive tracer concentration,
-:math:`T`. The corresponding field in Thetis is called
-``'tracer_2d'``.
+:math:`T`. By default he corresponding field in Thetis is called
+``'tracer_2d'``. An arbitrary number of custom tracer fields can
+also be defined, as detailed in
+`the multiple 2D tracer demo <demos/demo_2d_multiple_tracers.py.html>`__.
 
 A conservative tracer model is also available, given by
 :eq:`cons_tracer_eq_2d`.

--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -179,7 +179,7 @@ def stepper(request):
 
 @pytest.mark.parametrize(('diffusivity'),
                          [(Constant(0.1))])
-def test_horizontal_advection(polynomial_degree, stepper, diffusivity, family):
+def test_diff_flux(polynomial_degree, stepper, diffusivity, family):
     run_convergence(polynomial_degree=polynomial_degree,
                     timestepper_type=stepper,
                     horizontal_diffusivity=diffusivity,

--- a/test/tracerEq/test_bcs_2d.py
+++ b/test/tracerEq/test_bcs_2d.py
@@ -164,7 +164,15 @@ def polynomial_degree(request):
     return request.param
 
 
-@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'BackwardEuler', 'DIRK22', 'DIRK33'])
+@pytest.fixture(params=[
+    'CrankNicolson',
+    'SSPRK33',
+    'ForwardEuler',
+    'BackwardEuler',
+    'DIRK22',
+    'DIRK33',
+    'CoupledTracerPicard',
+])
 def stepper(request):
     return request.param
 
@@ -180,7 +188,7 @@ def test_horizontal_advection(polynomial_degree, stepper, diffusivity, family):
 
 if __name__ == '__main__':
     run_convergence(polynomial_degree=1,
-                    timestepper_type='CrankNicolson',
+                    timestepper_type='CoupledTracerPicard',
                     horizontal_diffusivity=Constant(0.1),
                     tracer_element_family='cg',
                     no_exports=False)

--- a/test/tracerEq/test_consistency_2d.py
+++ b/test/tracerEq/test_consistency_2d.py
@@ -99,7 +99,15 @@ def run_tracer_consistency(constant_c=True, **model_options):
 # ---------------------------
 
 
-@pytest.fixture(params=['CrankNicolson', 'SSPRK33', 'ForwardEuler', 'BackwardEuler', 'DIRK22', 'DIRK33'])
+@pytest.fixture(params=[
+    'CrankNicolson',
+    'SSPRK33',
+    'ForwardEuler',
+    'BackwardEuler',
+    'DIRK22',
+    'DIRK33',
+    'CoupledTracerPicard',
+])
 def stepper(request):
     return request.param
 
@@ -155,4 +163,4 @@ if __name__ == '__main__':
                            solve_tracer=True,
                            use_limiter_for_tracers=False,
                            no_exports=False,
-                           timestepper_type='CrankNicolson')
+                           timestepper_type='CoupledTracerPicard')

--- a/test/tracerEq/test_h-advection_mes_2d.py
+++ b/test/tracerEq/test_h-advection_mes_2d.py
@@ -28,9 +28,6 @@ def run(refinement, **model_options):
     t_init = 0.0
     t_export = (t_end - t_init)/8.0
 
-    # outputs
-    outputdir = 'outputs'
-
     # bathymetry
     P1_2d = get_functionspace(mesh2d, 'CG', 1)
     bathymetry_2d = Function(P1_2d, name='Bathymetry')
@@ -44,13 +41,13 @@ def run(refinement, **model_options):
     options.use_lax_friedrichs_tracer = False
     options.horizontal_velocity_scale = Constant(abs(u))
     options.no_exports = True
-    options.output_directory = outputdir
     options.simulation_end_time = t_end
     options.simulation_export_time = t_export
     solverobj.create_function_spaces()
     corr_factor = Function(solverobj.function_spaces.H_2d, name='uv tracer factor').interpolate(Constant(1.0))
     options.tracer_advective_velocity_factor = corr_factor
     options.solve_tracer = True
+    options.tracer_only = True
     options.use_limiter_for_tracers = True
     options.fields_to_export = ['tracer_2d']
     options.update(model_options)
@@ -68,14 +65,12 @@ def run(refinement, **model_options):
 
     solverobj.create_equations()
 
-    t = t_init  # simulation time
-
     x0 = 0.3*lx
     sigma = 1600.
     xy = SpatialCoordinate(solverobj.mesh2d)
-    t_const = Constant(t)
+    t_const = Constant(t_init)
     ana_tracer_expr = exp(-(xy[0] - x0 - u*t_const)**2/sigma**2)
-    tracer_ana = Function(solverobj.function_spaces.H_2d, name='tracer analytical')
+    tracer_ana = Function(solverobj.function_spaces.Q_2d, name='tracer analytical')
     uv_init = Function(solverobj.function_spaces.U_2d, name='initial uv')
     uv_init.project(uv_expr)
     solverobj.assign_initial_conditions(uv=uv_init, tracer=ana_tracer_expr)
@@ -86,32 +81,14 @@ def run(refinement, **model_options):
 
     def export_func():
         if not options.no_exports:
-            solverobj.export()
             # update analytical solution to correct time
             t_const.assign(t)
             out_tracer_ana.write(tracer_ana.project(ana_tracer_expr))
 
-    # export initial conditions
-    export_func()
-
-    # custom time loop that solves tracer equation only
-    ti = solverobj.timestepper.timesteppers.tracer_2d
-
-    i = 0
-    iexport = 1
-    next_export_t = t + solverobj.options.simulation_export_time
-    while t < t_end - 1e-8:
-        ti.advance(t)
-        t += solverobj.dt
-        i += 1
-        if t >= next_export_t - 1e-8:
-            print_output('{:3d} i={:5d} t={:8.2f} s salt={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.tracer_2d)))
-            export_func()
-            next_export_t += solverobj.options.simulation_export_time
-            iexport += 1
+    solverobj.iterate(export_func=export_func)
 
     # project analytical solution on high order mesh
-    t_const.assign(t)
+    t_const.assign(t_end)
 
     # compute L2 norm
     l2_err = errornorm(ana_tracer_expr, solverobj.fields.tracer_2d)/numpy.sqrt(area)
@@ -181,7 +158,14 @@ def polynomial_degree(request):
     return request.param
 
 
-@pytest.fixture(params=['CrankNicolson', 'ForwardEuler', 'SSPRK33', 'DIRK22', 'DIRK33'])
+@pytest.fixture(params=[
+    'CrankNicolson',
+    'ForwardEuler',
+    'SSPRK33',
+    'DIRK22',
+    'DIRK33',
+    'CoupledTracerPicard',
+])
 def stepper(request):
     return request.param
 
@@ -197,5 +181,5 @@ def test_horizontal_advection(polynomial_degree, stepper):
 
 if __name__ == '__main__':
     run_convergence([1, 2, 3, 4], polynomial_degree=1,
-                    timestepper_type='CrankNicolson',
+                    timestepper_type='CoupledTracerPicard',
                     no_exports=False, saveplot=True)

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -41,7 +41,6 @@ def run(refinement, **model_options):
     options.simulation_end_time = t_end
     options.simulation_export_time = t_export
     options.solve_tracer = True
-    options.tracer_only = True
     options.use_limiter_for_tracers = True
     options.fields_to_export = ['tracer_2d']
     options.horizontal_diffusivity = Constant(horizontal_diffusivity)
@@ -50,13 +49,15 @@ def run(refinement, **model_options):
 
     solverobj.create_equations()
 
-    t_const = Constant(t_init)
+    t = t_init  # simulation time
+
+    t_const = Constant(t)
     u_max = 1.0
     u_min = -1.0
     x0 = lx/2.0
     x, y = SpatialCoordinate(solverobj.mesh2d)
     tracer_expr = 0.5*(u_max + u_min) - 0.5*(u_max - u_min)*erf((x - x0)/sqrt(4*horizontal_diffusivity*t_const))
-    tracer_ana = Function(solverobj.function_spaces.Q_2d, name='tracer analytical')
+    tracer_ana = Function(solverobj.function_spaces.H_2d, name='tracer analytical')
     elev_init = Function(solverobj.function_spaces.H_2d, name='elev init')
     solverobj.assign_initial_conditions(elev=elev_init, tracer=tracer_expr)
 
@@ -66,14 +67,35 @@ def run(refinement, **model_options):
 
     def export_func():
         if not options.no_exports:
+            solverobj.export()
             # update analytical solution to correct time
             t_const.assign(t)
             out_tracer_ana.write(tracer_ana.project(tracer_expr))
 
-    solverobj.iterate(export_func=export_func)
+    # export initial conditions
+    export_func()
+
+    # custom time loop that solves tracer equation only
+    if options.timestepper_type == 'CoupledTracerPicard':
+        ti = solverobj.timestepper.timesteppers.coupled_tracer
+    else:
+        ti = solverobj.timestepper.timesteppers.tracer_2d
+
+    i = 0
+    iexport = 1
+    next_export_t = t + solverobj.options.simulation_export_time
+    while t < t_end - 1e-8:
+        ti.advance(t)
+        t += solverobj.dt
+        i += 1
+        if t >= next_export_t - 1e-8:
+            print_output('{:3d} i={:5d} t={:8.2f} s tracer={:8.2f}'.format(iexport, i, t, norm(solverobj.fields.tracer_2d)))
+            export_func()
+            next_export_t += solverobj.options.simulation_export_time
+            iexport += 1
 
     # project analytical solution on high order mesh
-    t_const.assign(t_end)
+    t_const.assign(t)
     # compute L2 norm
     l2_err = errornorm(tracer_expr, solverobj.fields.tracer_2d)/numpy.sqrt(area)
     print_output('L2 error {:.12f}'.format(l2_err))
@@ -161,6 +183,6 @@ def test_horizontal_diffusion(polynomial_degree, stepper, expected_rate):
 
 if __name__ == '__main__':
     run_convergence([1, 2, 4, 6, 8], polynomial_degree=1,
-                    timestepper_type='CoupledTracerPicard',
+                    timestepper_type='CrankNicolson',
                     expected_rate=1.8,
                     no_exports=False, saveplot=True)

--- a/test/tracerEq/test_h-diffusion_mes_2d.py
+++ b/test/tracerEq/test_h-diffusion_mes_2d.py
@@ -57,7 +57,7 @@ def run(refinement, **model_options):
     x0 = lx/2.0
     x, y = SpatialCoordinate(solverobj.mesh2d)
     tracer_expr = 0.5*(u_max + u_min) - 0.5*(u_max - u_min)*erf((x - x0)/sqrt(4*horizontal_diffusivity*t_const))
-    tracer_ana = Function(solverobj.function_spaces.H_2d, name='tracer analytical')
+    tracer_ana = Function(solverobj.function_spaces.Q_2d, name='tracer analytical')
     elev_init = Function(solverobj.function_spaces.H_2d, name='elev init')
     solverobj.assign_initial_conditions(elev=elev_init, tracer=tracer_expr)
 

--- a/thetis/configuration.py
+++ b/thetis/configuration.py
@@ -213,6 +213,31 @@ class PETScSolverParameters(Dict):
         self.error(obj, value)
 
 
+class CoupledTracerImplicitness(Dict):
+    info_text = 'a dictionary of implicness values for CoupledTracerPicard'
+
+    def __init__(self, default_value=Undefined, bounds=None, **kwargs):
+        self.minval = bounds[0]
+        self.maxval = bounds[1]
+        super(CoupledTracerImplicitness, self).__init__(default_value=default_value, **kwargs)
+
+    def validate(self, obj, value):
+        if (isinstance(value, dict)
+                and all(self.minval <= theta <= self.maxval for key, theta in value.items())):
+            return value
+        self.error(obj, value)
+
+
+class CoupledTracerSemiImplicitness(Dict):
+    info_text = 'a dictionary of bools toggling semi-implicitness for CoupledTracerPicard'
+
+    def validate(self, obj, value):
+        if (isinstance(value, dict)
+                and all(isinstance(semi_implicit, bool) for key, semi_implicit in value.items())):
+            return value
+        self.error(obj, value)
+
+
 class PairedEnum(Enum):
     """A enum whose value must be in a given sequence.
 

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -100,7 +100,8 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
         # compatible with the 2d coupled timeintegrator
         assert solution2d == self.fields.solution_2d
 
-        self.timesteppers.swe2d.initialize(self.fields.solution_2d)
+        if not self.options.tracer_only:
+            self.timesteppers.swe2d.initialize(self.fields.solution_2d)
         if self.options.solve_tracer:
             if self.coupled:
                 solutions = {

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -153,6 +153,19 @@ class CoupledMatchingTimeIntegrator2D(CoupledTimeIntegrator2D):
         super(CoupledMatchingTimeIntegrator2D, self).__init__(solver)
 
 
+class CoupledTracerTimeIntegrator2D(CoupledTimeIntegrator2D):
+    def __init__(self, solver):
+        if not solver.options.tracer_only:
+            self.swe_integrator = timeintegrator.CrankNicolson
+        if solver.options.solve_tracer:
+            self.tracer_integrator = timeintegrator.CoupledTracerPicard
+        if solver.options.sediment_model_options.solve_suspended_sediment:
+            self.sediment_integrator = timeintegrator.CrankNicolson
+        if solver.options.sediment_model_options.solve_exner:
+            self.exner_integrator = timeintegrator.CrankNicolson
+        super(CoupledTracerTimeIntegrator2D, self).__init__(solver)
+
+
 class CoupledCrankEuler2D(CoupledTimeIntegrator2D):
     swe_integrator = timeintegrator.CrankNicolson
     tracer_integrator = timeintegrator.ForwardEuler

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -75,7 +75,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                     self.timesteppers[label] = self.tracer_integrator(*args, **kwargs)
         if self.options.sediment_model_options.solve_suspended_sediment:
             args, kwargs = self.solver.get_sediment_timestepper_setup()
-            self.timesteppers.sediment = self.sediment_timestepper(*args, **kwargs)
+            self.timesteppers.sediment = self.sediment_integrator(*args, **kwargs)
         if self.options.sediment_model_options.solve_exner:
             args, kwargs = self.solver.get_exner_timestepper_setup()
             self.timesteppers.exner = self.exner_integrator(*args, **kwargs)

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -57,7 +57,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
         if self.options.solve_tracer:
             self.coupled = self.options.timestepper_type == 'CoupledTracerPicard'
             if self.coupled:
-                equations, solutions, fields, bnd_conditions = {}, {}, {}, {}
+                equations, solutions, fields, bnd_conditions = OrderedDict(), {}, {}, {}
                 for label in self.options.tracer_metadata:
                     args, kwargs = self.solver.get_tracer_timestepper_setup(label)
                     equations[label], solutions[label], fields[label], dt = args

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -144,8 +144,18 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
 
 
 class CoupledMatchingTimeIntegrator2D(CoupledTimeIntegrator2D):
+    """
+    A :class:`CoupledTimeIntegrator2D` which uses the
+    same time integrator for all components.
+    """
     def __init__(self, solver, integrator):
-        self.swe_integrator = integrator
+        """
+        :arg solver: the :class:`FlowSolver2d` object
+        :arg integrator: the time integrator to be used
+            for all equations
+        """
+        if not solver.options.tracer_only:
+            self.swe_integrator = integrator
         if solver.options.solve_tracer:
             self.tracer_integrator = integrator
         if solver.options.sediment_model_options.solve_suspended_sediment:
@@ -156,7 +166,16 @@ class CoupledMatchingTimeIntegrator2D(CoupledTimeIntegrator2D):
 
 
 class CoupledTracerTimeIntegrator2D(CoupledTimeIntegrator2D):
+    """
+    A :class:`CoupledTimeIntegrator2D` which uses a
+    Picard iteration to solve coupled tracer
+    equations and Crank-Nicolson for all other
+    components.
+    """
     def __init__(self, solver):
+        """
+        :arg solver: the :class:`FlowSolver2d` object
+        """
         if not solver.options.tracer_only:
             self.swe_integrator = timeintegrator.CrankNicolson
         if solver.options.solve_tracer:
@@ -169,6 +188,12 @@ class CoupledTracerTimeIntegrator2D(CoupledTimeIntegrator2D):
 
 
 class CoupledCrankEuler2D(CoupledTimeIntegrator2D):
+    """
+    A :class:`CoupledTimeIntegrator2D` which uses
+    Crank-Nicolson to integrate the shallow water
+    and Exner components and Forward Euler for any
+    tracer and sediment components.
+    """
     swe_integrator = timeintegrator.CrankNicolson
     tracer_integrator = timeintegrator.ForwardEuler
     sediment_integrator = timeintegrator.ForwardEuler

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -74,8 +74,8 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
                     args, kwargs = self.solver.get_tracer_timestepper_setup(label)
                     self.timesteppers[label] = self.tracer_integrator(*args, **kwargs)
         if self.options.sediment_model_options.solve_suspended_sediment:
-            args, kwargs = self.solver.get_sediment_timestepper()
-            self.timesteppers.sediment = self.solver.get_sediment_timestepper_setup(*args, **kwargs)
+            args, kwargs = self.solver.get_sediment_timestepper_setup()
+            self.timesteppers.sediment = self.sediment_timestepper(*args, **kwargs)
         if self.options.sediment_model_options.solve_exner:
             args, kwargs = self.solver.get_exner_timestepper_setup()
             self.timesteppers.exner = self.exner_integrator(*args, **kwargs)

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -110,13 +110,19 @@ class PressureProjectionTimestepperOptions2d(TimeStepperOptions):
 
 class CoupledTracerTimestepperOptions2d(SemiImplicitTimestepperOptions2d):
     """Options for 2d coupled tracer time integrator"""
+    implicitness_theta_tracer = CoupledTracerImplicitness(
+        default_value={'tracer_2d': 0.5}, bounds=[0.5, 1.0],
+        help='implicitness parameter theta for tracer timesteppers. Value 0.5 implies Crank-Nicolson scheme, 1.0 implies fully implicit formulation.').tag(config=True)
     implicitness_theta = BoundedFloat(
         default_value=0.5, bounds=[0.5, 1.0],
-        help='implicitness parameter theta. Value 0.5 implies Crank-Nicolson scheme, 1.0 implies fully implicit formulation.').tag(config=True)
+        help='implicitness parameter theta for other timesteppers. Value 0.5 implies Crank-Nicolson scheme, 1.0 implies fully implicit formulation.').tag(config=True)
     picard_iterations = PositiveInteger(
         default_value=1,
         help='number of Picard iterations to converge the nonlinearity in the equations.')
-
+    use_semi_implicit_linearization_tracer = CoupledTracerSemiImplicitness(
+        default_value={'tracer_2d': False}, help="Use linearized semi-implicit time integration for tracer timesteppers").tag(config=True)
+    use_semi_implicit_linearization = Bool(
+        False, help="Use linearized semi-implicit time integration for other timesteppers").tag(config=True)
 
 class ExplicitTimestepperOptions2d(ExplicitTimestepperOptions):
     """Options for 2d explicit time integrator"""

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -108,6 +108,16 @@ class PressureProjectionTimestepperOptions2d(TimeStepperOptions):
         help='number of Picard iterations to converge the nonlinearity in the equations.')
 
 
+class CoupledTracerTimestepperOptions2d(SemiImplicitTimestepperOptions2d):
+    """Options for 2d coupled tracer time integrator"""
+    implicitness_theta = BoundedFloat(
+        default_value=0.5, bounds=[0.5, 1.0],
+        help='implicitness parameter theta. Value 0.5 implies Crank-Nicolson scheme, 1.0 implies fully implicit formulation.').tag(config=True)
+    picard_iterations = PositiveInteger(
+        default_value=2,
+        help='number of Picard iterations to converge the nonlinearity in the equations.')
+
+
 class ExplicitTimestepperOptions2d(ExplicitTimestepperOptions):
     """Options for 2d explicit time integrator"""
     solver_parameters = PETScSolverParameters({
@@ -633,6 +643,7 @@ class SedimentModelOptions(FrozenHasTraits):
                                    ('DIRK33', SemiImplicitTimestepperOptions2d),
                                    ('SteadyState', SteadyStateTimestepperOptions2d),
                                    ('PressureProjectionPicard', PressureProjectionTimestepperOptions2d),
+                                   ('CoupledTracerPicard', CoupledTracerTimestepperOptions2d),
                                    ('SSPIMEX', SemiImplicitTimestepperOptions2d),
                                    ],
                                   "timestepper_options",

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -114,7 +114,7 @@ class CoupledTracerTimestepperOptions2d(SemiImplicitTimestepperOptions2d):
         default_value=0.5, bounds=[0.5, 1.0],
         help='implicitness parameter theta. Value 0.5 implies Crank-Nicolson scheme, 1.0 implies fully implicit formulation.').tag(config=True)
     picard_iterations = PositiveInteger(
-        default_value=2,
+        default_value=1,
         help='number of Picard iterations to converge the nonlinearity in the equations.')
 
 

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -724,7 +724,8 @@ class ModelOptions2d(CommonModelOptions):
         False, help="Use SUPG stabilisation in tracer advection").tag(config=True)
 
     def __init__(self, *args, **kwargs):
-        self.tracer_metadata = {}
+        from collections import OrderedDict
+        self.tracer_metadata = OrderedDict()
         super(ModelOptions2d, self).__init__(*args, **kwargs)
 
     def add_tracer_2d(self, label, name, filename, shortname=None, unit='-', source=None):

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -124,6 +124,7 @@ class CoupledTracerTimestepperOptions2d(SemiImplicitTimestepperOptions2d):
     use_semi_implicit_linearization = Bool(
         False, help="Use linearized semi-implicit time integration for other timesteppers").tag(config=True)
 
+
 class ExplicitTimestepperOptions2d(ExplicitTimestepperOptions):
     """Options for 2d explicit time integrator"""
     solver_parameters = PETScSolverParameters({

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -419,7 +419,7 @@ class FlowSolver2d(FrozenClass):
 
         self._isfrozen = True  # disallow creating new attributes
 
-    def get_swe_timestepper(self, integrator):
+    def get_swe_timestepper_setup(self):
         """
         Gets shallow water timestepper object with appropriate parameters
         """
@@ -471,9 +471,9 @@ class FlowSolver2d(FrozenClass):
             }
         else:
             kwargs['solver_parameters'] = self.options.timestepper_options.solver_parameters
-        return integrator(*args, **kwargs)
+        return args, kwargs
 
-    def get_tracer_timestepper(self, integrator, label):
+    def get_tracer_timestepper_setup(self, label):
         """
         Gets tracer timestepper object with appropriate parameters
         """
@@ -499,9 +499,9 @@ class FlowSolver2d(FrozenClass):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
         if hasattr(self.options.timestepper_options, 'implicitness_theta'):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta
-        return args, kwargs if coupled else integrator(*args, **kwargs)
+        return args, kwargs
 
-    def get_sediment_timestepper(self, integrator):
+    def get_sediment_timestepper_setup(self):
         """
         Gets sediment timestepper object with appropriate parameters
         """
@@ -523,9 +523,9 @@ class FlowSolver2d(FrozenClass):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
         if hasattr(self.options.timestepper_options, 'implicitness_theta'):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta
-        return integrator(*args, **kwargs)
+        return args, kwargs
 
-    def get_exner_timestepper(self, integrator):
+    def get_exner_timestepper_setup(self):
         """
         Gets exner timestepper object with appropriate parameters
         """
@@ -549,7 +549,7 @@ class FlowSolver2d(FrozenClass):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
         if hasattr(self.options.timestepper_options, 'implicitness_theta'):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta
-        return integrator(*args, **kwargs)
+        return args, kwargs
 
     def get_fs_timestepper(self, integrator):
         """

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -600,9 +600,7 @@ class FlowSolver2d(FrozenClass):
             'PressureProjectionPicard': timeintegrator.PressureProjectionPicard,
             'SSPIMEX': implicitexplicit.IMEXLPUM2,
         }
-        try:
-            assert self.options.timestepper_type in steppers
-        except AssertionError:
+        if self.options.timestepper_type not in steppers
             raise Exception('Unknown time integrator type: {:s}'.format(self.options.timestepper_type))
         if self.options.nh_model_options.solve_nonhydrostatic_pressure:
             self.poisson_solver = DepthIntegratedPoissonSolver(
@@ -615,17 +613,13 @@ class FlowSolver2d(FrozenClass):
                 steppers[self.options.nh_model_options.free_surface_timestepper_type]
             )
         elif self.options.solve_tracer:
-            try:
-                assert self.options.timestepper_type not in ('PressureProjectionPicard', 'SSPIMEX')
-            except AssertionError:
+            if self.options.timestepper_type in ('PressureProjectionPicard', 'SSPIMEX')
                 raise NotImplementedError("2D tracer model currently only supports SSPRK33, ForwardEuler, SteadyState, BackwardEuler, DIRK22, DIRK33 and CrankNicolson time integrators.")
             self.timestepper = coupled_timeintegrator_2d.CoupledMatchingTimeIntegrator2D(
                 weakref.proxy(self), steppers[self.options.timestepper_type],
             )
         elif self.options.sediment_model_options.solve_suspended_sediment or self.options.sediment_model_options.solve_exner:
-            try:
-                assert self.options.timestepper_type not in ('PressureProjectionPicard', 'SSPIMEX', 'SteadyState')
-            except AssertionError:
+            if self.options.timestepper_type in ('PressureProjectionPicard', 'SSPIMEX', 'SteadyState')
                 raise NotImplementedError("2D sediment model currently only supports SSPRK33, ForwardEuler, BackwardEuler, DIRK22, DIRK33 and CrankNicolson time integrators.")
             self.timestepper = coupled_timeintegrator_2d.CoupledMatchingTimeIntegrator2D(
                 weakref.proxy(self), steppers[self.options.timestepper_type],

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -499,7 +499,7 @@ class FlowSolver2d(FrozenClass):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
         if hasattr(self.options.timestepper_options, 'implicitness_theta'):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta
-        return integrator(*args, **kwargs)
+        return args, kwargs if coupled else integrator(*args, **kwargs)
 
     def get_sediment_timestepper(self, integrator):
         """

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -614,20 +614,30 @@ class FlowSolver2d(FrozenClass):
                 steppers[self.options.nh_model_options.free_surface_timestepper_type]
             )
         elif self.options.solve_tracer:
-            if self.options.timestepper_type in ('PressureProjectionPicard', 'SSPIMEX')
-                raise NotImplementedError("2D tracer model currently only supports SSPRK33, ForwardEuler, SteadyState, BackwardEuler, DIRK22, DIRK33 and CrankNicolson time integrators.")
-            self.timestepper = coupled_timeintegrator_2d.CoupledMatchingTimeIntegrator2D(
-                weakref.proxy(self), steppers[self.options.timestepper_type],
-            )
+            if self.options.timestepper_type in ('PressureProjectionPicard', 'SSPIMEX'):
+                raise NotImplementedError("2D tracer model currently only supports SSPRK33,"
+                                          + " ForwardEuler, SteadyState, BackwardEuler, DIRK22,"
+                                          + " DIRK33, CrankNicolson and CoupledTracerPicard time"
+                                          + " integrators.")
+            if self.options.timestepper_type == 'CoupledTracerPicard':
+                self.timestepper = coupled_timeintegrator_2d.CoupledTracerTimeIntegrator2D(
+                    weakref.proxy(self),
+                )
+            else:
+                self.timestepper = coupled_timeintegrator_2d.CoupledMatchingTimeIntegrator2D(
+                    weakref.proxy(self), steppers[self.options.timestepper_type],
+                )
         elif self.options.sediment_model_options.solve_suspended_sediment or self.options.sediment_model_options.solve_exner:
             if self.options.timestepper_type in ('PressureProjectionPicard', 'SSPIMEX', 'SteadyState', 'CoupledTracerPicard'):
-                raise NotImplementedError("2D sediment model currently only supports SSPRK33, ForwardEuler, BackwardEuler, DIRK22, DIRK33 and CrankNicolson time integrators.")
+                raise NotImplementedError("2D sediment model currently only supports SSPRK33,"
+                                          + " ForwardEuler, BackwardEuler, DIRK22, DIRK33 and"
+                                          + " CrankNicolson time integrators.")
             self.timestepper = coupled_timeintegrator_2d.CoupledMatchingTimeIntegrator2D(
                 weakref.proxy(self), steppers[self.options.timestepper_type],
             )
         else:
             if self.options.timestepper_type == 'CoupledTracerPicard':
-                raise NotImplementedError  # TODO: Need capability for mixed ts choices
+                raise ValueError("Cannot use CoupledTracerPicard without tracers")
             self.timestepper = self.get_swe_timestepper(steppers[self.options.timestepper_type])
         print_output('Using time integrator: {:}'.format(self.timestepper.__class__.__name__))
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -604,6 +604,8 @@ class FlowSolver2d(FrozenClass):
         if self.options.timestepper_type not in steppers:
             raise Exception('Unknown time integrator type: {:s}'.format(self.options.timestepper_type))
         if self.options.nh_model_options.solve_nonhydrostatic_pressure:
+            if self.options.timestepper_type == 'CoupledTracerPicard':
+                raise ValueError("CoupledTracerPicard is not supported in non-hydostatic mode")
             self.poisson_solver = DepthIntegratedPoissonSolver(
                 self.fields.q_2d, self.fields.uv_2d, self.fields.w_2d,
                 self.fields.elev_2d, self.depth, self.dt, self.bnd_functions,

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -646,7 +646,7 @@ class FlowSolver2d(FrozenClass):
         else:
             if self.options.timestepper_type == 'CoupledTracerPicard':
                 raise ValueError("Cannot use CoupledTracerPicard without tracers")
-            args, kwargs = self.get_swe_timestepper_setup()
+            args, kwargs = self.setup_swe_timestepper()
             self.timestepper = steppers[self.options.timestepper_type](*args, **kwargs)
         print_output('Using time integrator: {:}'.format(self.timestepper.__class__.__name__))
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -500,8 +500,8 @@ class FlowSolver2d(FrozenClass):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization_tracer[label]
         elif hasattr(self.options.timestepper_options, 'use_semi_implicit_linearization'):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
-        if (hasattr(self.options.timestepper_options, 'implicitness_theta_tracer') and
-                label in self.options.timestepper_options.implicitness_theta_tracer):
+        if (hasattr(self.options.timestepper_options, 'implicitness_theta_tracer')
+                and label in self.options.timestepper_options.implicitness_theta_tracer):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta_tracer[label]
         elif hasattr(self.options.timestepper_options, 'implicitness_theta'):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -419,9 +419,9 @@ class FlowSolver2d(FrozenClass):
 
         self._isfrozen = True  # disallow creating new attributes
 
-    def get_swe_timestepper_setup(self):
+    def setup_swe_timestepper(self):
         """
-        Gets shallow water timestepper object with appropriate parameters
+        Gets parameters for shallow water timestepper
         """
         fields = {
             'linear_drag_coefficient': self.options.linear_drag_coefficient,
@@ -473,9 +473,9 @@ class FlowSolver2d(FrozenClass):
             kwargs['solver_parameters'] = self.options.timestepper_options.solver_parameters
         return args, kwargs
 
-    def get_tracer_timestepper_setup(self, label):
+    def setup_tracer_timestepper(self, label):
         """
-        Gets tracer timestepper object with appropriate parameters
+        Gets parameters for tracer timestepper
         """
         uv, elev = self.fields.solution_2d.split()
         fields = {
@@ -495,15 +495,21 @@ class FlowSolver2d(FrozenClass):
             kwargs['bnd_conditions'] = self.bnd_functions[label[:-3]]
         else:
             kwargs['bnd_conditions'] = {}
-        if hasattr(self.options.timestepper_options, 'use_semi_implicit_linearization'):
+        if (hasattr(self.options.timestepper_options, 'use_semi_implicit_linearization_tracer')
+                and label in self.options.timestepper_options.use_semi_implicit_linearization_tracer):
+            kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization_tracer[label]
+        elif hasattr(self.options.timestepper_options, 'use_semi_implicit_linearization'):
             kwargs['semi_implicit'] = self.options.timestepper_options.use_semi_implicit_linearization
-        if hasattr(self.options.timestepper_options, 'implicitness_theta'):
+        if (hasattr(self.options.timestepper_options, 'implicitness_theta_tracer') and
+                label in self.options.timestepper_options.implicitness_theta_tracer):
+            kwargs['theta'] = self.options.timestepper_options.implicitness_theta_tracer[label]
+        elif hasattr(self.options.timestepper_options, 'implicitness_theta'):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta
         return args, kwargs
 
-    def get_sediment_timestepper_setup(self):
+    def setup_sediment_timestepper(self):
         """
-        Gets sediment timestepper object with appropriate parameters
+        Gets parameters for sediment timestepper
         """
         uv, elev = self.fields.solution_2d.split()
         fields = {
@@ -525,9 +531,9 @@ class FlowSolver2d(FrozenClass):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta
         return args, kwargs
 
-    def get_exner_timestepper_setup(self):
+    def setup_exner_timestepper(self):
         """
-        Gets exner timestepper object with appropriate parameters
+        Gets parameters for Exner timestepper
         """
         uv, elev = self.fields.solution_2d.split()
         if not self.options.sediment_model_options.solve_suspended_sediment:
@@ -551,9 +557,9 @@ class FlowSolver2d(FrozenClass):
             kwargs['theta'] = self.options.timestepper_options.implicitness_theta
         return args, kwargs
 
-    def get_fs_timestepper(self, integrator):
+    def setup_fs_timestepper(self):
         """
-        Gets free-surface correction timestepper object with appropriate parameters
+        Gets parameters for free-surface correction timestepper
         """
         nh_options = self.options.nh_model_options
         fields_fs = {
@@ -569,7 +575,7 @@ class FlowSolver2d(FrozenClass):
             kwargs['semi_implicit'] = nh_options.free_surface_timestepper_options.use_semi_implicit_linearization
         if hasattr(nh_options.free_surface_timestepper_options, 'implicitness_theta'):
             kwargs['theta'] = nh_options.free_surface_timestepper_options.implicitness_theta
-        return integrator(*args, **kwargs)
+        return args, kwargs
 
     def create_timestepper(self):
         """

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -638,7 +638,8 @@ class FlowSolver2d(FrozenClass):
         else:
             if self.options.timestepper_type == 'CoupledTracerPicard':
                 raise ValueError("Cannot use CoupledTracerPicard without tracers")
-            self.timestepper = self.get_swe_timestepper(steppers[self.options.timestepper_type])
+            args, kwargs = self.get_swe_timestepper_setup()
+            self.timestepper = steppers[self.options.timestepper_type](*args, **kwargs)
         print_output('Using time integrator: {:}'.format(self.timestepper.__class__.__name__))
 
         self._isfrozen = True  # disallow creating new attributes


### PR DESCRIPTION
At the minute, a system of multiple 2D tracers can be solved sequentially in any order and it won't make a difference. There is some interest in extending the 2D tracer model to include reaction terms. In that case, the order does matter and it will probably be worthwhile to iterate at each timestep.

This PR introduces a `CoupledTracerPicard` time integrator which does this. For some specified number of iterations, it solves each tracer equation sequentially.