### PR TITLE
Fix `get_facet_areas`

### DIFF
--- a/thetis/utility.py
+++ b/thetis/utility.py
@@ -591,7 +591,6 @@ def get_facet_areas(mesh):
     mass_term = v('+')*u('+')*dS + v*u*ds
     rhs = v('+')*FacetArea(mesh)*dS + v*FacetArea(mesh)*ds
     sp = {
-        "mat_type": "matfree",
         "snes_type": "ksponly",
         "ksp_type": "preonly",
         "pc_type": "jacobi",


### PR DESCRIPTION
The utility function `get_facet_areas` is broken because we are no longer allowed to assemble the diagonal on interior facets. Switching from Jacobi to SOR is probably sufficient.