### PR TITLE
Transect callback

### DIFF
--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -36,6 +36,7 @@ COMODO lock exchange benchmark [2]:
 from thetis import *
 from diagnostics import *
 from plotting import *
+from thetis.callback import TransectCallback
 
 
 def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
@@ -174,12 +175,17 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
     options.equation_of_state_options.beta = 0.0
     options.update(custom_options)
 
+    solver_obj.create_equations()
+
     if comm.size == 1:
         solver_obj.add_callback(RPECalculator(solver_obj))
         solver_obj.add_callback(FrontLocationCalculator(solver_obj))
-        # solver_obj.add_callback(PlotCallback(solver_obj, append_to_log=False))
-
-    solver_obj.create_equations()
+        solver_obj.add_callback(PlotCallback(solver_obj, append_to_log=False))
+        trans_x = np.linspace(-10e3, 30e3, 100)
+        trans_y = 10.0
+        tcp = TransectCallback(solver_obj, ['temp_3d', 'uv_3d'],
+                               trans_x, trans_y, 'along', append_to_log=True)
+        solver_obj.add_callback(tcp)
 
     print_output('Running lock exchange problem with options:')
     print_output('Resolution: {:}'.format(reso_str))

--- a/examples/lockExchange/lockExchange.py
+++ b/examples/lockExchange/lockExchange.py
@@ -181,7 +181,7 @@ def run_lockexchange(reso_str='coarse', poly_order=1, element_family='dg-dg',
         solver_obj.add_callback(RPECalculator(solver_obj))
         solver_obj.add_callback(FrontLocationCalculator(solver_obj))
         solver_obj.add_callback(PlotCallback(solver_obj, append_to_log=False))
-        trans_x = np.linspace(-10e3, 30e3, 100)
+        trans_x = np.linspace(-30e3, 30e3, 300)
         trans_y = 10.0
         tcp = TransectCallback(solver_obj, ['temp_3d', 'uv_3d'],
                                trans_x, trans_y, 'along', append_to_log=True)

--- a/examples/lockExchange/plotting.py
+++ b/examples/lockExchange/plotting.py
@@ -3,6 +3,7 @@ Plotting routines
 """
 from thetis import *
 import itertools
+import copy
 
 try:
     import matplotlib
@@ -52,7 +53,7 @@ class PlotCallback(DiagnosticCallback):
             x_max = x.max()
             x_min = x.min()
             delta_x = self.solver_obj.fields.h_elem_size_2d.dat.data.mean()*np.sqrt(2)
-            n_x = np.round((x_max - x_min)/delta_x)
+            n_x = int(np.round((x_max - x_min)/delta_x))
             npoints = layers*4
             epsilon = 1e-10  # nudge points to avoid libspatialindex errors
             z_min = -(depth - epsilon)
@@ -67,7 +68,7 @@ class PlotCallback(DiagnosticCallback):
             self.x_plot = x/1000.0  # to km
             self.z_plot = z
 
-            self.cmap = plt.get_cmap('RdBu_r')
+            self.cmap = copy.copy(plt.get_cmap('RdBu_r'))
             self.cmap.set_over('#ffa500')
             self.cmap.set_under('#00e639')
 
@@ -79,8 +80,9 @@ class PlotCallback(DiagnosticCallback):
             overshoot_tol = 1e-6
             # divide each integer in color array to this many levels
             cbar_reso = max(min(int(np.round(5.0/(cmax - cmin)*4)), 6), 1)
+            nlevels = int(cbar_reso*(cmax-cmin) + 1)
             levels = np.linspace(cmin - overshoot_tol, cmax + overshoot_tol,
-                                 cbar_reso*(cmax-cmin) + 1)
+                                 nlevels)
             p = ax.contourf(self.x_plot, self.z_plot, color_array, levels, cmap=cmap, extend='both')
             ax.set_xlabel('x [km]')
             ax.set_ylabel('z [m]')
@@ -110,7 +112,7 @@ class PlotCallback(DiagnosticCallback):
             nplots = 1
             fix, ax = plt.subplots(nrows=nplots, figsize=(12, 3.5*nplots))
 
-            iexp = self.export_count.next()
+            iexp = next(self.export_count)
             title = 'Time {:.2f} h'.format(self.solver_obj.simulation_time/3600.0)
             fname = 'plot_density_{0:06d}.png'.format(iexp)
             fname = os.path.join(self.imgdir, fname)

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -881,7 +881,7 @@ class TransectCallback(DiagnosticCallback):
     name = 'transect'
     variable_names = ['z_coord', 'value']
 
-    def __init__(self, solver_obj, fieldname, x, y,
+    def __init__(self, solver_obj, fieldnames, x, y,
                  location_name,
                  n_points_z=48,
                  z_min=None, z_max=None,
@@ -889,14 +889,16 @@ class TransectCallback(DiagnosticCallback):
                  append_to_log=True):
         """
         :arg solver_obj: Thetis :class:`FlowSolver` object
-        :arg fieldname: Field to extract
-        :arg x, y: list of location coordinates in model coordinate system
+        :arg fieldnames: List of fields to extract
+        :arg x, y: location coordinates in model coordinate system.
         :arg location_name: Unique name for this location. This
             determines the name of the output h5 file (prefixed with
             `diagnostic_`).
-        :arg int npoints: Number of points along the vertical axis. The 3D
+        :arg int n_points_z: Number of points along the vertical axis. The 3D
             field will be interpolated on these points, ranging from the bottom
             to the (time dependent) free surface.
+        :kwarg float z_min, zmax: Force min/max value of z coordinate extent.
+            By default, transect will cover entire depth from bed to surface.
         :kwarg str outputdir: Custom directory where hdf5 files will be stored.
             By default solver's output directory is used.
         :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
@@ -905,10 +907,12 @@ class TransectCallback(DiagnosticCallback):
             printed in log
         """
         assert export_to_hdf5 is True
-        self.fieldname = fieldname
+        self.fieldnames = fieldnames
         self.location_name = location_name
+        field_short_names = [f.split('_')[0] for f in self.fieldnames]
+        field_str = '-'.join(field_short_names)
         self.name += '_' + self.location_name
-        self.name += '_' + self.fieldname
+        self.name += '_' + field_str
 
         self.x = np.array([x]).ravel()
         self.y = np.array([y]).ravel()
@@ -927,12 +931,19 @@ class TransectCallback(DiagnosticCallback):
         self.force_z_min = z_min
         self.force_z_max = z_max
 
-        self.field = solver_obj.fields[self.fieldname]
-        self.field_dim = self.field.function_space().value_size
-        if self.field_dim == 2:
-            self.variable_names = ['z_coord', 'value_x', 'value_y']
-        if self.field_dim == 3:
-            self.variable_names = ['z_coord', 'value_x', 'value_y', 'value_z']
+        self.field_dims = {}
+        for f in self.fieldnames:
+            func = solver_obj.fields[f]
+            self.field_dims[f] = func.function_space().value_size
+        self.variable_names = ['z_coord']
+        for f, f_short in zip(fieldnames, field_short_names):
+            if self.field_dims[f] == 1:
+                self.variable_names.append(f_short)
+            else:
+                coords = ['x', 'y', 'z']
+                for k in range(self.field_dims[f]):
+                    f_comp_name = f_short + '_' + coords[k]
+                    self.variable_names.append(f_comp_name)
 
         super().__init__(
             solver_obj,
@@ -978,25 +989,32 @@ class TransectCallback(DiagnosticCallback):
             self._initialize()
         self._update_coords()
 
-        # evaluate function on regular grid
-        func = self.field
-        try:
-            vals = func.at(tuple(self.xyz))
-        except PointNotInDomainError as e:
-            error('{:}: Cannot evaluate data on transect {:}'.format(self.__class__.__name__, self.location_name))
-            raise e
-        shape = list(self.value_shape) + [self.field_dim]
-        arr = np.array(vals).reshape(shape)
-        if self.field_dim == 3:
-            return (self.trans_z, arr[..., 0], arr[..., 1], arr[..., 2])
-        if self.field_dim == 2:
-            return (self.trans_z, arr[..., 0], arr[..., 1])
-        return (self.trans_z, arr[..., 0])
+        outvals = [self.trans_z]
+        for fieldname in self.fieldnames:
+            field = self.solver_obj.fields[fieldname]
+            field_dim = self.field_dims[fieldname]
+            try:
+                vals = field.at(tuple(self.xyz))
+                arr = np.array(vals)
+            except PointNotInDomainError as e:
+                error('{:}: Cannot evaluate data on transect {:}'.format(self.__class__.__name__, self.location_name))
+                raise e
+            shape = list(self.value_shape) + [field_dim]
+            arr = np.array(vals).reshape(shape)
+            if field_dim == 3:
+                outvals.extend([arr[..., 0], arr[..., 1], arr[..., 2]])
+            elif field_dim == 2:
+                outvals.extend([arr[..., 0], arr[..., 1]])
+            else:
+                outvals.extend([arr[..., 0]])
+        return tuple(outvals)
 
     def message_str(self, *args):
-        minval = args[1].min()
-        maxval = args[1].max()
-
-        line = 'Evaluated {:} profile, value range: {:.3g} - {:.3g}'.format(
-            self.fieldname, minval, maxval)
-        return line
+        out = 'Evaluated transect "{:}":\n'.format(self.location_name)
+        for fieldname, arr in zip(self.variable_names[1:], args[1:]):
+            minval = arr.min()
+            maxval = arr.max()
+            out += '  {:} range: {:.3g} - {:.3g}\n'.format(
+                fieldname, minval, maxval)
+        out = out[:-1]  # suppress last line break
+        return out

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -870,3 +870,133 @@ class VerticalProfileCallback(DiagnosticCallback):
                 fieldname, self.location_name, minval, maxval)
         out = out[:-1]  # suppress last line break
         return out
+
+
+class TransectCallback(DiagnosticCallback):
+    """
+    Extract a vertical transect of a 3D field at a given (x,y) locations.
+
+    Only for the 3D model.
+    """
+    name = 'transect'
+    variable_names = ['z_coord', 'value']
+
+    def __init__(self, solver_obj, fieldname, x, y,
+                 location_name,
+                 n_points_z=48,
+                 z_min=None, z_max=None,
+                 outputdir=None, export_to_hdf5=True,
+                 append_to_log=True):
+        """
+        :arg solver_obj: Thetis :class:`FlowSolver` object
+        :arg fieldname: Field to extract
+        :arg x, y: list of location coordinates in model coordinate system
+        :arg location_name: Unique name for this location. This
+            determines the name of the output h5 file (prefixed with
+            `diagnostic_`).
+        :arg int npoints: Number of points along the vertical axis. The 3D
+            field will be interpolated on these points, ranging from the bottom
+            to the (time dependent) free surface.
+        :kwarg str outputdir: Custom directory where hdf5 files will be stored.
+            By default solver's output directory is used.
+        :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
+            format
+        :kwarg bool append_to_log: If True, callback output messages will be
+            printed in log
+        """
+        assert export_to_hdf5 is True
+        self.fieldname = fieldname
+        self.location_name = location_name
+        self.name += '_' + self.location_name
+        self.name += '_' + self.fieldname
+
+        self.x = np.array([x]).ravel()
+        self.y = np.array([y]).ravel()
+        if len(self.x) == 1:
+            self.x = np.ones_like(self.y) * self.x
+        if len(self.y) == 1:
+            self.y = np.ones_like(self.x) * self.y
+
+        attrs = {'x': self.x, 'y': self.y}
+        attrs['location_name'] = self.location_name
+
+        assert len(self.y) == len(self.x)
+        self.n_points_xy = len(self.x)
+        self.n_points_z = n_points_z
+        self.value_shape = (self.n_points_z, self.n_points_xy)
+        self.force_z_min = z_min
+        self.force_z_max = z_max
+
+        self.field = solver_obj.fields[self.fieldname]
+        self.field_dim = self.field.function_space().value_size
+        if self.field_dim == 2:
+            self.variable_names = ['z_coord', 'value_x', 'value_y']
+        if self.field_dim == 3:
+            self.variable_names = ['z_coord', 'value_x', 'value_y', 'value_z']
+
+        super().__init__(
+            solver_obj,
+            outputdir=outputdir,
+            array_dim=self.value_shape,
+            attrs=attrs,
+            export_to_hdf5=export_to_hdf5,
+            append_to_log=append_to_log)
+        self._initialized = False
+
+    def _initialize(self):
+        outputdir = self.outputdir
+        if outputdir is None:
+            outputdir = self.solver_obj.options.outputdir
+
+        # construct mesh points for evaluation
+        self.xy = list(zip(self.x, self.y))
+        self.trans_x = np.tile(self.x[np.newaxis, :], (self.n_points_z, 1))
+        self.trans_y = np.tile(self.y[np.newaxis, :], (self.n_points_z, 1))
+
+    def _update_coords(self):
+        try:
+            depth = np.array(self.solver_obj.fields.bathymetry_2d.at(self.xy))
+            elev = np.array(self.solver_obj.fields.elev_cg_2d.at(self.xy))
+        except PointNotInDomainError as e:
+            error('{:}: Transect "{:}" point out of horizontal domain'.format(self.__class__.__name__, self.location_name))
+            raise e
+        epsilon = 1e-5  # nudge points to avoid libspatialindex errors
+        z_min = -(depth - epsilon)
+        z_max = elev - epsilon
+        if self.force_z_min is not None:
+            z_min = np.maximum(z_min, self.force_z_min)
+        if self.force_z_max is not None:
+            z_max = np.minimum(z_max, self.force_z_max)
+        self.trans_z = np.linspace(z_max, z_min, self.n_points_z)
+        self.trans_z = self.trans_z.reshape(self.value_shape)
+        self.xyz = np.vstack((self.trans_x.ravel(),
+                              self.trans_y.ravel(),
+                              self.trans_z.ravel())).T
+
+    def __call__(self):
+        if not self._initialized:
+            self._initialize()
+        self._update_coords()
+
+        # evaluate function on regular grid
+        func = self.field
+        try:
+            vals = func.at(tuple(self.xyz))
+        except PointNotInDomainError as e:
+            error('{:}: Cannot evaluate data on transect {:}'.format(self.__class__.__name__, self.location_name))
+            raise e
+        shape = list(self.value_shape) + [self.field_dim]
+        arr = np.array(vals).reshape(shape)
+        if self.field_dim == 3:
+            return (self.trans_z, arr[..., 0], arr[..., 1], arr[..., 2])
+        if self.field_dim == 2:
+            return (self.trans_z, arr[..., 0], arr[..., 1])
+        return (self.trans_z, arr[..., 0])
+
+    def message_str(self, *args):
+        minval = args[1].min()
+        maxval = args[1].max()
+
+        line = 'Evaluated {:} profile, value range: {:.3g} - {:.3g}'.format(
+            self.fieldname, minval, maxval)
+        return line

--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -70,7 +70,8 @@ class DiagnosticHDF5(object):
         :arg str filename: Full filename of the HDF5 file.
         :arg varnames: List of variable names that the diagnostic callback
             provides
-        :kwarg int array_dim: Dimension of the output array. 1 for scalars.
+        :kwarg array_dim: Dimension of the output array.
+            Can be a tuple for multi-dimensional output. Use "1" for scalars.
         :kwarg dict attrs: Additional attributes to be saved in the hdf5 file.
         :kwarg comm: MPI communicator
         :kwarg bool new_file: Define whether to create a new hdf5 file or
@@ -89,20 +90,27 @@ class DiagnosticHDF5(object):
                     hdf5file.create_dataset('time', (0, 1),
                                             maxshape=(None, 1), dtype=dtype)
                 for var in self.varnames:
-                    hdf5file.create_dataset(var, (0, array_dim),
-                                            maxshape=(None, array_dim), dtype=dtype)
+                    dim_list = array_dim
+                    if isinstance(dim_list, tuple):
+                        dim_list = list(array_dim)
+                    elif not isinstance(dim_list, list):
+                        dim_list = list([array_dim])
+                    shape = tuple([0] + dim_list)
+                    max_shape = tuple([None] + dim_list)
+                    hdf5file.create_dataset(var, shape,
+                                            maxshape=max_shape, dtype=dtype)
                 if attrs is not None:
                     hdf5file.attrs.update(attrs)
 
     def _expand_array(self, hdf5file, varname):
         """Expands array varname by 1 entry"""
         arr = hdf5file[varname]
-        shape = arr.shape
-        arr.resize((shape[0] + 1, shape[1]))
+        new_shape = list(arr.shape)
+        new_shape[0] += 1
+        arr.resize(tuple(new_shape))
 
     def _expand(self, hdf5file):
         """Expands data arrays by 1 entry"""
-        # TODO is there an easier way for doing this?
         for var in self.varnames:
             self._expand_array(hdf5file, var)
         if self.include_time:
@@ -156,7 +164,8 @@ class DiagnosticCallback(ABC):
         :arg solver_obj: Thetis solver object
         :kwarg str outputdir: Custom directory where hdf5 files will be stored.
             By default solver's output directory is used.
-        :kwarg int array_dim: Dimension of the output array. 1 for scalars.
+        :kwarg array_dim: Dimension of the output array.
+            Can be a tuple for multi-dimensional output. Use "1" for scalars.
         :kwarg dict attrs: Additional attributes to be saved in the hdf5 file.
         :kwarg bool export_to_hdf5: If True, diagnostics will be stored in hdf5
             format


### PR DESCRIPTION
Adds a callback for storing structured grid transects of 3D fields. Transect is defined by user-specified (x,y) coordinates and number of points in the vertical direction. The vertical coordinate of the transect adapts to the moving grid. The callback is included in the lock exchange example so that it'll be executed in the test suite.