### PR TITLE
Monolithic tracer systems

### DIFF
--- a/examples/reaction/gray_scott_mixed.py
+++ b/examples/reaction/gray_scott_mixed.py
@@ -1,0 +1,95 @@
+"""
+In this version of the Gray-Scott demo, we solve the
+two equations as a monolithic system.
+
+The main difference is the use of
+`ModelOptions2d.add_tracers_2d`, rather than
+`ModelOptions2d.add_tracer_2d`.
+"""
+from thetis import *
+
+
+# Doubly periodic domain
+mesh2d = PeriodicSquareMesh(65, 65, 2.5, quadrilateral=True, direction='both')
+x, y = SpatialCoordinate(mesh2d)
+
+# Arbitrary bathymetry
+P1_2d = get_functionspace(mesh2d, "CG", 1)
+bathymetry2d = Function(P1_2d).assign(1.0)
+
+# Diffusion and reactivity constants
+D1 = Constant(8.0e-05)
+D2 = Constant(4.0e-05)
+gamma = Constant(0.024)
+kappa = Constant(0.06)
+
+# Setup solver object
+solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry2d)
+options = solver_obj.options
+options.tracer_only = True
+options.tracer_element_family = 'cg'
+options.use_supg_tracer = False
+options.use_limiter_for_tracers = False
+sim_end_time = 2000.0
+
+# Specify iterative method
+options.set_timestepper_type('CrankNicolson', implicitness_theta=1.0)
+
+# Add tracer fields and the associated coefficients
+W = P1_2d*P1_2d
+ab_2d = Function(W)
+a_2d, b_2d = split(ab_2d)
+options.add_tracers_2d(
+    ["a_2d", "b_2d"],
+    ["Tracer A", "Tracer B"],
+    ["TracerA2d", "TracerB2d"],
+    function=ab_2d,
+    a_2d={
+        "diffusivity": D1,
+        "source": gamma - a_2d*b_2d**2 - gamma*a_2d,
+    },
+    b_2d={
+        "diffusivity": D2,
+        "source": a_2d*b_2d**2 - (gamma + kappa)*b_2d,
+    },
+)
+options.fields_to_export = ["a_2d", "b_2d"]
+
+# Define initial conditions
+tracer_a_init = Function(P1_2d)
+tracer_b_init = Function(P1_2d)
+tracer_b_init.interpolate(
+    conditional(
+        And(And(1.0 <= x, x <= 1.5), And(1.0 <= y, y <= 1.5)),
+        0.25*sin(4*pi*x)**2*sin(4*pi*y)**2, 0
+    )
+)
+tracer_a_init.interpolate(
+    1.0 - 2.0*tracer_b_init
+)
+solver_obj.assign_initial_conditions(a=tracer_a_init, b=tracer_b_init)
+
+solver_obj.create_timestepper()
+
+# Turn off exports and reduce time duration if regression testing
+if os.getenv('THETIS_REGRESSION_TEST') is not None:
+    options.no_exports = True
+    sim_end_time = 500.0
+
+# Spin up timestep
+dt = 1.0e-04
+end_time = 0.0
+for i in range(4):
+    dt *= 10
+    end_time += 10*dt if i == 0 else 9*dt
+    options.timestep = dt
+    solver_obj.export_initial_state = i == 0
+    options.simulation_export_time = 10*dt
+    options.simulation_end_time = end_time
+    solver_obj.create_timestepper()
+    solver_obj.iterate()
+
+# Run for duration
+options.simulation_end_time = sim_end_time
+solver_obj.create_timestepper()
+solver_obj.iterate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ netCDF4
 pyproj
 uptide
 pytz
-ordered_set

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ netCDF4
 pyproj
 uptide
 pytz
+ordered_set

