### PR TITLE
Add traitlets to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ netCDF4
 pyproj
 uptide
 pytz
+traitlets


### PR DESCRIPTION
Thetis depends on `traitlets` but this is not currently mentioned in `requirements.txt`.