### PR TITLE
Fix passing of timestepper options.

### DIFF
--- a/thetis/implicitexplicit.py
+++ b/thetis/implicitexplicit.py
@@ -31,7 +31,7 @@ class IMEXGeneric(TimeIntegrator):
         pass
 
     def __init__(self, equation, solution, fields, dt, options, bnd_conditions, solver_parameters=None):
-        super(IMEXGeneric, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(IMEXGeneric, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         """
         :arg equation: equation to solve
         :type equation: :class:`Equation` object

--- a/thetis/rungekutta.py
+++ b/thetis/rungekutta.py
@@ -462,7 +462,7 @@ class DIRKGeneric(RungeKuttaTimeIntegrator):
             added to this solver. Default 'all' implies ['implicit', 'explicit', 'source'].
         :type terms_to_add: 'all' or list of 'implicit', 'explicit', 'source'.
         """
-        super(DIRKGeneric, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(DIRKGeneric, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         self.solver_parameters.setdefault('snes_type', 'newtonls')
         self._initialized = False
 
@@ -578,7 +578,7 @@ class DIRKGenericUForm(RungeKuttaTimeIntegrator):
             added to this solver. Default 'all' implies ['implicit', 'explicit', 'source'].
         :type terms_to_add: 'all' or list of 'implicit', 'explicit', 'source'.
         """
-        super().__init__(equation, solution, fields, dt, solver_parameters)
+        super().__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         semi_implicit = options.use_semi_implicit_linearization
         if semi_implicit:
             self.solver_parameters.setdefault('snes_type', 'ksponly')
@@ -759,7 +759,7 @@ class ERKGeneric(RungeKuttaTimeIntegrator):
             added to this solver. Default 'all' implies ['implicit', 'explicit', 'source'].
         :type terms_to_add: 'all' or list of 'implicit', 'explicit', 'source'.
         """
-        super(ERKGeneric, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(ERKGeneric, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         self._initialized = False
         self.solution_old = Function(self.equation.function_space, name='old solution')
 
@@ -861,7 +861,7 @@ class ERKGenericShuOsher(TimeIntegrator):
             added to this solver. Default 'all' implies ['implicit', 'explicit', 'source'].
         :type terms_to_add: 'all' or list of 'implicit', 'explicit', 'source'.
         """
-        super(ERKGenericShuOsher, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(ERKGenericShuOsher, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
 
         self.tendency = Function(self.equation.function_space, name='tendency')
         self.stage_sol = []

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -52,6 +52,7 @@ class TimeIntegrator(TimeIntegratorBase):
         :arg fields: Dictionary of fields that are passed to the equation
         :type fields: dict of :class:`Function` or :class:`Constant` objects
         :arg float dt: time step in seconds
+        :arg options: :class:`TimeStepperOptions` instance containing parameter values
         :kwarg dict solver_parameters: PETSc solver options
         """
         super(TimeIntegrator, self).__init__()
@@ -91,7 +92,7 @@ class ForwardEuler(TimeIntegrator):
         :arg dict bnd_conditions: Dictionary of boundary conditions passed to the equation
         :kwarg dict solver_parameters: PETSc solver options
         """
-        super(ForwardEuler, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(ForwardEuler, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         self.solution_old = Function(self.equation.function_space)
 
         # create functions to hold the values of previous time step
@@ -152,7 +153,7 @@ class CrankNicolson(TimeIntegrator):
         :arg dict bnd_conditions: Dictionary of boundary conditions passed to the equation
         :kwarg dict solver_parameters: PETSc solver options
         """
-        super(CrankNicolson, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(CrankNicolson, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         theta = options.implicitness_theta
         semi_implicit = options.use_semi_implicit_linearization
         if semi_implicit:
@@ -240,7 +241,7 @@ class SteadyState(TimeIntegrator):
         :arg dict bnd_conditions: Dictionary of boundary conditions passed to the equation
         :kwarg dict solver_parameters: PETSc solver options
         """
-        super(SteadyState, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(SteadyState, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         self.solver_parameters.setdefault('snes_type', 'newtonls')
         self.F = self.equation.residual('all', solution, solution, fields, fields, bnd_conditions)
         self.update_solver()
@@ -291,7 +292,7 @@ class PressureProjectionPicard(TimeIntegrator):
         :arg dict bnd_conditions: Dictionary of boundary conditions passed to the equation
         :kwarg dict solver_parameters: PETSc solver options
         """
-        super(PressureProjectionPicard, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(PressureProjectionPicard, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
         theta = options.implicitness_theta
         semi_implicit = options.use_semi_implicit_linearization
         solver_parameters = options.solver_parameters_pressure
@@ -469,7 +470,7 @@ class LeapFrogAM3(TimeIntegrator):
             added to this solver. Default 'all' implies ['implicit', 'explicit', 'source'].
         :type terms_to_add: 'all' or list of 'implicit', 'explicit', 'source'.
         """
-        super(LeapFrogAM3, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(LeapFrogAM3, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
 
         self.gamma = 1./12.
         self.gamma_const = Constant(self.gamma)
@@ -605,7 +606,7 @@ class SSPRK22ALE(TimeIntegrator):
             added to this solver. Default 'all' implies ['implicit', 'explicit', 'source'].
         :type terms_to_add: 'all' or list of 'implicit', 'explicit', 'source'.
         """
-        super(SSPRK22ALE, self).__init__(equation, solution, fields, dt, solver_parameters)
+        super(SSPRK22ALE, self).__init__(equation, solution, fields, dt, options, solver_parameters=solver_parameters)
 
         fs = self.equation.function_space
         self.mu = Function(fs, name='dual solution')


### PR DESCRIPTION
Since #247 TimeStepperOptions are passed directly to the
timeintegrators. For this an options argument was added to __init__ of
TimeIntegrator and all its subclasses, however the subclasses didn't
actually pass on the new argument when calling super().__init__ I think
the reason this didn't break anything was because the _optional_
solver_parameters was substituted for the required options argument -
because the solver_parameters weren't passed through a keyword in the
call. This means that _all_ solver_parameters will have been assumed
not-provided which probably only worked because it then uses Firedrake's
default of using mumps.
Better to always use the keyword in the call to a function for keyword
arguments - as the convention is that the order of these may change.
Also it masks any mismatch in required arguments like here.