--- a/thetis/conservative_tracer_eq_2d.py
+++ b/thetis/conservative_tracer_eq_2d.py
@@ -31,13 +31,17 @@ class ConservativeTracerTerm(TracerTerm):
     Generic depth-integrated tracer term that provides commonly used members and mapping for
     boundary functions.
     """
-    def __init__(self, function_space, depth, options, test_function=None):
+    def __init__(self, function_space, depth, options,
+                 trial_function=None, test_function=None):
         """
         :arg function_space: :class:`FunctionSpace` where the solution belongs
         :arg depth: :class: `DepthExpression` containing depth info
         :arg options: :class`ModelOptions2d` containing parameters
+        :kwarg trial_function: custom :class:`TrialFunction`.
+        :kwarg test_function: custom :class:`TestFunction`.
         """
         super(ConservativeTracerTerm, self).__init__(function_space, depth, options,
+                                                     trial_function=trial_function,
                                                      test_function=test_function)
 
     # TODO: at the moment this is the same as TracerTerm, but we probably want to overload its

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -54,7 +54,7 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
         if not self.options.tracer_only:
             self.timesteppers.swe2d = self.solver.get_swe_timestepper(self.swe_integrator)
         for i, label in enumerate(self.options.tracer):
-            if self.options.solve_tracer_mixed_form:
+            if len(self.options._mixed_tracers) > 0:  # TODO: Allow some to be mixed and some not
                 if i == 0:
                     self.timesteppers[label] = self.solver.get_tracer_timestepper(self.tracer_integrator, self.options.tracer.keys())
                 else:

--- a/thetis/coupled_timeintegrator_2d.py
+++ b/thetis/coupled_timeintegrator_2d.py
@@ -53,8 +53,14 @@ class CoupledTimeIntegrator2D(timeintegrator.TimeIntegratorBase):
         """
         if not self.options.tracer_only:
             self.timesteppers.swe2d = self.solver.get_swe_timestepper(self.swe_integrator)
-        for label in self.options.tracer:
-            self.timesteppers[label] = self.solver.get_tracer_timestepper(self.tracer_integrator, label)
+        for i, label in enumerate(self.options.tracer):
+            if self.options.solve_tracer_mixed_form:
+                if i == 0:
+                    self.timesteppers[label] = self.solver.get_tracer_timestepper(self.tracer_integrator, self.options.tracer.keys())
+                else:
+                    self.timesteppers[label] = timeintegrator.DummyTimeIntegrator()
+            else:
+                self.timesteppers[label] = self.solver.get_tracer_timestepper(self.tracer_integrator, label)
         if self.solver.options.sediment_model_options.solve_suspended_sediment:
             self.timesteppers.sediment = self.solver.get_sediment_timestepper(self.sediment_integrator)
         if self.solver.options.sediment_model_options.solve_exner:

--- a/thetis/equation.py
+++ b/thetis/equation.py
@@ -14,16 +14,17 @@ class Term(object):
     .. note::
         Sign convention: all terms are assumed to be on the right hand side of the equation: d(u)/dt = term.
     """
-    def __init__(self, function_space, test_function=None):
+    def __init__(self, function_space, trial_function=None, test_function=None):
         """
         :arg function_space: the :class:`FunctionSpace` the solution belongs to
+        :kwarg trial_function: custom :class:`TrialFunction`.
         :kwarg test_function: custom :class:`TestFunction`.
         """
         # define bunch of members needed to construct forms
         self.function_space = function_space
         self.mesh = self.function_space.mesh()
         self.test = test_function or TestFunction(self.function_space)
-        self.tri = TrialFunction(self.function_space)
+        self.tri = trial_function or TrialFunction(self.function_space)
         self.normal = FacetNormal(self.mesh)
         # TODO construct them here from mesh ?
         self.boundary_markers = sorted(function_space.mesh().exterior_facets.unique_markers)
@@ -81,16 +82,18 @@ class Equation(object):
         The term is nonlinear and should be treated fully implicitly
     """
 
-    def __init__(self, function_space):
+    def __init__(self, function_space, trial_function=None, test_function=None):
         """
         :arg function_space: the :class:`FunctionSpace` the solution belongs to
+        :kwarg trial_function: custom :class:`TrialFunction`.
+        :kwarg test_function: custom :class:`TestFunction`.
         """
         self.terms = OrderedDict()
         self.labels = {}
         self.function_space = function_space
         self.mesh = self.function_space.mesh()
