### PR TITLE
Logger: add set_log_directory

### DIFF
--- a/thetis/__init__.py
+++ b/thetis/__init__.py
@@ -24,3 +24,5 @@ import numpy  # NOQA
 __version__ = get_versions()['version']
 del get_versions
 
+thetis_log_level(DEBUG)
+set_thetis_loggers(comm=COMM_WORLD)

--- a/thetis/__init__.py
+++ b/thetis/__init__.py
@@ -24,8 +24,3 @@ import numpy  # NOQA
 __version__ = get_versions()['version']
 del get_versions
 
-parameters['pyop2_options']['lazy_evaluation'] = False
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions

--- a/thetis/log.py
+++ b/thetis/log.py
@@ -101,7 +101,6 @@ def set_log_directory(output_directory, comm=COMM_WORLD, mode='w'):
             logger = logging.getLogger(name)
             for handler in logger.handlers:
                 if isinstance(handler, cls):
-                    debug(f'rm handler {type(handler)} from {name}')
                     logger.removeHandler(handler)
 
     def rm_file_handlers():
@@ -125,8 +124,7 @@ def set_log_directory(output_directory, comm=COMM_WORLD, mode='w'):
     if thetis_log_config.filename == logfile:
         # no change
         return
-    different_file = (thetis_log_config.filename is not None
-                      and thetis_log_config.filename != logfile)
+    different_file = thetis_log_config.filename is not None
     if different_file:
         old_file = str(thetis_log_config.filename)
         rm_file_handlers()

