### PR TITLE
Fix build badge image on homepage

### DIFF
--- a/docs/source/_themes/thetis/layout.html
+++ b/docs/source/_themes/thetis/layout.html
@@ -32,7 +32,6 @@
         <li class="page_item"><a href="{{ pathto('funding.html', 1) }}" title="Our financial supporters">Funding</a></li>
         <li class="page_item"><a href="{{ pathto('contact.html', 1) }}" title="Getting in touch">Contact</a></li>
         <li class="page_item"><a href="https://github.com/thetisproject/thetis" title="Thetis source on GitHub">GitHub</a></li>
-        <li class="page_item"><a href="https://jenkins.ese.ic.ac.uk:1080/blue/organizations/jenkins/thetis/branches" title="Thetis build status">Jenkins</a></li>
       </ul>
     </div><!-- .menu -->
   </div><!-- #access -->

--- a/docs/source/_themes/thetis/static/thetis.css_t
+++ b/docs/source/_themes/thetis/static/thetis.css_t
@@ -132,9 +132,9 @@ div.sidebar {
     border-width: 2px;
     border-color: #888;
     background-color: #eee;
-    width: 250px;
+    width: 240px;
     float: right;
-    padding: 6px 6px 6px 6px;
+    padding: 3px 6px 16px 16px;
     border-radius: 8px;
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,8 +51,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Thetis'
-copyright = u'2016-2020, Tuomas Karna et al.'
-author = u'Tuomas Karna et al.'
+copyright = u'2016-2021, Tuomas Kärnä et al.'
+author = u'Tuomas Kärnä et al.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,14 +6,14 @@
 
     .. container:: buildstatus
 
-    Latest status: |thetisbuild|
+    |thetisbuild|
 
     Thetis source code is hosted on  `Github
     <https://github.com/thetisproject/thetis/>`__ and is being
-    continually tested using `Jenkins <https://jenkins.io/>`__.
+    continually tested using GitHub Actions.
 
-    .. |thetisbuild| image:: https://jenkins.ese.ic.ac.uk:1080/job/thetis/job/master/badge/icon
-                             :target: https://jenkins.ese.ic.ac.uk:1080/blue/organizations/jenkins/thetis/branches/
+    .. |thetisbuild| image:: https://github.com/thetisproject/thetis/actions/workflows/build.yml/badge.svg
+                             :target: https://github.com/thetisproject/thetis/actions/workflows/build.yml
 
 The Thetis project
 ==================


### PR DESCRIPTION
- fix link to GitHub Actions build status badge
- remove Jenkins link from the menu
- tweak layout of the build status side bar
- bump copyright year to 2021