-        self.test = TestFunction(self.function_space)
-        self.trial = TrialFunction(self.function_space)
+        self.test = test_function or TestFunction(self.function_space)
+        self.trial = trial_function or TrialFunction(self.function_space)
         # mesh dependent variables
         self.normal = FacetNormal(self.mesh)
         self.xyz = SpatialCoordinate(self.mesh)

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -874,6 +874,9 @@ class ModelOptions2d(CommonModelOptions):
         False, help="Use SUPG stabilisation in tracer advection").tag(config=True)
     tracer_picard_iterations = PositiveInteger(
         1, help="Number of Picard iterations taken for tracer equations.").tag(config=True)
+    solve_tracer_mixed_form = Bool(
+        False, help="Solve all tracer equations as a mixed system.").tag(config=True)
+    # TODO: Enable the case where only a subset are solved as a mixed system
 
     def __init__(self, *args, **kwargs):
         self.tracer = OrderedDict()

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -478,8 +478,10 @@ class TracerFieldOptions(FrozenHasTraits):
     name = 'Tracer options'
     function = FiredrakeScalarExpression(
         None, allow_none=True, help='Firedrake Function representing the tracer')
-    parent = FiredrakeVectorExpression(
-        None, allow_none=True, help='Firedrake Function representing the parent mixed Function')
+    parent = Union([
+        FiredrakeVectorExpression(None, allow_none=True), FiredrakeScalarExpression()],
+        help='Firedrake Function representing the parent mixed Function')
+    _parent_metadata = None  # NOTE: Otherwise would be added by traitlets.Union
     source = FiredrakeScalarExpression(
         None, allow_none=True, help='Source term for the tracer equation')
     diffusivity = FiredrakeScalarExpression(

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -868,6 +868,8 @@ class ModelOptions2d(CommonModelOptions):
         help="""Finite element family for tracer transport
 
         2D solver supports 'dg' or 'cg'.""").tag(config=True)
+    tracer_polynomial_degree = NonNegativeInteger(
+        1, help="Polynomial degree of elements used for tracer equations.")
     use_supg_tracer = Bool(
         False, help="Use SUPG stabilisation in tracer advection").tag(config=True)
     tracer_picard_iterations = PositiveInteger(

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -874,13 +874,11 @@ class ModelOptions2d(CommonModelOptions):
         False, help="Use SUPG stabilisation in tracer advection").tag(config=True)
     tracer_picard_iterations = PositiveInteger(
         1, help="Number of Picard iterations taken for tracer equations.").tag(config=True)
-    solve_tracer_mixed_form = Bool(
-        False, help="Solve all tracer equations as a mixed system.").tag(config=True)
-    # TODO: Enable the case where only a subset are solved as a mixed system
 
     def __init__(self, *args, **kwargs):
         self.tracer = OrderedDict()
         self._mixed_tracers = []
+        self._mixed_tracer_function = None
         super().__init__(*args, **kwargs)
 
     def add_tracer_2d(self, label, name, filename, shortname=None, unit='-', **kwargs):
@@ -930,12 +928,14 @@ class ModelOptions2d(CommonModelOptions):
         :arg filenames: a list of file names for outputs
         :kwarg shortnames: a list of short version names
         :kwarg units: a list of units for fields
