### PR TITLE
BUGFIX: Rossby wave test was being run on dg-dg only

### DIFF
--- a/test/swe2d/test_rossby_wave.py
+++ b/test/swe2d/test_rossby_wave.py
@@ -138,8 +138,9 @@ def asymptotic_expansion_elev(H_2d, order=1, time=0.0, soliton_amplitude=0.395):
 
 def run(refinement_level, **model_options):
     order = model_options.pop('expansion_order')
-    family = model_options.get('element_family')
-    stepper = model_options.get('swe_timestepper_type')
+    # these are normal Thetis options, but we need to set them early on
+    family = model_options.pop('element_family')
+    stepper = model_options.pop('swe_timestepper_type')
     print_output("--- running refinement level {:d} in {:s} space".format(refinement_level, family))
 
     # Set up domain
@@ -158,7 +159,10 @@ def run(refinement_level, **model_options):
     # Create solver object
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry2d)
     options = solver_obj.options
+    # set timestepper early so we can set the relevant suboptions
     options.swe_timestepper_type = stepper
+    # set element_type early so we can create function spaces
+    options.element_family = family
     if hasattr(options.swe_timestepper_options, 'use_automatic_timestep'):
         options.swe_timestepper_options.use_automatic_timestep = False
     options.timestep = 0.96/refinement_level if stepper == 'SSPRK33' else 9.6/refinement_level


### PR DESCRIPTION
The call to options.update(model_options) which a.o. sets the element_family option only happened after the call to create_function_spaces() so that the function spaces were always based on the default dg-dg rather than going through dg-dg, dg-cg, rt-dg and bdm-dg as intended.

Also the setting of the timestepper type should probably not be repeated as it may overwrite the timestepper sub-options that were set previously.