### PR TITLE
NetCDF outputs for 2D fields

### DIFF
--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -61,6 +61,6 @@ options.horizontal_velocity_scale = Constant(0.01)
 options.check_volume_conservation_2d = True
 options.fields_to_export = ['uv_2d', 'elev_2d']
 options.fields_to_export_hdf5 = ['uv_2d', 'elev_2d']
-options.fields_to_export_netcdf = ['elev_2d']
+options.fields_to_export_netcdf = ['uv_2d', 'elev_2d']
 
 solver_obj.iterate()

--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -61,5 +61,6 @@ options.horizontal_velocity_scale = Constant(0.01)
 options.check_volume_conservation_2d = True
 options.fields_to_export = ['uv_2d', 'elev_2d']
 options.fields_to_export_hdf5 = ['uv_2d', 'elev_2d']
+options.fields_to_export_netcdf = ['elev_2d']
 
 solver_obj.iterate()

--- a/examples/stommel2d/stommel2d.py
+++ b/examples/stommel2d/stommel2d.py
@@ -61,6 +61,5 @@ options.horizontal_velocity_scale = Constant(0.01)
 options.check_volume_conservation_2d = True
 options.fields_to_export = ['uv_2d', 'elev_2d']
 options.fields_to_export_hdf5 = ['uv_2d', 'elev_2d']
-options.fields_to_export_netcdf = ['uv_2d', 'elev_2d']
 
 solver_obj.iterate()