+        :kwarg function: :class:`Function` to use for the mixed tracer
         :kwargs: labels which provide the other kwargs of :attr:`add_tracer_2d`
         """
         N = len(labels)
         shortnames = shortnames or names
         units = units or ['-']*N
         assert len(names) == len(filenames) == len(shortnames) == len(units) == N
+        self._mixed_tracer_function = kwargs.pop('function', None)
         if kwargs == {}:
             kwargs = {label: {} for label in labels}
         assert set(kwargs.keys()).issubset(set(labels))

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -478,6 +478,8 @@ class TracerFieldOptions(FrozenHasTraits):
     name = 'Tracer options'
     function = FiredrakeScalarExpression(
         None, allow_none=True, help='Firedrake Function representing the tracer')
+    parent = FiredrakeVectorExpression(
+        None, allow_none=True, help='Firedrake Function representing the parent mixed Function')
     source = FiredrakeScalarExpression(
         None, allow_none=True, help='Source term for the tracer equation')
     diffusivity = FiredrakeScalarExpression(
@@ -878,7 +880,6 @@ class ModelOptions2d(CommonModelOptions):
     def __init__(self, *args, **kwargs):
         self.tracer = OrderedDict()
         self._mixed_tracers = []
-        self._mixed_tracer_function = None
         super().__init__(*args, **kwargs)
 
     def add_tracer_2d(self, label, name, filename, shortname=None, unit='-', **kwargs):
@@ -935,12 +936,13 @@ class ModelOptions2d(CommonModelOptions):
         shortnames = shortnames or names
         units = units or ['-']*N
         assert len(names) == len(filenames) == len(shortnames) == len(units) == N
-        self._mixed_tracer_function = kwargs.pop('function', None)
+        parent = kwargs.pop('function', None)
         if kwargs == {}:
             kwargs = {label: {} for label in labels}
         assert set(kwargs.keys()).issubset(set(labels))
         for label, name, filename, shortname, unit in zip(labels, names, filenames, shortnames, units):
             self.add_tracer_2d(label, name, filename, shortname=shortname, unit=unit, **kwargs[label])
+            self.tracer[label].parent = parent
         self._mixed_tracers.append(','.join(labels))
 
     def set_timestepper_type(self, timestepper_type, **kwargs):

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -920,6 +920,7 @@ class ModelOptions2d(CommonModelOptions):
         self.tracer[label].use_conservative_form = kwargs.get('use_conservative_form', False)
         if not kwargs.get('mixed', False):
             self.tracer_systems.append(label)
+            self.tracer[label].parent = self.tracer[label].function
 
     def add_tracers_2d(self, labels, names, filenames, shortnames=None, units=None, **kwargs):
         """

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -323,9 +323,9 @@ class FlowSolver2d(FrozenClass):
         self.function_spaces.V_2d = MixedFunctionSpace([self.function_spaces.U_2d, self.function_spaces.H_2d])
 
         if self.options.tracer_element_family == 'dg':
-            self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'DG', 1, name='Q_2d')
+            self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'DG', self.options.tracer_polynomial_degree, name='Q_2d')
         elif self.options.tracer_element_family == 'cg':
-            self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'CG', 1, name='Q_2d')
+            self.function_spaces.Q_2d = get_functionspace(self.mesh2d, 'CG', self.options.tracer_polynomial_degree, name='Q_2d')
         else:
             raise Exception('Unsupported finite element family {:}'.format(self.options.tracer_element_family))
 
@@ -408,7 +408,7 @@ class FlowSolver2d(FrozenClass):
                     self.function_spaces.Q_2d, self.depth, self.options, uv_2d)
         self.solve_tracer = self.options.tracer != {}
         if self.solve_tracer:
-            if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
+            if self.options.use_limiter_for_tracers and self.options.tracer_polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:
                 self.tracer_limiter = None
@@ -423,7 +423,7 @@ class FlowSolver2d(FrozenClass):
             self.equations.sediment = sediment_eq_2d.SedimentEquation2D(
                 self.function_spaces.Q_2d, self.depth, self.options, self.sediment_model,
                 conservative=sediment_options.use_sediment_conservative_form)
-            if self.options.use_limiter_for_tracers and self.options.polynomial_degree > 0:
+            if self.options.use_limiter_for_tracers and self.options.tracer_polynomial_degree > 0:
                 self.tracer_limiter = limiter.VertexBasedP1DGLimiter(self.function_spaces.Q_2d)
             else:
                 self.tracer_limiter = None
@@ -821,7 +821,7 @@ class FlowSolver2d(FrozenClass):
         if not self._initialized:
             self.initialize()
 
