### PR TITLE
Fixing issues around domain-less Constants and adjoint

### DIFF
--- a/examples/channel_inversion/inverse_problem.py
+++ b/examples/channel_inversion/inverse_problem.py
@@ -90,7 +90,7 @@ sta_manager.load_observation_data(observation_data_dir, station_names, variable)
 sta_manager.set_model_field(solver_obj.fields.elev_2d)
 
 # Define the scaling for the cost function so that J ~ O(1)
-J_scalar = Constant(solver_obj.dt / options.simulation_end_time)
+J_scalar = Constant(solver_obj.dt / options.simulation_end_time, domain=mesh2d)
 
 # Create inversion manager and add controls
 inv_manager = inversion_tools.InversionManager(

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -47,7 +47,7 @@ class InversionManager(FrozenHasTraits):
         self.real = real
         self.penalty_parameters = penalty_parameters
         self.cost_function_scaling = cost_function_scaling or fd.Constant(1.0)
-        self.sta_manager.cost_function_scaling.assign(cost_function_scaling)
+        self.sta_manager.cost_function_scaling = self.cost_function_scaling
         self.test_consistency = test_consistency
         self.test_gradient = test_gradient
         self.outfiles_m = []
@@ -207,6 +207,7 @@ class InversionManager(FrozenHasTraits):
         def gradient_eval_cb(j, djdm, m):
             self.set_control_state(j, djdm, m)
             self.nb_grad_evals += 1
+            return djdm
 
         params = {
             'derivative_cb_post': gradient_eval_cb,
@@ -476,8 +477,7 @@ class StationObservationManager:
         self.indicator_0d = fd.Function(self.fs_points_0d, name='station use indicator')
         self.indicator_0d.assign(1.0)
         self.cost_function_scaling_0d = fd.Constant(0.0, domain=mesh0d)
-        self.cost_function_scaling_0d.assign(AdjFloat(self.cost_function_scaling))
-        self.cost_function_scaling_0d.rename('cost function scaling 0d')
+        self.cost_function_scaling_0d.assign(self.cost_function_scaling)
         self.station_weight_0d = fd.Function(self.fs_points_0d, name='station-wise weighting')
         self.station_weight_0d.assign(1.0)
         interp_kw = {}

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -475,6 +475,9 @@ class StationObservationManager:
         self.mod_values_0d = fd.Function(self.fs_points_0d, name='model values')
         self.indicator_0d = fd.Function(self.fs_points_0d, name='station use indicator')
         self.indicator_0d.assign(1.0)
+        self.cost_function_scaling_0d = fd.Constant(0.0, domain=mesh0d)
+        self.cost_function_scaling_0d.assign(AdjFloat(self.cost_function_scaling))
+        self.cost_function_scaling_0d.rename('cost function scaling 0d')
         self.station_weight_0d = fd.Function(self.fs_points_0d, name='station-wise weighting')
         self.station_weight_0d.assign(1.0)
         interp_kw = {}
@@ -544,7 +547,7 @@ class StationObservationManager:
         # compute square error
         self.obs_values_0d.assign(obs_func)
         self.mod_values_0d.interpolate(self.model_observation_field, ad_block_tag='observation')
-        s = self.cost_function_scaling * self.indicator_0d * self.station_weight_0d
+        s = self.cost_function_scaling_0d * self.indicator_0d * self.station_weight_0d
         self.J_misfit = fd.assemble(s * self.misfit_expr ** 2 * fd.dx, ad_block_tag='misfit_eval')
         return self.J_misfit
 

--- a/thetis/timeintegrator.py
+++ b/thetis/timeintegrator.py
@@ -85,6 +85,30 @@ class TimeIntegrator(TimeIntegratorBase):
         """
         raise NotImplementedError(f"Picard iterations are not supported for {self} time integrators.")
 
+    def create_fields_old(self):
+        """
+        Create a copy of fields dictionary to store beginning of timestep values
+        """
+        self._legacy_constants = isinstance(Constant(0.0, domain=self.solution.ufl_domain()), Constant)
+
+        # create functions to hold the values of previous time step
+        self.fields_old = {}
+        for k in sorted(self.fields):
+            if self.fields[k] is not None:
+                if isinstance(self.fields[k], Function):
+                    self.fields_old[k] = Function(
+                        self.fields[k].function_space())
+                elif isinstance(self.fields[k], Constant):
+                    if self._legacy_constants:
+                        self.fields_old[k] = Constant(self.fields[k])
+                    else:
+                        self.fields_old[k] = self.fields[k]
+
+    def update_fields_old(self):
+        for k in sorted(self.fields):
+            if isinstance(self.fields[k], Function) or self._legacy_constants:
+                self.fields_old[k].assign(self.fields[k])
+
 
 class ForwardEuler(TimeIntegrator):
     """Standard forward Euler time integration scheme."""
@@ -105,15 +129,7 @@ class ForwardEuler(TimeIntegrator):
         super(ForwardEuler, self).__init__(equation, solution, fields, dt, options)
         self.solution_old = Function(self.equation.function_space)
 
-        # create functions to hold the values of previous time step
-        self.fields_old = {}
-        for k in sorted(self.fields):
-            if self.fields[k] is not None:
-                if isinstance(self.fields[k], Function):
-                    self.fields_old[k] = Function(
-                        self.fields[k].function_space())
-                elif isinstance(self.fields[k], Constant):
-                    self.fields_old[k] = Constant(self.fields[k])
+        self.create_fields_old()
 
         u_old = self.solution_old
         u_tri = self.equation.trial
@@ -135,9 +151,7 @@ class ForwardEuler(TimeIntegrator):
     def initialize(self, solution):
         """Assigns initial conditions to all required fields."""
         self.solution_old.assign(solution)
-        # assign values to old functions
-        for k in sorted(self.fields_old):
-            self.fields_old[k].assign(self.fields[k])
+        self.update_fields_old()
 
     @PETSc.Log.EventDecorator("thetis.ForwardEuler.advance")
     def advance(self, t, update_forcings=None):
@@ -146,9 +160,7 @@ class ForwardEuler(TimeIntegrator):
             update_forcings(t + self.dt)
         self.solution_old.assign(self.solution)
         self.solver.solve()
-        # shift time
-        for k in sorted(self.fields_old):
-            self.fields_old[k].assign(self.fields[k])
+        self.update_fields_old()
 
 
 class CrankNicolson(TimeIntegrator):
@@ -175,16 +187,7 @@ class CrankNicolson(TimeIntegrator):
         else:
             self.solver_parameters.setdefault('snes_type', 'newtonls')
         self.solution_old = Function(self.equation.function_space, name='solution_old')
-        # create functions to hold the values of previous time step
-        # TODO is this necessary? is self.fields sufficient?
-        self.fields_old = {}
-        for k in sorted(self.fields):
-            if self.fields[k] is not None:
-                if isinstance(self.fields[k], Function):
-                    self.fields_old[k] = Function(
-                        self.fields[k].function_space(), name=self.fields[k].name()+'_old')
-                elif isinstance(self.fields[k], Constant):
-                    self.fields_old[k] = Constant(self.fields[k])
+        self.create_fields_old()
 
         u = self.solution
         u_old = self.solution_old
@@ -224,9 +227,7 @@ class CrankNicolson(TimeIntegrator):
     def initialize(self, solution):
         """Assigns initial conditions to all required fields."""
         self.solution_old.assign(solution)
-        # assign values to old functions
-        for k in sorted(self.fields_old):
-            self.fields_old[k].assign(self.fields[k])
+        self.update_fields_old()
 
     @PETSc.Log.EventDecorator("thetis.CrankNicolson.advance")
     def advance(self, t, update_forcings=None):
@@ -235,9 +236,7 @@ class CrankNicolson(TimeIntegrator):
             update_forcings(t + self.dt)
         self.solution_old.assign(self.solution)
         self.solver.solve()
-        # shift time
-        for k in sorted(self.fields_old):
-            self.fields_old[k].assign(self.fields[k])
+        self.update_fields_old()
 
     @PETSc.Log.EventDecorator("thetis.CrankNicolson.advance_picard")
     def advance_picard(self, t, update_forcings=None, update_lagged=True, update_fields=True):
@@ -248,9 +247,7 @@ class CrankNicolson(TimeIntegrator):
             self.solution_old.assign(self.solution)
         self.solver.solve()
         if update_fields:
-            # shift time
-            for k in sorted(self.fields_old):
-                self.fields_old[k].assign(self.fields[k])
+            self.update_fields_old()
 
 
 class SteadyState(TimeIntegrator):
@@ -370,15 +367,8 @@ class PressureProjectionPicard(TimeIntegrator):
             raise Exception("The timestepper PressureProjectionPicard is only recommended in combination with the "
                             "dg-cg element_family. If you want to use it in combination with dg-dg or rt-dg you need to adjust the solver_parameters_pressure option.")
 
-        # create functions to hold the values of previous time step
-        self.fields_old = {}
-        for k in sorted(self.fields):
-            if self.fields[k] is not None:
-                if isinstance(self.fields[k], Function):
-                    self.fields_old[k] = Function(
-                        self.fields[k].function_space())
-                elif isinstance(self.fields[k], Constant):
-                    self.fields_old[k] = Constant(self.fields[k])
+        self.create_fields_old()
+
         # for the mom. eqn. the 'eta' field is just one of the 'other' fields
         fields_mom = self.fields.copy()
         fields_mom_old = self.fields_old.copy()
@@ -452,9 +442,7 @@ class PressureProjectionPicard(TimeIntegrator):
         """Assigns initial conditions to all required fields."""
         self.solution_old.assign(solution)
         self.solution_lagged.assign(solution)
-        # assign values to old functions
-        for k in sorted(self.fields_old):
-            self.fields_old[k].assign(self.fields[k])
+        self.update_fields_old()
 
     @PETSc.Log.EventDecorator("thetis.PressureProjectionPicard.advance")
     def advance(self, t, update_forcings=None):
@@ -471,9 +459,7 @@ class PressureProjectionPicard(TimeIntegrator):
             with timed_stage("Pressure solve"):
                 self.solver.solve()
 
-        # shift time
-        for k in sorted(self.fields_old):
-            self.fields_old[k].assign(self.fields[k])
+        self.update_fields_old()
 
 
 class LeapFrogAM3(TimeIntegrator):


### PR DESCRIPTION
Changes required to fix adjoint:
* Constants used as control (and any Constant that changes value during the run) requires a domain for the adjoint to work
* callbacks pre and post derivative calculation of a ReducedFunctional now need to pass through resp. the control and the derivatives
* avoid assigning to Constants internally as this causes issues with the adjoint - notably this was done in updating fields_old in some timesteppers (we maybe should just get rid of fields_old altogether)