### PR TITLE
Tohoku: add 'radial' and 'box' source models

### DIFF
--- a/examples/tohoku_inversion/Makefile
+++ b/examples/tohoku_inversion/Makefile
@@ -1,6 +1,6 @@
 all: invert plot
 
-MODELS	= DG0 CG1
+MODELS	= DG0 CG1 radial box
 
 invert:
 	for model in $(MODELS); do \

--- a/examples/tohoku_inversion/Makefile
+++ b/examples/tohoku_inversion/Makefile
@@ -9,6 +9,7 @@ invert:
 
 plot:
 	python3 plot_elevation_progress.py
+	python3 plot_elevation_optimised.py
 	python3 plot_convergence.py
 
 clean:

--- a/examples/tohoku_inversion/forward_run.py
+++ b/examples/tohoku_inversion/forward_run.py
@@ -10,7 +10,7 @@ parser = argparse.ArgumentParser(
     description="Tohoku tsunami propagation",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
-parser.add_argument("--source_model", type=str, default="CG1")
+parser.add_argument("-s", "--source-model", type=str, default="CG1")
 args = parser.parse_args()
 source_model = args.source_model
 no_exports = os.getenv("THETIS_REGRESSION_TEST") is not None
@@ -23,11 +23,9 @@ solver_obj = construct_solver(
     no_exports=no_exports,
 )
 mesh2d = solver_obj.mesh2d
-elev_init = initial_condition(mesh2d, source_model=source_model)
-elev = Function(elev_init.function_space())
-elev.project(mask(mesh2d) * elev_init)
+elev_init, controls = initial_condition(mesh2d, source_model=source_model)
 print_output(f"Exporting to {solver_obj.options.output_directory}")
-solver_obj.assign_initial_conditions(elev=elev)
+solver_obj.assign_initial_conditions(elev=elev_init)
 tic = time_mod.perf_counter()
 solver_obj.iterate()
 toc = time_mod.perf_counter()

--- a/examples/tohoku_inversion/forward_run.py
+++ b/examples/tohoku_inversion/forward_run.py
@@ -11,14 +11,19 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
 parser.add_argument("-s", "--source-model", type=str, default="CG1")
+parser.add_argument("--suffix", type=str, default="")
 args = parser.parse_args()
 source_model = args.source_model
+suffix = args.suffix
 no_exports = os.getenv("THETIS_REGRESSION_TEST") is not None
 
 # Solve forward
 pwd = os.path.abspath(os.path.dirname(__file__))
+output_dir = f"{pwd}/outputs_forward_{source_model}"
+if suffix != "":
+    output_dir = "_".join([output_dir, suffix])
 solver_obj = construct_solver(
-    output_directory=f"{pwd}/outputs_forward_{source_model}",
+    output_directory=output_dir,
     store_station_time_series=not no_exports,
     no_exports=no_exports,
 )

--- a/examples/tohoku_inversion/inverse_problem.py
+++ b/examples/tohoku_inversion/inverse_problem.py
@@ -52,6 +52,7 @@ else:
 op = inversion_tools.OptimisationProgress(
     options.output_directory,
     real=source_model[:2] not in ("CG", "DG"),
+    no_exports=options.no_exports,
 )
 for c in controls:
     op.add_control(c)

--- a/examples/tohoku_inversion/inverse_problem.py
+++ b/examples/tohoku_inversion/inverse_problem.py
@@ -18,16 +18,20 @@ parser.add_argument("--maxiter", type=int, default=40)
 parser.add_argument("--ftol", type=float, default=1.0e-05)
 parser.add_argument("--no-consistency-test", action="store_true")
 parser.add_argument("--no-taylor-test", action="store_true")
+parser.add_argument("--suffix", type=str, default=None)
 args = parser.parse_args()
 source_model = args.source_model
 do_consistency_test = not args.no_consistency_test
 do_taylor_test = not args.no_taylor_test
-
+suffix = args.suffix
 
 # Setup PDE
 pwd = os.path.abspath(os.path.dirname(__file__))
+output_dir = f"{pwd}/outputs_elev-init-optimization_{source_model}"
+if suffix is not None:
+    output_dir = "_".join([output_dir, suffix])
 solver_obj = construct_solver(
-    output_directory=f"{pwd}/outputs_elev-init-optimization_{source_model}",
+    output_directory=output_dir,
     store_station_time_series=False,
     no_exports=os.getenv("THETIS_REGRESSION_TEST") is not None,
 )

--- a/examples/tohoku_inversion/inverse_problem.py
+++ b/examples/tohoku_inversion/inverse_problem.py
@@ -5,6 +5,7 @@ from model_config import *
 import argparse
 import numpy
 import os
+import sys
 
 
 # Parse user input
@@ -12,8 +13,8 @@ parser = argparse.ArgumentParser(
     description="Tohoku tsunami source inversion problem",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
-parser.add_argument("--source-model", type=str, default="CG1")
-parser.add_argument("--maxiter", type=int, default=100)
+parser.add_argument("-s", "--source-model", type=str, default="CG1")
+parser.add_argument("--maxiter", type=int, default=40)
 parser.add_argument("--ftol", type=float, default=1.0e-05)
 parser.add_argument("--no-consistency-test", action="store_true")
 parser.add_argument("--no-taylor-test", action="store_true")
@@ -31,9 +32,7 @@ solver_obj = construct_solver(
     no_exports=os.getenv("THETIS_REGRESSION_TEST") is not None,
 )
 mesh2d = solver_obj.mesh2d
-elev_init = initial_condition(mesh2d, source_model=source_model)
-elev = Function(elev_init.function_space(), name="Elevation")
-elev.project(mask(mesh2d) * elev_init)
+elev_init, controls = initial_condition(mesh2d, source_model=source_model)
 options = solver_obj.options
 mesh2d = solver_obj.mesh2d
 bathymetry_2d = solver_obj.fields.bathymetry_2d
@@ -41,17 +40,21 @@ bathymetry_2d = solver_obj.fields.bathymetry_2d
 # Assign initial conditions
 if not options.no_exports:
     print_output(f"Exporting to {options.output_directory}")
-solver_obj.assign_initial_conditions(elev=elev)
+solver_obj.assign_initial_conditions(elev=elev_init)
 
 # Choose optimisation parameters
 control = "elev_init"
-control_bounds = [-numpy.inf, numpy.inf]
+nc = len(controls)
+if nc == 1:
+    control_bounds = [-numpy.inf, numpy.inf]
+else:
+    control_bounds = [[-numpy.inf] * nc, [numpy.inf] * nc]
 op = inversion_tools.OptimisationProgress(
     options.output_directory,
-    no_exports=options.no_exports,
+    real=source_model[:2] not in ("CG", "DG"),
 )
-op.add_control(elev_init)
-gamma_hessian_list = [Constant(0.1)]
+for c in controls:
+    op.add_control(c)
 
 # Define the (appropriately scaled) cost function
 dt_const = Constant(solver_obj.dt)
@@ -75,11 +78,18 @@ stationmanager.load_observation_data(
     end_times=end_times,
 )
 stationmanager.set_model_field(solver_obj.fields.elev_2d)
-reg_manager = inversion_tools.ControlRegularizationManager(
-    op.control_coeff_list,
-    gamma_hessian_list,
-    J_scalar=J_scalar,
-)
+
+# Compute regularization term
+if source_model[:2] in ("CG", "DG"):
+    gamma_hessian_list = [Constant(0.1)]
+    reg_manager = inversion_tools.ControlRegularizationManager(
+        op.control_coeff_list,
+        gamma_hessian_list,
+        J_scalar=J_scalar,
+    )
+    op.J = reg_manager.eval_cost_function()
+else:
+    reg_manager = None
 
 # Extract the regularized cost function
 cost_function = inversion_tools.get_cost_function(
@@ -130,15 +140,26 @@ op.reset_counters()
 op.start_clock()
 J = float(Jhat(op.control_coeff_list))
 op.set_initial_state(J, Jhat.derivative(), op.control_coeff_list)
-control_opt = minimize(
+control_opt_list = minimize(
     Jhat,
     method=opt_method,
     bounds=control_bounds,
     callback=optimisation_callback,
     options=opt_options,
 )
-control_opt.rename(op.control_coeff_list[0].name())
-print_function_value_range(control_opt, prefix="Optimal")
-if not options.no_exports:
-    fname = f"{op.control_coeff_list[0].name()}_optimised.pvd"
-    File(f"{pwd}/{options.output_directory}/{fname}").write(control_opt)
+if options.no_exports:
+    sys.exit(0)
+if source_model[:2] in ("CG", "DG"):
+    cc = control_opt_list
+    if not isinstance(control_opt_list, Function):
+        cc = cc[0]
+    oc = op.control_coeff_list[0]
+    name = cc.name()
+    oc.rename(name)
+else:
+    oc = initial_condition(
+        mesh2d, source_model=source_model, controls=op.control_coeff_list
+    )[0]
+outfile = File(f"{options.output_directory}/elevation_optimised.pvd")
+print_function_value_range(oc, prefix="Optimal")
+outfile.write(oc)

--- a/examples/tohoku_inversion/model_config.py
+++ b/examples/tohoku_inversion/model_config.py
@@ -211,7 +211,7 @@ def interpolate_bathymetry(bathymetry_2d, cap=30.0):
     interp = si.RectBivariateSpline(lat, lon, elev)
     for i, xy in enumerate(mesh.coordinates.dat.data_ro):
         lon, lat = trans.transform(*xy)
-        bathymetry_2d.dat.data[i] -= min(interp(lat, lon), -30)
+        bathymetry_2d.dat.data[i] -= min(interp(lat, lon), -cap)
 
 
 def construct_solver(store_station_time_series=True, **model_options):

--- a/examples/tohoku_inversion/plot_convergence.py
+++ b/examples/tohoku_inversion/plot_convergence.py
@@ -1,5 +1,6 @@
 import glob
 import matplotlib.pyplot as plt
+import numpy
 
 
 fig, axes = plt.subplots()
@@ -9,13 +10,9 @@ if len(fpaths) == 0:
     raise ValueError("Nothing to plot!")
 for fpath in fpaths:
     source_model = fpath.split(inv_dir + "_")[-1]
-    J_progress = []
-    for line in open(f"{fpath}/log", "r"):
-        if not line.startswith("line search"):
-            continue
-        J = line.split("J=")[1].split(",")[0]
-        J_progress.append(float(J))
-    axes.plot(J_progress, label=source_model)
+    J_progress = numpy.load(f"{fpath}/J_progress.npy")
+    it = numpy.arange(1, len(J_progress) + 1)
+    axes.loglog(it, J_progress, label=source_model)
 axes.set_xlabel("Iteration")
 axes.set_ylabel("Mean square error")
 axes.grid(True)

--- a/examples/tohoku_inversion/plot_elevation_initial_guess.py
+++ b/examples/tohoku_inversion/plot_elevation_initial_guess.py
@@ -48,7 +48,7 @@ for fpath in fpaths:
             time = h5file["time"][:].flatten() / 60.0
             vals = h5file["elev"][:].flatten()
         if len(vals) > 0:
-            vals -= vals[0]
+            vals -= vals[time >= time_obs[0]][0]
             ax.plot(time, vals, "r:", zorder=3, label="Initial guess", lw=1.5)
 
         ax.set_xlim([time_obs[0], time_obs[-1]])

--- a/examples/tohoku_inversion/plot_elevation_optimised.py
+++ b/examples/tohoku_inversion/plot_elevation_optimised.py
@@ -1,0 +1,66 @@
+import glob
+import h5py
+import matplotlib.pyplot as plt
+
+
+station_names = [
+    "801",
+    "802",
+    "803",
+    "804",
+    "806",
+    "807",
+    "P02",
+    "P06",
+    "KPG1",
+    "KPG2",
+    "MPG1",
+    "MPG2",
+    "21401",
+    "21413",
+    "21418",
+    "21419",
+]
+
+nplots = len(station_names)
+
+inv_dir = "outputs_elev-init-optimization"
+fpaths = glob.glob(f"{inv_dir}_*")
+if len(fpaths) == 0:
+    raise ValueError("Nothing to plot!")
+
+fig = plt.figure(figsize=(40, 20))
+axes = fig.subplots(4, 4)
+for i, sta in enumerate(station_names):
+
+    o = f"observations/diagnostic_timeseries_{sta}_elev.hdf5"
+    with h5py.File(o, "r") as h5file:
+        time_obs = h5file["time"][:].flatten() / 60.0
+        vals_obs = h5file["elev"][:].flatten()
+        ax = axes[i // 4, i % 4]
+        ax.plot(time_obs, vals_obs, "k", zorder=3, label="Observation", lw=1.3)
+
+    for fpath in fpaths:
+        source_model = fpath.split(inv_dir + "_")[-1]
+
+        f = f"{fpath}/diagnostic_timeseries_progress_{sta}_elev.hdf5"
+        with h5py.File(f, "r") as h5file:
+            time = h5file["time"][:].flatten() / 60.0
+            vals = h5file["elev"][:]
+
+        v = vals[-1]
+        v -= v[time >= time_obs[0]][0]
+        ax.plot(time, v, label=source_model, lw=0.5)
+
+    ax.set_title(sta)
+    ax.set_xlim([time_obs[0], time_obs[-1]])
+    if i // 4 == 3:
+        ax.set_xlabel("Time (min)")
+    if i % 4 == 0:
+        ax.set_ylabel("Elevation (m)")
+    ax.legend(ncol=2)
+    ax.grid(True)
+
+imgfile = "optimization_opt_elev_ts.png"
+print(f"Saving to {imgfile}")
+plt.savefig(imgfile, dpi=200, bbox_inches="tight")

--- a/examples/tohoku_inversion/plot_elevation_progress.py
+++ b/examples/tohoku_inversion/plot_elevation_progress.py
@@ -24,14 +24,13 @@ station_names = [
 
 nplots = len(station_names)
 
-fig = plt.figure(figsize=(40, 20))
-axes = fig.subplots(4, 4)
-
 inv_dir = "outputs_elev-init-optimization"
 fpaths = glob.glob(f"{inv_dir}_*")
 if len(fpaths) == 0:
     raise ValueError("Nothing to plot!")
 for fpath in fpaths:
+    fig = plt.figure(figsize=(40, 20))
+    axes = fig.subplots(4, 4)
     source_model = fpath.split(inv_dir + "_")[-1]
 
     for i, sta in enumerate(station_names):
@@ -49,8 +48,7 @@ for fpath in fpaths:
         ax = axes[i // 4, i % 4]
         ax.plot(time_obs, vals_obs, "k", zorder=3, label="Observation", lw=1.3)
         for i, v in enumerate(vals):
-            if sta[:2] in ["80", "P0"]:
-                v -= v[0]
+            v -= v[time >= time_obs[0]][0]
             ax.plot(time, v, label=f"_iter {i}", lw=0.5)
         ax.set_title(sta)
         ax.set_xlim([time_obs[0], time_obs[-1]])

--- a/examples/tohoku_inversion/plot_optimised_source.py
+++ b/examples/tohoku_inversion/plot_optimised_source.py
@@ -1,0 +1,37 @@
+from thetis import *
+from model_config import *
+import argparse
+import numpy
+
+
+# Parse user input
+parser = argparse.ArgumentParser(
+    description="Tohoku tsunami source inversion problem",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument("-s", "--source-model", type=str, default="CG1")
+parser.add_argument("--maxiter", type=int, default=40)
+args = parser.parse_args()
+source_model = args.source_model
+maxiter = args.maxiter
+
+# Load optimised controls
+mesh2d = Mesh("japan_sea.msh")
+output_directory = f"outputs_elev-init-optimization_{source_model}"
+source_model = source_model.split("_")[0]
+if source_model[:2] in ("CG", "DG"):
+    family = source_model[:2]
+    degree = int(source_model[2:])
+    Pk = get_functionspace(mesh2d, family, degree)
+    elev = Function(Pk)
+    fname = f"{output_directory}/hdf5/control_00_{maxiter:02d}"
+    with DumbCheckpoint(fname, mode=FILE_READ) as chk:
+        chk.load(elev, name="Elevation")
+else:
+    c = numpy.load(f"{output_directory}/m_progress.npy")[-1]
+    elev = initial_condition(mesh2d, source_model=source_model, initial_guess=c)[0]
+
+# Write to vtu
+outfile = File(f"{output_directory}/elevation_optimised.pvd")
+print_function_value_range(elev, prefix="Optimal")
+outfile.write(elev)

--- a/test/examples/test_examples.py
+++ b/test/examples/test_examples.py
@@ -43,6 +43,7 @@ exclude_files = [
     'tohoku_inversion/plot_elevation_initial_guess.py',
     'tohoku_inversion/plot_elevation_progress.py',
     'tohoku_inversion/plot_optimised_source.py',
+    'tohoku_inversion/plot_elevation_optimised.py',
 ]
 
 cwd = os.path.abspath(os.path.dirname(__file__))

--- a/test/examples/test_examples.py
+++ b/test/examples/test_examples.py
@@ -42,6 +42,7 @@ exclude_files = [
     'tohoku_inversion/plot_convergence.py',
     'tohoku_inversion/plot_elevation_initial_guess.py',
     'tohoku_inversion/plot_elevation_progress.py',
+    'tohoku_inversion/plot_optimised_source.py',
 ]
 
 cwd = os.path.abspath(os.path.dirname(__file__))

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -198,7 +198,7 @@ class StationObservationManager:
         # model time when cost function was evaluated
         self.simulation_time = []
         self.model_observation_field = None
-        self.initialzed = False
+        self.initialized = False
 
     def register_observation_data(self, station_names, variable, time,
                                   values, x, y, start_times=None, end_times=None):
@@ -342,7 +342,7 @@ class StationObservationManager:
 
         # expressions for cost function
         self.misfit_expr = self.obs_values_0d - self.mod_values_0d
-        self.initialzed = True
+        self.initialized = True
 
     def eval_observation_at_time(self, t):
         """
@@ -360,7 +360,7 @@ class StationObservationManager:
 
         Should be called at every export of the forward model.
         """
-        assert self.initialzed, 'Not initialized, call construct_evaluator first.'
+        assert self.initialized, 'Not initialized, call construct_evaluator first.'
         assert self.model_observation_field is not None, 'Model field not set.'
         self.simulation_time.append(t)
         # evaluate observations at simulation time and stash the result

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -121,6 +121,10 @@ class OptimisationProgress(object):
                 numpy.save(f'{self.output_dir}/m_progress', self.m_progress)
             numpy.save(f'{self.output_dir}/J_progress', self.J_progress)
             numpy.save(f'{self.output_dir}/dJdm_progress', self.dJdm_progress)
+        if len(djdm) > 10:
+            djdm = f"[{numpy.min(djdm):.4e} .. {numpy.max(djdm):.4e}]"
+        else:
+            djdm = "[" + ", ".join([f"{dj:.4e}" for dj in djdm]) + "]"
         print_output(f'line search {self.i:2d}: '
                      f'J={self.J:.3e}, dJdm={djdm}, '
                      f'grad_ev={self.nb_grad_evals}, duration {elapsed}')

--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -798,13 +798,16 @@ def print_function_value_range(f, comm=COMM_WORLD, name=None, prefix=None,
     :kwarg prefix: Optional prefix for the output string
     :kwarg format: Value formatting string
     """
-    f_min = comm.allreduce(f.dat.data.min(), MPI.MIN)
-    f_max = comm.allreduce(f.dat.data.max(), MPI.MAX)
-    bound_str_list = [f'{{:{format}}}'.format(v) for v in [f_min, f_max]]
     if name is None:
         name = f.name()
+    f_min = comm.allreduce(f.dat.data.min(), MPI.MIN)
+    f_max = comm.allreduce(f.dat.data.max(), MPI.MAX)
     pre = prefix + ' ' if prefix is not None else ''
-    print_output(f'{pre}{name}: {bound_str_list[0]} .. {bound_str_list[1]}')
+    bound_str_list = [f'{{:{format}}}'.format(v) for v in [f_min, f_max]]
+    if numpy.allclose(f_min, f_max):
+        print_output(f'{pre}{name}: {bound_str_list[0]}')
+    else:
+        print_output(f'{pre}{name}: {bound_str_list[0]} .. {bound_str_list[1]}')
 
 
 @PETSc.Log.EventDecorator("thetis.select_and_move_detectors")


### PR DESCRIPTION
This PR adds two additional source models to the Tohoku inversion example. Instead of inverting for a field in CG or DG space, we invert for an array of controls in R-space, which provide the coefficients for linear combinations of basis functions.

Note that this PR includes commits from #300, so that will need to be merged first.