-        self.options.use_limiter_for_tracers &= self.options.polynomial_degree > 0
+        self.options.use_limiter_for_tracers &= self.options.tracer_polynomial_degree > 0
 
         t_epsilon = 1.0e-5
         cputimestamp = time_mod.perf_counter()

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -407,16 +407,16 @@ class FlowSolver2d(FrozenClass):
             for label in labels
         ]
         tracer_parents = OrderedSet(self.options.tracer[label].parent for label in labels)
-        if len(self.options._mixed_tracers) > 0:
-            if len(self.options._mixed_tracers) > 1:
+        if len(self.options.tracer_systems) > 0:
+            if len(self.options.tracer_systems) > 1:
                 raise NotImplementedError("Multiple mixed blocks are not yet supported")  # TODO
-            elif not set(self.options.tracer.keys()).issubset(set(self.options._mixed_tracers[0].split(','))):
+            elif not set(self.options.tracer.keys()).issubset(set(self.options.tracer_systems[0].split(','))):
                 raise NotImplementedError("Tracers need to all either be solved all simultaneously or all sequentially")  # TODO
             parent = tracer_parents[0]
             name = ' x '.join(self.options.tracer[label].metadata['name'] for label in labels)
             shortname = ' x '.join(self.options.tracer[label].metadata['shortname'] for label in labels)
             unit = ' x '.join(self.options.tracer[label].metadata['unit'] for label in labels)
-            self.add_new_field(parent, self.options._mixed_tracers[0], name, 'unused', shortname=shortname, unit=unit)
+            self.add_new_field(parent, self.options.tracer_systems[0], name, 'unused', shortname=shortname, unit=unit)
             if parent is None:
                 self.function_spaces.W_2d = MixedFunctionSpace(tracer_function_spaces)
                 parent = Function(self.function_spaces.W_2d)
@@ -535,7 +535,7 @@ class FlowSolver2d(FrozenClass):
         if not isinstance(label, str):
             assert isinstance(label, Iterable)
             assert set(label).issubset(set(self.fields.keys()))
-            labels = self.options._mixed_tracers[0]  # TODO: Extend
+            labels = self.options.tracer_systems[0]  # TODO: Extend
             integrators = [
                 self.get_tracer_timestepper(integrator, _label, create_solver=False, solution=_solution)
                 for (_label, _solution) in zip(label, split(self.fields[labels]))

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -557,7 +557,7 @@ class FlowSolver2d(FrozenClass):
             bcs = self.bnd_functions[label[:-3]]
         # TODO: Different timestepper options for different tracers
         return integrator(self.equations[label], solution or self.fields[label], fields, self.dt,
-                          self.options.tracer_timestepper_options, bcs, create_solver=create_solver)
+                          self.options.tracer_timestepper_options, bcs, create_solver=create_solver)  # FIXME: Not everyone has create_solver
 
     def get_sediment_timestepper(self, integrator):
         """

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -87,14 +87,6 @@ class TimeIntegrator(TimeIntegratorBase):
         raise NotImplementedError(f"Picard iterations are not supported for {self} time integrators.")
 
 
-class DummyTimeIntegrator(TimeIntegrator):
-    """
-    A do-nothing :class:`TimeIntegrator`.
-    """
-    def __init__(self):
-        pass
-
-
 # TODO: Think of a better name
 class SpecialTimeIntegrator(TimeIntegrator):
     """


### PR DESCRIPTION
The main contribution of this PR is to allow tracers to be added and then solved as mixed systems. All the user needs to do is to call `add_tracers_2d`, rather than `add_tracer_2d`. This is achieved by introducing a mixed time integrator class and allowing trial and test functions to be passed through to the tracer equations.

Other changes in this PR:
* Allow control of the degree of the `Q_2d` space.
* Tracer function space is inherited from the `function` kwarg to `add_tracer_2d`/`add_tracers_2d`, otherwise  `Q_2d` is used by default. Maybe the tracer function space and discretisation parameters should be controlled by `add_tracer_2d`/`add_tracers_2d`, to ensure consistency?