### PR TITLE
Add boundary drag term to shallow water equations

### DIFF
--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -270,7 +270,14 @@ class ShallowWaterTerm(Term):
             raise Exception('Unsupported open bnd type: {:}'.format(funcs.keys()))
         return eta_ext, uv_ext
 
-    def is_open_bnd(self, bnd_funcs, bnd_id):
+    def bnd_state_defined(self, bnd_funcs, bnd_id):
+        """
+        Check if the prognostic variables have been speficied on the boundary
+
+        :arg bnd_funcs: None or dictionary of boundary coefficients.
+        :arg bnd_id: Boundary marker id
+        :returns: True if elev or uv is defined, otherwise False.
+        """
         open_tags = ['elev', 'uv', 'un', 'flux']
         all_tags = open_tags + ['drag']
         if bnd_funcs is None:
@@ -355,7 +362,7 @@ class ExternalPressureGradientTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if self.is_open_bnd(funcs, bnd_marker):
+                if self.bnd_state_defined(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(head, uv, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
                     un_jump = inner(uv - uv_ext, self.normal)
@@ -372,7 +379,7 @@ class ExternalPressureGradientTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if self.is_open_bnd(funcs, bnd_marker):
+                if self.bnd_state_defined(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(head, uv, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
                     un_jump = inner(uv - uv_ext, self.normal)
@@ -416,7 +423,7 @@ class HUDivTerm(ShallowWaterContinuityTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if self.is_open_bnd(funcs, bnd_marker):
+                if self.bnd_state_defined(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(eta, uv, bnd_marker, bnd_conditions)
                     eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
@@ -433,7 +440,7 @@ class HUDivTerm(ShallowWaterContinuityTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if self.is_open_bnd(funcs, bnd_marker) or 'un' in funcs:
+                if self.bnd_state_defined(funcs, bnd_marker) or 'un' in funcs:
                     f += -total_h*dot(uv, self.normal)*self.eta_test*ds_bnd
         return -f
 
@@ -477,7 +484,7 @@ class HorizontalAdvectionTerm(ShallowWaterMomentumTerm):
                     for bnd_marker in self.boundary_markers:
                         funcs = bnd_conditions.get(bnd_marker)
                         ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                        if not self.is_open_bnd(funcs, bnd_marker):
+                        if not self.bnd_state_defined(funcs, bnd_marker):
                             # impose impermeability with mirror velocity
                             n = self.normal
                             uv_ext = uv - 2*dot(uv, n)*n
@@ -486,7 +493,7 @@ class HorizontalAdvectionTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if self.is_open_bnd(funcs, bnd_marker):
+                if self.bnd_state_defined(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(eta, uv, bnd_marker, bnd_conditions)
                     eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
@@ -578,7 +585,7 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if self.is_open_bnd(funcs, bnd_marker):
+                if self.bnd_state_defined(funcs, bnd_marker):
                     if 'un' in funcs:
                         delta_uv = (dot(uv, n) - funcs['un'])*n
                     else:

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -656,7 +656,7 @@ class QuadraticDragTerm(ShallowWaterMomentumTerm):
     Quadratic Manning bottom friction term
     :math:`C_D \| \bar{\textbf{u}} \| \bar{\textbf{u}}`
 
-    where the drag term is computed with the Manning formula
+    where the drag coefficient is computed with the Manning formula
 
     .. math::
         C_D = g \frac{\mu^2}{H^{1/3}}
@@ -692,9 +692,10 @@ class QuadraticDragTerm(ShallowWaterMomentumTerm):
 class BoundaryDragTerm(ShallowWaterMomentumTerm):
     r"""
     Quadratic friction term on the boundary
-    :math:`C_D \| \bar{\textbf{u}} \| \bar{\textbf{u}}`
+    :math:`C_D \| \bar{\textbf{u}}_t \| \bar{\textbf{u}}_t`
 
-    where the drag term is user-defined.
+    where :math:`\bar{\textbf{u}}_t` denotes the tangential velocity component
+    and the drag coefficient :math:`C_D` is user-defined.
     """
     def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions):
         f = 0
@@ -703,8 +704,12 @@ class BoundaryDragTerm(ShallowWaterMomentumTerm):
             ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
             if funcs is not None and 'drag' in funcs:
                 C_D = funcs['drag']
-                uv_mag = sqrt(dot(uv_old, uv_old))
-                f += C_D * uv_mag * inner(self.u_test, uv) * ds_bnd
+                # compute tangetial velocity
+                n = self.normal
+                ut = uv - dot(uv, n) * n
+                ut_old = uv_old - dot(uv_old, n) * n
+                ut_mag = sqrt(dot(ut_old, ut_old))
+                f += C_D * ut_mag * inner(self.u_test, ut) * ds_bnd
         return -f
 
 

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -812,13 +812,13 @@ class BaseShallowWaterEquation(Equation):
 
     def add_momentum_terms(self, *args):
         self.add_term(ExternalPressureGradientTerm(*args), 'implicit')
-        self.add_term(HorizontalAdvectionTerm(*args), 'explicit')
+        self.add_term(HorizontalAdvectionTerm(*args), 'implicit')
         self.add_term(HorizontalViscosityTerm(*args), 'explicit')
-        self.add_term(CoriolisTerm(*args), 'explicit')
+        self.add_term(CoriolisTerm(*args), 'implicit')
         self.add_term(WindStressTerm(*args), 'source')
         self.add_term(AtmosphericPressureTerm(*args), 'source')
-        self.add_term(QuadraticDragTerm(*args), 'explicit')
-        self.add_term(LinearDragTerm(*args), 'explicit')
+        self.add_term(QuadraticDragTerm(*args), 'implicit')
+        self.add_term(LinearDragTerm(*args), 'implicit')
         self.add_term(BottomDrag3DTerm(*args), 'source')
         self.add_term(TurbineDragTerm(*args), 'implicit')
         self.add_term(MomentumSourceTerm(*args), 'source')

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -239,6 +239,8 @@ class ShallowWaterTerm(Term):
         """
         bnd_len = self.boundary_len[bnd_id]
         funcs = bnd_conditions.get(bnd_id)
+        assert funcs is not None
+        eta_ext = uv_ext = None
         if 'elev' in funcs and 'uv' in funcs:
             eta_ext = funcs['elev']
             uv_ext = funcs['uv']
@@ -264,9 +266,22 @@ class ShallowWaterTerm(Term):
             h_ext = self.depth.get_total_depth(eta_ext)
             area = h_ext*bnd_len  # NOTE using internal elevation
             uv_ext = funcs['flux']/area*self.normal
-        else:
-            raise Exception('Unsupported bnd type: {:}'.format(funcs.keys()))
+        if eta_ext is None or uv_ext is None:
+            raise Exception('Unsupported open bnd type: {:}'.format(funcs.keys()))
         return eta_ext, uv_ext
+
+    def is_open_bnd(self, bnd_funcs, bnd_id):
+        open_tags = ['elev', 'uv', 'un', 'flux']
+        all_tags = open_tags + ['drag']
+        if bnd_funcs is None:
+            return False
+        for k in bnd_funcs.keys():
+            if k not in all_tags:
+                raise Exception(f'Invalid boundary tag "{k}" '
+                                f'specified on boundary {bnd_id}')
+            if k in open_tags:
+                return True
+        return False
 
 
 class ShallowWaterMomentumTerm(ShallowWaterTerm):
@@ -340,13 +355,13 @@ class ExternalPressureGradientTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if funcs is not None:
+                if self.is_open_bnd(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(head, uv, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
                     un_jump = inner(uv - uv_ext, self.normal)
                     eta_rie = 0.5*(head + eta_ext) + sqrt(total_h/g_grav)*un_jump
                     f += g_grav*eta_rie*dot(self.u_test, self.normal)*ds_bnd
-                if funcs is None or 'symm' in funcs:
+                else:
                     # assume land boundary
                     # impermeability implies external un=0
                     un_jump = inner(uv, self.normal)
@@ -357,7 +372,7 @@ class ExternalPressureGradientTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if funcs is not None:
+                if self.is_open_bnd(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(head, uv, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
                     un_jump = inner(uv - uv_ext, self.normal)
@@ -401,7 +416,7 @@ class HUDivTerm(ShallowWaterContinuityTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if funcs is not None:
+                if self.is_open_bnd(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(eta, uv, bnd_marker, bnd_conditions)
                     eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
@@ -418,7 +433,7 @@ class HUDivTerm(ShallowWaterContinuityTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if funcs is None or 'un' in funcs:
+                if self.is_open_bnd(funcs, bnd_marker) or 'un' in funcs:
                     f += -total_h*dot(uv, self.normal)*self.eta_test*ds_bnd
         return -f
 
@@ -462,7 +477,7 @@ class HorizontalAdvectionTerm(ShallowWaterMomentumTerm):
                     for bnd_marker in self.boundary_markers:
                         funcs = bnd_conditions.get(bnd_marker)
                         ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                        if funcs is None:
+                        if not self.is_open_bnd(funcs, bnd_marker):
                             # impose impermeability with mirror velocity
                             n = self.normal
                             uv_ext = uv - 2*dot(uv, n)*n
@@ -471,7 +486,7 @@ class HorizontalAdvectionTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if funcs is not None:
+                if self.is_open_bnd(funcs, bnd_marker):
                     eta_ext, uv_ext = self.get_bnd_functions(eta, uv, bnd_marker, bnd_conditions)
                     eta_ext_old, uv_ext_old = self.get_bnd_functions(eta_old, uv_old, bnd_marker, bnd_conditions)
                     # Compute linear riemann solution with eta, eta_ext, uv, uv_ext
@@ -563,7 +578,7 @@ class HorizontalViscosityTerm(ShallowWaterMomentumTerm):
             for bnd_marker in self.boundary_markers:
                 funcs = bnd_conditions.get(bnd_marker)
                 ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
-                if funcs is not None:
+                if self.is_open_bnd(funcs, bnd_marker):
                     if 'un' in funcs:
                         delta_uv = (dot(uv, n) - funcs['un'])*n
                     else:
@@ -671,6 +686,25 @@ class QuadraticDragTerm(ShallowWaterMomentumTerm):
 
         if C_D is not None:
             f += C_D * sqrt(dot(uv_old, uv_old) + self.options.norm_smoother**2) * inner(self.u_test, uv) / total_h * self.dx
+        return -f
+
+
+class BoundaryDragTerm(ShallowWaterMomentumTerm):
+    r"""
+    Quadratic friction term on the boundary
+    :math:`C_D \| \bar{\textbf{u}} \| \bar{\textbf{u}}`
+
+    where the drag term is user-defined.
+    """
+    def residual(self, uv, eta, uv_old, eta_old, fields, fields_old, bnd_conditions):
+        f = 0
+        for bnd_marker in self.boundary_markers:
+            funcs = bnd_conditions.get(bnd_marker)
+            ds_bnd = ds(int(bnd_marker), degree=self.quad_degree)
+            if funcs is not None and 'drag' in funcs:
+                C_D = funcs['drag']
+                uv_mag = sqrt(dot(uv_old, uv_old))
+                f += C_D * uv_mag * inner(self.u_test, uv) * ds_bnd
         return -f
 
 
@@ -819,6 +853,7 @@ class BaseShallowWaterEquation(Equation):
         self.add_term(AtmosphericPressureTerm(*args), 'source')
         self.add_term(QuadraticDragTerm(*args), 'implicit')
         self.add_term(LinearDragTerm(*args), 'implicit')
+        self.add_term(BoundaryDragTerm(*args), 'implicit')
         self.add_term(BottomDrag3DTerm(*args), 'source')
         self.add_term(TurbineDragTerm(*args), 'implicit')
         self.add_term(MomentumSourceTerm(*args), 'source')

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -317,9 +317,11 @@ class FlowSolver2d(FrozenClass):
         DG = 'DG' if self.mesh2d.ufl_cell().cellname() == 'triangle' else 'DQ'
         self.function_spaces.P0_2d = get_functionspace(self.mesh2d, DG, 0, name='P0_2d')
         self.function_spaces.P1_2d = get_functionspace(self.mesh2d, 'CG', 1, name='P1_2d')
-        self.function_spaces.P1v_2d = VectorFunctionSpace(self.mesh2d, 'CG', 1, name='P1v_2d')
+        self.function_spaces.P1v_2d = get_functionspace(self.mesh2d, 'CG', 1, name='P1v_2d',
+                                                        vector=True)
         self.function_spaces.P1DG_2d = get_functionspace(self.mesh2d, DG, 1, name='P1DG_2d')
-        self.function_spaces.P1DGv_2d = VectorFunctionSpace(self.mesh2d, DG, 1, name='P1DGv_2d')
+        self.function_spaces.P1DGv_2d = get_functionspace(self.mesh2d, DG, 1, name='P1DGv_2d',
+                                                          vector=True)
         # 2D velocity space
         if self.options.element_family in ['rt-dg', 'bdm-dg']:
             family_prefix = self.options.element_family.split('-')[0].upper()
@@ -330,10 +332,10 @@ class FlowSolver2d(FrozenClass):
             self.function_spaces.U_2d = get_functionspace(self.mesh2d, fam, degree, name='U_2d')
             self.function_spaces.H_2d = get_functionspace(self.mesh2d, DG, self.options.polynomial_degree, name='H_2d')
         elif self.options.element_family == 'dg-cg':
-            self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, DG, self.options.polynomial_degree, name='U_2d')
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, DG, self.options.polynomial_degree, name='U_2d', vector=True)
             self.function_spaces.H_2d = get_functionspace(self.mesh2d, 'CG', self.options.polynomial_degree+1, name='H_2d')
         elif self.options.element_family == 'dg-dg':
-            self.function_spaces.U_2d = VectorFunctionSpace(self.mesh2d, DG, self.options.polynomial_degree, name='U_2d')
+            self.function_spaces.U_2d = get_functionspace(self.mesh2d, DG, self.options.polynomial_degree, name='U_2d', vector=True)
             self.function_spaces.H_2d = get_functionspace(self.mesh2d, DG, self.options.polynomial_degree, name='H_2d')
         else:
             raise Exception('Unsupported finite element family {:}'.format(self.options.element_family))


### PR DESCRIPTION
User can now define a quadratic drag term on any boundary by adding a `'drag'` key to the boundary condition dictionary:
```python
land_bnd_id = 1
land_bnd_funcs = {
    'drag': Constant(0.01),  # quadratic drag coefficient
}
solver_obj.bnd_functions['shallow_water'] = {
    land_bnd_id: land_bnd_funcs,
}
```
Other updates:
- Adds correct linearization in `DIRKGeneric` time integrator
- The Coriolis, advection and friction terms are treated implicitly
- All function spaces are created with `get_functionspace` routine