### PR TITLE
Fix JITModule error that breaks all CI tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ def pytest_runtest_teardown(item, nextitem):
     """Clear Thetis caches after running a test"""
     from firedrake.tsfc_interface import TSFCKernel
     from pyop2.op2 import Kernel
-    from pyop2.base import JITModule
+    from pyop2.parloop import JITModule
 
     # disgusting hack, clear the Class-Cached objects in PyOP2 and
     # Firedrake, otherwise these will never be collected.  The Kernels

--- a/test_adjoint/conftest.py
+++ b/test_adjoint/conftest.py
@@ -4,7 +4,7 @@ def pytest_runtest_teardown(item, nextitem):
     """Clear Thetis caches after running a test"""
     from firedrake.tsfc_interface import TSFCKernel
     from pyop2.op2 import Kernel
-    from pyop2.base import JITModule
+    from pyop2.parloop import JITModule
     from pyadjoint import get_working_tape
 
     # disgusting hack, clear the Class-Cached objects in PyOP2 and


### PR DESCRIPTION
JITModule seems to have moved from pyop2.base to pyop2.parloop