### PR TITLE
HessianRecoverer2D

### DIFF
--- a/test/operations/test_diagnostics.py
+++ b/test/operations/test_diagnostics.py
@@ -1,0 +1,48 @@
+from thetis import *
+from thetis.diagnostics import *
+import pytest
+
+
+@pytest.fixture(params=[True, False])
+def interp(request):
+    return request.param
+
+
+def test_hessian_recovery2d(interp, tol=1.0e-08):
+    r"""
+    Apply Hessian recovery techniques to the quadratic
+    polynomial :math:`f(x, y) = \frac12(x^2 + y^2)` and
+    check that the result is the identity matrix.
+
+    We get the gradient approximation as part of the
+    recovery procedure, so check that this is also as
+    expected.
+
+    :arg interp: should the polynomial be interpolated as
+        as a :class:`Function`, or left as a UFL expression?
+    :kwarg tol: relative tolerance for value checking
+    """
+    mesh2d = UnitSquareMesh(4, 4)
+    x, y = SpatialCoordinate(mesh2d)
+    bowl = 0.5*(x**2 + y**2)
+    if interp:
+        P2_2d = get_functionspace(mesh2d, 'CG', 2)
+        bowl = interpolate(bowl, P2_2d)
+    P1v_2d = get_functionspace(mesh2d, 'CG', 1, vector=True)
+    P1t_2d = get_functionspace(mesh2d, 'CG', 1, tensor=True)
+
+    # Recover derivatives
+    g = Function(P1v_2d, name='Gradient')
+    H = Function(P1t_2d, name='Hessian')
+    hessian_recoverer = HessianRecoverer2D(bowl, H, g)
+    hessian_recoverer.solve()
+
+    # Check values
+    g_expect = Function(P1v_2d, name='Expected gradient')
+    g_expect.interpolate(as_vector([x, y]))
+    H_expect = Function(P1t_2d, name='Expected Hessian')
+    H_expect.interpolate(Identity(2))
+    err_g = errornorm(g, g_expect)/norm(g_expect)
+    assert err_g < tol, f'Gradient approximation error {err_g:.4e}'
+    err_H = errornorm(H, H_expect)/norm(H_expect)
+    assert err_H < tol, f'Hessian approximation error {err_H:.4e}'