--- a/thetis/netcdf_io.py
+++ b/thetis/netcdf_io.py
@@ -13,13 +13,13 @@ def write_nc_field(function, filename, fieldname):
     """
     fs = function.function_space()
     mesh = fs.mesh()
-    is_vector = fs.shape != ()
-    if is_vector:
-        vector_dim = fs.shape[0]
 
-    fs_p0 = get_functionspace(mesh, 'DG', 0)
-    fs_p1 = get_functionspace(mesh, 'CG', 1)
-    fs_p1dg = get_functionspace(mesh, 'DG', 1)
+    tri_mesh = mesh.ufl_cell() == fd.triangle
+    dg_family = 'DG' if tri_mesh else 'DQ'
+    cg_family = 'CG' if tri_mesh else 'Q'
+    fs_p0 = get_functionspace(mesh, dg_family, 0)
+    fs_p1 = get_functionspace(mesh, cg_family, 1)
+    fs_p1dg = get_functionspace(mesh, dg_family, 1)
 
     elem = fs.ufl_element()
     family = elem.family()
@@ -37,6 +37,9 @@ def write_nc_field(function, filename, fieldname):
     data_at_cells = degree == 0
     is_dg = family in ['Discontinuous Lagrange', 'DQ']
     fs_vertex = fs_p1dg if (is_dg and degree == 1) else fs_p1
+    is_vector = fs.shape != ()
+    if is_vector:
+        vector_dim = fs.shape[0]
     face_nodes = elem.cell().num_vertices()
 
     gdim = mesh.geometric_dimension()
@@ -45,18 +48,10 @@ def write_nc_field(function, filename, fieldname):
         raise NotImplementedError(f'Fields of dimension {gdim} are not supported')
     if gdim != 2:
         raise NotImplementedError(f'Mesh coordinates of dimension {gdim} are not supported')
-    # define mesh connectivity and coordinates
+
+    # define mesh connectivity
     global_nb_cells = fs_p0.dim()
     global_nb_vertices = fs_vertex.dim()
-
-    # make coordinate field
-    elem = fs_vertex.ufl_element()
-    family = elem.family()
-    degree = elem.degree()
-    fs_coords = get_functionspace(mesh, family, degree, vector=True)
-    f_coords = fd.Function(fs_coords)
-    x, y = fd.SpatialCoordinate(mesh)
-    f_coords.interpolate(fd.as_vector((x, y)))
 
     def get_lg_index(fs):
         local_nb_dofs = fs.dof_dset.size * fs.dof_dset.cdim
@@ -66,12 +61,19 @@ def write_nc_field(function, filename, fieldname):
 
     local2global_cell_ix = get_lg_index(fs_p0)
     local2global_vertex_ix = get_lg_index(fs_vertex)
-
     local2global_map = fs_vertex.dof_dset.lgmap
-
     local_nb_cells = fs_p0.dof_dset.size * fs_p0.dof_dset.cdim
     local_cell_nodes = fs_vertex.cell_node_list[:local_nb_cells, :]
     global_cell_nodes = local2global_map.apply(local_cell_nodes).reshape(local_cell_nodes.shape)
+
+    # make coordinate field
+    elem = fs_vertex.ufl_element()
+    family = elem.family()
+    degree = elem.degree()
+    fs_coords = get_functionspace(mesh, family, degree, vector=True)
+    f_coords = fd.Function(fs_coords)
+    x, y = fd.SpatialCoordinate(mesh)
+    f_coords.interpolate(fd.as_vector((x, y)))
 
     with netCDF4.Dataset(filename, 'w', parallel=True) as ncfile:
         ncfile.createDimension('face', global_nb_cells)

--- a/thetis/netcdf_io.py
+++ b/thetis/netcdf_io.py
@@ -1,0 +1,94 @@
+import netCDF4
+import firedrake as fd
+from .utility import get_functionspace
+
+
+def write_nc_field(function, filename, fieldname):
+    """
+    Write Function to disk in netCDF format
+
+    :arg function: Firedrake function to export
+    :arg string filename: output filename
+    :arg string fieldname: canonical field name
+    """
+    fs = function.function_space()
+    mesh = fs.mesh()
+
+    fs_p0 = get_functionspace(mesh, 'DG', 0)
+    fs_p1 = get_functionspace(mesh, 'CG', 1)
+    fs_p1dg = get_functionspace(mesh, 'DG', 1)
+
+    elem = fs.ufl_element()
+    family = elem.family()
+    degree = elem.degree()
+    supported = [
+        ('Discontinuous Lagrange', 0),
+        ('Discontinuous Lagrange', 1),
+        ('DQ', 0),
+        ('DQ', 1),
+        ('Lagrange', 1),
+        ('Q', 1),
+    ]
+    assert (family, degree) in supported, \
+        f'Unsupported function space: "{family}" degree={degree}'
+    data_at_cells = degree == 0
+    is_dg = family in ['Discontinuous Lagrange', 'DQ']
+    fs_vertex = fs_p1dg if (is_dg and degree == 1) else fs_p1
+    face_nodes = elem.cell().num_vertices()
+
+    gdim = mesh.geometric_dimension()
+    tdim = mesh.topological_dimension()
+    if tdim != 2:
+        raise NotImplementedError(f'Fields of dimension {gdim} are not supported')
+    if gdim != 2:
+        raise NotImplementedError(f'Mesh coordinates of dimension {gdim} are not supported')
+    # define mesh connectivity and coordinates
+    global_nb_cells = fs_p0.dim()
+    global_nb_vertices = fs_vertex.dim()
+
+    # make coordinate field
+    elem = fs_vertex.ufl_element()
+    family = elem.family()
+    degree = elem.degree()
+    fs_coords = get_functionspace(mesh, family, degree, vector=True)
+    f_coords = fd.Function(fs_coords)
+    x, y = fd.SpatialCoordinate(mesh)
+    f_coords.interpolate(fd.as_vector((x, y)))
+
+    def get_lg_index(fs):
+        local_nb_dofs = fs.dof_dset.size * fs.dof_dset.cdim
+        local2global_map = fs.dof_dset.lgmap
+        local2global_dof_ix = local2global_map.getIndices()[:local_nb_dofs]
+        return local2global_dof_ix
+
+    local2global_cell_ix = get_lg_index(fs_p0)
+    local2global_vertex_ix = get_lg_index(fs_vertex)
+
+    local2global_map = fs_vertex.dof_dset.lgmap
+
+    local_nb_cells = fs_p0.dof_dset.size * fs_p0.dof_dset.cdim
+    local_cell_nodes = fs_vertex.cell_node_list[:local_nb_cells, :]
+    global_cell_nodes = local2global_map.apply(local_cell_nodes).reshape(local_cell_nodes.shape)
+
+    with netCDF4.Dataset(filename, 'w', parallel=True) as ncfile:
+        ncfile.createDimension('face', global_nb_cells)
+        ncfile.createDimension('face_nb_nodes', face_nodes)
+        ncfile.createDimension('vertex', global_nb_vertices)
+
+        mesh_prefix = 'Mesh'
+
+        var = ncfile.createVariable(
+            f'{mesh_prefix}_face_nodes', 'u8', ('face', 'face_nb_nodes'))
+        var.start_index = 0
+        var[local2global_cell_ix, :] = global_cell_nodes
+
+        for i, label in zip(range(gdim), ('x', 'y', 'z')):
+            var = ncfile.createVariable(f'{mesh_prefix}_node_{label}', 'f', ('vertex', ))
+            var[local2global_vertex_ix] = f_coords.dat.data_ro[:, i]
+
+        if data_at_cells:
+            var = ncfile.createVariable(fieldname, 'f', ('face', ))
+            var[local2global_cell_ix] = function.dat.data_ro
+        else:
+            var = ncfile.createVariable(fieldname, 'f', ('vertex', ))
+            var[local2global_vertex_ix] = function.dat.data_ro

--- a/thetis/optimisation.py
+++ b/thetis/optimisation.py
@@ -112,7 +112,7 @@ class DeferredExportManager(object):
         for function, function_arg in zip(self.functions, functions):
             assert function.function_space() is function_arg.function_space()
             function.assign(function_arg)
-        self.export_manager.export()
+        self.export_manager.export(time=0)
 
 
 class UserExportOptimisationCallback(UserExportManager):
@@ -139,7 +139,7 @@ class UserExportOptimisationCallback(UserExportManager):
         :args: these are ignored"""
         for name in self.fields_to_export:
             self.functions[name] = self.orig_functions[name].block_variable.saved_output