--- a/thetis/log.py
+++ b/thetis/log.py
@@ -11,30 +11,128 @@ Debug, warning etc. messages are issued with :func:`~.debug`, :func:`~.info`,
 """
 from thetis.utility import COMM_WORLD
 import logging
+from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
+import os
 
 __all__ = ('logger', 'output_logger',
-           'debug', 'info', 'warning', 'error', 'critical', 'print_output')
+           'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL',
+           'log', 'debug', 'info', 'warning', 'error', 'critical',
+           'print_output', 'set_thetis_loggers', 'thetis_log_level',
+           'set_log_directory')
+
+logger_format = {
+    'thetis': '%(name)s:%(levelname)s %(message)s',
+    'thetis_output': '%(message)s',
+}
 
 
-def get_new_logger(name, fmt='%(levelname)s %(message)s'):
-    logger = logging.getLogger(name)
-
-    for handler in logger.handlers:
-        logger.removeHandler(handler)
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(fmt))
-
-    if COMM_WORLD.rank != 0:
-        handler = logging.NullHandler()
-
-    logger.addHandler(handler)
-    return logger
+class ThetisLogConfig:
+    """Module-wide config object"""
+    filename = None
 
 
-# create conventional logger for error etc messages
-logger = get_new_logger('thetis')
-logger.setLevel(logging.DEBUG)
+thetis_log_config = ThetisLogConfig()
+
+
+def set_thetis_loggers(comm=COMM_WORLD):
+    """Set stream handlers for log messages.
+
+    :kwarg comm: The communicator the handler should be collective
+         over. If provided, only rank-0 on that communicator will
+         write to the log, other ranks will use a :class:`logging.NullHandler`.
+         If set to ``None``, all ranks will write to log.
+    """
+    for name, fmt in logger_format.items():
+        logger = logging.getLogger(name)
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                logger.removeHandler(handler)
+
+        if comm is None or comm.rank == 0:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter(fmt=fmt))
+        else:
+            handler = logging.NullHandler()
+        logger.addHandler(handler)
+
+
+def set_log_directory(output_directory, comm=COMM_WORLD, mode='w'):
+    """
+    Forward all log output to `output_directory/log` file.
+
+    When called, a new empty log file is created.
+
+    If called twice with a different `output_directory`, a warning is raised,
+    and the new log file location is assigned. The old log file or the
+    `output_directory` are not removed.
+
+    :arg output_directory: the directory where log file is stored
+    :kwarg comm: The communicator the handler should be collective
+         over. If provided, only rank-0 on that communicator will
+         write to the log, other ranks will use a :class:`logging.NullHandler`.
+         If set to ``None``, all ranks will write to log.
+    :kwarg mode: write mode, 'w' removes previous log file (if any), otherwise
+        appends to it. Default: 'w'.
+    """
+    def rm_all_file_handlers():
+        for name in logger_format:
+            logger = logging.getLogger(name)
+            for handler in logger.handlers:
+                if isinstance(handler, logging.FileHandler):
+                    logger.removeHandler(handler)
+
+    def assign_file_handler(logfile):
+        if comm.rank == 0:
+            if os.path.exists(output_directory):
+                if not os.path.isdir(output_directory):
+                    raise IOError('file with same name exists', output_directory)
+            else:
+                os.makedirs(output_directory)
+
+        for name, fmt in logger_format.items():
+            logger = logging.getLogger(name)
+            if comm.rank == 0:
+                new_handler = logging.FileHandler(logfile, mode='a')
+                new_handler.setFormatter(logging.Formatter(fmt))
+            else:
+                new_handler = logging.NullHandler()
+            logger.addHandler(new_handler)
+
+    logfile = os.path.join(output_directory, 'log')
+    if thetis_log_config.filename == logfile:
+        # no change
+        return
+    changed = (thetis_log_config.filename is not None
+               and thetis_log_config.filename != logfile)
+    if changed:
+        old_file = str(thetis_log_config.filename)
+        rm_all_file_handlers()
+    if mode == 'w' and os.path.isfile(logfile):
+        # silently remove previous log
+        if comm.rank == 0:
+            os.remove(logfile)
+    thetis_log_config.filename = logfile
+    assign_file_handler(logfile)
+    if changed:
+        msg = (f'Setting a log file "{logfile}" that differs from previous '
+               f'"{old_file}", removing old handler')
+        warning(msg)  # to new log
+
+
+def thetis_log_level(level):
+    """Set the log level for Thetis logger.
+
+    This controls what level of logging messages are printed to
+    stderr. The higher the level, the fewer the number of messages.
+
+    :arg level: The level to use.
+    """
+    logger = logging.getLogger('thetis')
+    logger.setLevel(level)
+
+
+# logger for error, warning etc messages
+logger = logging.getLogger('thetis')
 log = logger.log
 debug = logger.debug
 info = logger.info
@@ -42,7 +140,7 @@ warning = logger.warning
 error = logger.error
 critical = logger.critical
 
-# create additional logger for model output
-output_logger = get_new_logger('thetis_output', fmt='%(message)s')
-output_logger.setLevel(logging.INFO)
+# logger for model output messages with no prefix, used with print_output
+output_logger = logging.getLogger('thetis_output')
+output_logger.setLevel(INFO)
 print_output = output_logger.info

--- a/thetis/log.py
+++ b/thetis/log.py
@@ -44,9 +44,8 @@ def set_thetis_loggers(comm=COMM_WORLD):
     """Set stream handlers for log messages.
 
     :kwarg comm: The communicator the handler should be collective
-         over. If provided, only rank-0 on that communicator will
-         write to the log, other ranks will use a :class:`logging.NullHandler`.
-         If set to ``None``, all ranks will write to log.
+         over. Only rank-0 on that communicator will write to the log, other
+         ranks will use a :class:`logging.NullHandler`.
     """
     def add_stream_handler(buffered=False):
         if comm is None or comm.rank == 0:
@@ -84,9 +83,8 @@ def set_log_directory(output_directory, comm=COMM_WORLD, mode='w'):
 
     :arg output_directory: the directory where log file is stored
     :kwarg comm: The communicator the handler should be collective
-         over. If provided, only rank-0 on that communicator will
-         write to the log, other ranks will use a :class:`logging.NullHandler`.
-         If set to ``None``, all ranks will write to log.
+         over. Only rank-0 on that communicator will write to the log, other
+         ranks will use a :class:`logging.NullHandler`.
     :kwarg mode: write mode, 'w' removes previous log file (if any), otherwise
         appends to it. Default: 'w'.
     """
@@ -127,9 +125,9 @@ def set_log_directory(output_directory, comm=COMM_WORLD, mode='w'):
     if thetis_log_config.filename == logfile:
         # no change
         return