--- a/test/swe2d/test_standing_wave.py
+++ b/test/swe2d/test_standing_wave.py
@@ -114,4 +114,4 @@ def test_standing_wave_channel(timesteps, max_rel_err, timestepper, tmpdir, do_e
 
 
 if __name__ == '__main__':
-    test_standing_wave_channel(do_export=True)
+    test_standing_wave_channel(10, 1.6e-02, 'CrankNicolson', 'outputs', do_export=True)

--- a/thetis/__init__.py
+++ b/thetis/__init__.py
@@ -14,6 +14,7 @@ import thetis.coordsys as coordsys      # NOQA
 import thetis.timezone as timezone      # NOQA
 import thetis.turbines  # NOQA
 import thetis.optimisation  # NOQA
+import thetis.diagnostics  # NOQA
 from thetis._version import get_versions
 from thetis.assembledschur import AssembledSchurPC  # NOQA
 from thetis.options import TidalTurbineFarmOptions  # NOQA

--- a/thetis/diagnostics.py
+++ b/thetis/diagnostics.py
@@ -1,0 +1,46 @@
+"""
+Classes for computing diagnostics.
+"""
+from .utility import *
+
+
+class VorticityCalculator2D(object):
+    r"""
+    Linear solver for recovering fluid vorticity.
+
+    It is recommended that the vorticity is sought
+    in :math:`\mathbb P1` space.
+
+    :arg uv_2d: horizontal velocity :class:`Function`.
+    :arg vorticity_2d: :class:`Function` to hold calculated vorticity.
+    :kwargs: to be passed to the :class:`LinearVariationalSolver`.
+    """
+    @PETSc.Log.EventDecorator("thetis.VorticityCalculator2D.__init__")
+    def __init__(self, uv_2d, vorticity_2d, **kwargs):
+        fs = vorticity_2d.function_space()
+        dim = fs.mesh().topological_dimension()
+        if dim != 2:
+            raise ValueError(f'Dimension {dim} not supported')
+        if element_continuity(fs.ufl_element()).horizontal != 'cg':
+            raise ValueError('Vorticity must be calculated in a continuous space')
+        n = FacetNormal(fs.mesh())
+
+        # Weak formulation
+        test = TestFunction(fs)
+        a = TrialFunction(fs)*test*dx
+        L = -inner(perp(uv_2d), grad(test))*dx \
+            + dot(perp(uv_2d), test*n)*ds \
+            + dot(avg(perp(uv_2d)), jump(test, n))*dS
+
+        # Setup vorticity solver
+        prob = LinearVariationalProblem(a, L, vorticity_2d)
+        kwargs.setdefault('solver_parameters', {
+            "ksp_type": "cg",
+            "pc_type": "bjacobi",
+            "sub_pc_type": "ilu",
+        })
+        self.solver = LinearVariationalSolver(prob, **kwargs)
+
+    @PETSc.Log.EventDecorator("thetis.VorticityCalculator2D.solve")
+    def solve(self):
+        self.solver.solve()

--- a/thetis/diagnostics.py
+++ b/thetis/diagnostics.py
@@ -4,6 +4,9 @@ Classes for computing diagnostics.
 from .utility import *
 
 
+__all__ = ["VorticityCalculator2D", "HessianRecoverer2D"]
+
+
 class VorticityCalculator2D(object):
     r"""
     Linear solver for recovering fluid vorticity.

--- a/thetis/diagnostics.py
+++ b/thetis/diagnostics.py
@@ -44,3 +44,103 @@ class VorticityCalculator2D(object):
     @PETSc.Log.EventDecorator("thetis.VorticityCalculator2D.solve")
     def solve(self):
         self.solver.solve()
+
+
+class HessianRecoverer2D(object):
+    r"""
+    Linear solver for recovering Hessians.
+
+    Hessians are recoved using double :math:`L^2`
+    projection, which is implemented using a
+    mixed finite element method.
+
+    It is recommended that gradients and Hessians
+    are sought in :math:`\mathbb P1` space of
+    appropriate dimension.
+
+    :arg field_2d: :class:`Function` to recover the Hessian of.
+    :arg hessian_2d: :class:`Function` to hold recovered Hessian.
+    :kwarg gradient_2d: :class:`Function` to hold recovered gradient.
+    :kwargs: to be passed to the :class:`LinearVariationalSolver`.
+    """
+    @PETSc.Log.EventDecorator("thetis.HessianRecoverer2D.__init__")
+    def __init__(self, field_2d, hessian_2d, gradient_2d=None, **kwargs):
+        self.hessian_2d = hessian_2d
+        self.gradient_2d = gradient_2d
+        Sigma = hessian_2d.function_space()
+        mesh = Sigma.mesh()
+        dim = mesh.topological_dimension()
+        if dim != 2:
+            raise ValueError(f'Dimension {dim} not supported')
+        n = FacetNormal(mesh)
+
+        # Extract function spaces
+        if element_continuity(Sigma.ufl_element()).horizontal != 'cg':
+            raise ValueError('Hessians must be calculated in a continuous space')
+        if Sigma.dof_dset.dim != (2, 2):
+            raise ValueError('Expecting a square tensor function')
+        if gradient_2d is None:
+            V = get_functionspace(mesh, 'CG', 1, vector=True)
+        else:
+            V = gradient_2d.function_space()
+            if element_continuity(V.ufl_element()).horizontal != 'cg':
+                raise ValueError('Gradients must be calculated in a continuous space')
+            if V.dof_dset.dim != (2,):
+                raise ValueError('Expecting a 2D vector function')
+
+        # Setup function spaces
+        W = V*Sigma
+        g, H = TrialFunctions(W)
+        phi, tau = TestFunctions(W)
+        sol = Function(W)
+        self._gradient, self._hessian = sol.split()
+
+        # The formulation is chosen such that f does not need to have any
+        # finite element derivatives
+        a = inner(tau, H)*dx \
+            + inner(div(tau), g)*dx \
+            + inner(phi, g)*dx \
+            - dot(g, dot(tau, n))*ds \
+            - dot(avg(g), jump(tau, n))*dS
+        L = field_2d*dot(phi, n)*ds \
+            + avg(field_2d)*jump(phi, n)*dS \
+            - field_2d*div(phi)*dx
+
+        # Apply stationary preconditioners in the Schur complement to get away
+        # with applying GMRES to the whole mixed system
+        sp = {
+            "mat_type": "aij",
+            "ksp_type": "gmres",
+            "ksp_max_it": 20,
+            "pc_type": "fieldsplit",
+            "pc_fieldsplit_type": "schur",
+            "pc_fieldsplit_0_fields": "1",
+            "pc_fieldsplit_1_fields": "0",
+            "pc_fieldsplit_schur_precondition": "selfp",
+            "fieldsplit_0_ksp_type": "preonly",
+            "fieldsplit_1_ksp_type": "preonly",
+            "fieldsplit_1_pc_type": "gamg",
+            "fieldsplit_1_mg_levels_ksp_max_it": 5,
+        }
+        if COMM_WORLD.size == 1:
+            sp["fieldsplit_0_pc_type"] = "ilu"
+            sp["fieldsplit_1_mg_levels_pc_type"] = "ilu"
+        else:
+            sp["fieldsplit_0_pc_type"] = "bjacobi"
+            sp["fieldsplit_0_sub_ksp_type"] = "preonly"
+            sp["fieldsplit_0_sub_pc_type"] = "ilu"
+            sp["fieldsplit_1_mg_levels_pc_type"] = "bjacobi"
+            sp["fieldsplit_1_mg_levels_sub_ksp_type"] = "preonly"
+            sp["fieldsplit_1_mg_levels_sub_pc_type"] = "ilu"
+
+        # Setup solver
+        prob = LinearVariationalProblem(a, L, sol)
+        kwargs.setdefault('solver_parameters', sp)
+        self.solver = LinearVariationalSolver(prob, **kwargs)
+
+    @PETSc.Log.EventDecorator("thetis.HessianRecoverer2D.solve")
+    def solve(self):
+        self.solver.solve()
+        self.hessian_2d.assign(self._hessian)
+        if self.gradient_2d is not None:
+            self.gradient_2d.assign(self._gradient)

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -21,13 +21,15 @@ def get_visu_space(fs):
     :arg fs: function space
     :return: function space for VTK visualization
     """
-    is_vector = len(fs.ufl_element().value_shape()) == 1
     mesh = fs.mesh()
     family = 'Lagrange' if is_cg(fs) else 'Discontinuous Lagrange'
-    if is_vector:
+    if len(fs.ufl_element().value_shape()) == 1:
         dim = fs.ufl_element().value_shape()[0]
         visu_fs = get_functionspace(mesh, family, 1, family, 1,
                                     vector=True, dim=dim)
+    elif len(fs.ufl_element().value_shape()) == 2:
+        visu_fs = get_functionspace(mesh, family, 1, family, 1,
+                                    tensor=True)
     else:
         visu_fs = get_functionspace(mesh, family, 1, family, 1)
     # make sure that you always get the same temp work function

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -114,7 +114,7 @@ class FieldDict(AttrDict):
 
 
 def get_functionspace(mesh, h_family, h_degree, v_family=None, v_degree=None,
-                      vector=False, hdiv=False, variant=None, v_variant=None,
+                      vector=False, tensor=False, hdiv=False, variant=None, v_variant=None,
                       **kwargs):
     cell_dim = mesh.cell_dimension()
     assert cell_dim in [2, (2, 1)], 'Unsupported cell dimension'
@@ -146,7 +146,8 @@ def get_functionspace(mesh, h_family, h_degree, v_family=None, v_degree=None,
     else:
         elt = FiniteElement(h_family, mesh.ufl_cell(), h_degree, variant=variant)
 
-    constructor = VectorFunctionSpace if vector else FunctionSpace
+    assert not (vector and tensor)
+    constructor = TensorFunctionSpace if tensor else VectorFunctionSpace if vector else FunctionSpace
     return constructor(mesh, elt, **kwargs)
 
 


### PR DESCRIPTION
Building upon PR #242, maybe this will be useful for other people (e.g. in #277).

To use it in practice, do something like
```
from thetis.recovery import HessianRecoverer2D

P1_ten = TensorFunctionSpace(mesh2d, 'CG', 1)
hessian_2d = Function(P1_ten)
hessian_calculator = HessianRecoverer2D(hessian_2d, solver_obj, 'elev_2d')
solver_obj.add_new_field(hessian_2d, 'hessian_2d', 'Hessian of elevation', 'Hessian2d', preproc_func=hessian_calculator.solve)
solver_obj.options.fields_to_export = ['hessian_2d']
```