-        self.export()
+        self.export(time=0)
 
 
 class ControlsExportOptimisationCallback(DeferredExportManager):

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -743,6 +743,10 @@ class ModelOptions2d(CommonModelOptions):
         2D solver supports 'dg' or 'cg'.""").tag(config=True)
     use_supg_tracer = Bool(
         False, help="Use SUPG stabilisation in tracer advection").tag(config=True)
+    fields_to_export_netcdf = List(
+        trait=Unicode(),
+        default_value=[],
+        help="Fields to export in NetCDF format").tag(config=True)
 
     def __init__(self, *args, **kwargs):
         self.tracer = OrderedDict()

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -525,6 +525,10 @@ class CommonModelOptions(FrozenConfigurable):
         trait=Unicode(),
         default_value=[],
         help="Fields to export in HDF5 format").tag(config=True)
+    fields_to_export_netcdf = List(
+        trait=Unicode(),
+        default_value=[],
+        help="Fields to export in NetCDF format").tag(config=True)
     verbose = Integer(0, help="Verbosity level").tag(config=True)
     linear_drag_coefficient = FiredrakeScalarExpression(
         None, allow_none=True, help=r"""
@@ -743,10 +747,6 @@ class ModelOptions2d(CommonModelOptions):
         2D solver supports 'dg' or 'cg'.""").tag(config=True)
     use_supg_tracer = Bool(
         False, help="Use SUPG stabilisation in tracer advection").tag(config=True)
-    fields_to_export_netcdf = List(
-        trait=Unicode(),
-        default_value=[],
-        help="Fields to export in NetCDF format").tag(config=True)
 
     def __init__(self, *args, **kwargs):
         self.tracer = OrderedDict()

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -887,6 +887,15 @@ class FlowSolver(FrozenClass):
                                        verbose=self.options.verbose > 0,
                                        preproc_funcs=self._field_preproc_funcs)
             self.exporters['hdf5'] = e
+            nc_dir = os.path.join(self.options.output_directory, 'nc')
+            e = exporter.ExportManager(nc_dir,
+                                       self.options.fields_to_export_netcdf,
+                                       self.fields,
+                                       field_metadata,
+                                       export_type='netcdf',
+                                       verbose=self.options.verbose > 0,
+                                       preproc_funcs=self._field_preproc_funcs)
+            self.exporters['netcdf'] = e
 
         self._isfrozen = True
 

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -983,7 +983,7 @@ class FlowSolver(FrozenClass):
         # TODO find a cleaner way of doing this ...
         self.fields.uv_3d += self.fields.uv_dav_3d
         for e in self.exporters.values():
-            e.export()
+            e.export(self.simulation_time)
         # restore uv_3d
         self.fields.uv_3d -= self.fields.uv_dav_3d
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -636,6 +636,15 @@ class FlowSolver2d(FrozenClass):
                                        verbose=self.options.verbose > 0,
                                        preproc_funcs=self._field_preproc_funcs)
             self.exporters['hdf5'] = e
+            nc_dir = os.path.join(self.options.output_directory, 'nc')
+            e = exporter.ExportManager(nc_dir,
+                                       self.options.fields_to_export_netcdf,
+                                       self.fields,
+                                       field_metadata,
+                                       export_type='netcdf',
+                                       verbose=self.options.verbose > 0,
+                                       preproc_funcs=self._field_preproc_funcs)
+            self.exporters['netcdf'] = e
 
         self._isfrozen = True  # disallow creating new attributes
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -722,7 +722,7 @@ class FlowSolver2d(FrozenClass):
         """
         self.callbacks.evaluate(mode='export')
         for e in self.exporters.values():
