### PR TITLE
Fix traitlets

### DIFF
--- a/thetis/configuration.py
+++ b/thetis/configuration.py
@@ -362,6 +362,7 @@ def attach_paired_options(name, name_trait, value_trait):
         value_trait.class_init(cls, name_trait.paired_name)
         obs_handler.class_init(cls, "_%s_observer" % name)
         def_handler.class_init(cls, "_%s_default" % name_trait.paired_name)
+        cls.setup_class(cls.__dict__)
 
         return cls
     return update_class


### PR DESCRIPTION
Since traitlets 5.7.0 a lot more additional stuff happens in the initialisation of a HasTraits class (that is the initialisation of the class itself through its metaclass __init__()). All traits are assumed to be present already as class attributes and are registered internally in this initialisation. This means if we dynamically add traits to the class in a class decorator, we need reinitialize the class.