-    changed = (thetis_log_config.filename is not None
-               and thetis_log_config.filename != logfile)
-    if changed:
+    different_file = (thetis_log_config.filename is not None
+                      and thetis_log_config.filename != logfile)
+    if different_file:
         old_file = str(thetis_log_config.filename)
         rm_file_handlers()
     if mode == 'w' and os.path.isfile(logfile):
@@ -141,10 +139,10 @@ def set_log_directory(output_directory, comm=COMM_WORLD, mode='w'):
         buffer_content = thetis_log_config.mem_buffer.getvalue()
         with open(logfile, 'w') as f:
             f.write(buffer_content)
-        rm_buf_handlers()
+    rm_buf_handlers()
     thetis_log_config.filename = logfile
     assign_file_handler(logfile)
-    if changed:
+    if different_file:
         msg = (f'Setting a log file "{logfile}" that differs from previous '
                f'"{old_file}", removing old handler')
         warning(msg)  # to new log
@@ -156,7 +154,8 @@ def thetis_log_level(level):
     This controls what level of logging messages are printed to
     stderr. The higher the level, the fewer the number of messages.
 
-    :arg level: The level to use.
+    :arg level: The level to use, one of 'DEBUG', 'INFO', 'WARNING', 'ERROR',
+        'CRITICAL'.
     """
     logger = logging.getLogger('thetis')
     logger.setLevel(level)

--- a/thetis/solver.py
+++ b/thetis/solver.py
@@ -474,10 +474,7 @@ class FlowSolver(FrozenClass):
             self.create_function_spaces()
 
         if self.options.log_output and not self.options.no_exports:
-            logfile = os.path.join(create_directory(self.options.output_directory), 'log')
-            filehandler = logging.logging.FileHandler(logfile, mode='w')
-            filehandler.setFormatter(logging.logging.Formatter('%(message)s'))
-            output_logger.addHandler(filehandler)
+            set_log_directory(self.options.output_directory)
 
         # mesh velocity etc fields must be in the same space as 3D coordinates
         coord_is_dg = element_continuity(self.mesh2d.coordinates.function_space().ufl_element()).horizontal == 'dg'

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -389,6 +389,10 @@ class FlowSolver2d(FrozenClass):
         """
         if not hasattr(self.function_spaces, 'U_2d'):
             self.create_function_spaces()
+
+        if self.options.log_output and not self.options.no_exports:
+            set_log_directory(self.options.output_directory)
+
         # ----- fields
         self.fields.solution_2d = Function(self.function_spaces.V_2d, name='solution_2d')
         # correct treatment of the split 2d functions
@@ -582,12 +586,6 @@ class FlowSolver2d(FrozenClass):
         """
         if not hasattr(self, 'equations'):
             self.create_equations()
-
-        if self.options.log_output and not self.options.no_exports:
-            logfile = os.path.join(create_directory(self.options.output_directory), 'log')
-            filehandler = logging.logging.FileHandler(logfile, mode='w')
-            filehandler.setFormatter(logging.logging.Formatter('%(message)s'))
-            output_logger.addHandler(filehandler)
 
         self.compute_mesh_stats()
         self.set_time_step()


### PR DESCRIPTION
Trying to address #290, I have updated the `log.py` implementation and added a `set_log_directory` method by which the user can define the log directory early on:

```python
from thetis import *
set_log_directory('my_directory')  # this actually creates the dir and empty log file
print_output('now this goes to the log file')
```

`solver.create_timestepper` now calls `set_log_directory` internally. If the user calls `set_log_directory` twice with the same target, the second call has no effect (e.g. does not remove old log). If called again with a different target directory, a warning is raised:

```python
from thetis import *
set_log_directory('dir1')
set_log_directory('dir2')  # raises warning, will not delete previous dir nor log file
# thetis:WARNING Setting a log file "dir2/log" that differs from previous "dir1/log", removing old handler
solver_obj = solver2d.FlowSolver2d(...)
solver_obj.options.output_directory = 'my_outputs'
solver_obj.assign_initial_conditions(...)  # raises another warning
```

The new implementation also correctly appends `warning`, `error` etc messages to the same log file.