-            e.export()
+            e.export(self.simulation_time)
 
     def load_state(self, i_export, outputdir=None, t=None, iteration=None):
         """


### PR DESCRIPTION
Adds netCDF outputs for 2d fields. Usage via the new option:
```python
options.fields_to_export_netcdf = ['uv_2d', 'elev_2d']
```

Supports:
- 2D fields (also in the 3D model)
- P0, P1, and P1DG function spaces
  - all other functions will be interpolated to P1DG space prior to exporting
- triangular and quad meshes
- scalar and vector fields
- output only (netcdf files cannot be read back in)

Benefits:
- portable output format (unlike vtk)
- smaller files (mesh stored only once)

Outputs will be stored in files `outputs/nc/Elevation2d/Elevation2d.nc`. All time steps will be appended in the same file. NetCDF header looks like this
```
netcdf Elevation2d {
dimensions:
        face = 800 ;
        face_nb_nodes = 3 ;
        vertex = 2400 ;
        time = UNLIMITED ; // (99 currently)
variables:
        uint64 Mesh_face_nodes(face, face_nb_nodes) ;
                Mesh_face_nodes:start_index = 0LL ;
        float Mesh_node_x(vertex) ;
        float Mesh_node_y(vertex) ;
        float time(time) ;
                time:standard_name = "time" ;
                time:units = "s" ;
        float elev_2d(time, vertex) ;
}
```

The stored mesh and data are defined as follows:

**P0** fields:
- connectivity and mesh coordinates: P1
- data: P0 (a.k.a. "cells")

**P1** fields:
- connectivity and mesh coordinates: P1
- data: P1 (a.k.a. "vertices")

**P1DG** fields:
- connectivity and mesh coordinates: P1DG
- data: P1DG (a.k.a. "vertices")

To enable netcdf outputs firedrake must be installed with:
`PETSC_CONFIGURE_OPTIONS="--download-netcdf-configure-arguments=--enable-parallel"`
In addition, `netCDF4-python` package has to be installed manually because its default configuration fails to detect parallel netcdf4 capability. `setup.py` needs to be modified to set `has_parallel4_support = True`.
