### PR TITLE
Update scaling for adjoint problems

### DIFF
--- a/examples/channel_inversion/inverse_problem.py
+++ b/examples/channel_inversion/inverse_problem.py
@@ -90,13 +90,13 @@ station_names = [
 ]
 sta_manager = inversion_tools.StationObservationManager(
     mesh2d, output_directory=options.output_directory)
+# TODO: Update scaling to depend on number of DOFs in the problem
 cost_function_scaling = domain_constant(100000 * solver_obj.dt / options.simulation_end_time, mesh2d)
 sta_manager.cost_function_scaling = cost_function_scaling
 sta_manager.load_observation_data(observation_data_dir, station_names, variable)
 sta_manager.set_model_field(solver_obj.fields.elev_2d)
 
-# Define the scaling for the cost function so that J ~ O(1)
-# TODO: is this right, or is it dJ/dm that needs to be ~ O(1)?
+# Define the scaling for the cost function so that dJ/dm ~ O(1)
 J_scalar = sta_manager.cost_function_scaling
 
 # Create inversion manager and add controls

--- a/examples/channel_inversion/inverse_problem.py
+++ b/examples/channel_inversion/inverse_problem.py
@@ -90,11 +90,14 @@ station_names = [
 ]
 sta_manager = inversion_tools.StationObservationManager(
     mesh2d, output_directory=options.output_directory)
+cost_function_scaling = domain_constant(100000 * solver_obj.dt / options.simulation_end_time, mesh2d)
+sta_manager.cost_function_scaling = cost_function_scaling
 sta_manager.load_observation_data(observation_data_dir, station_names, variable)
 sta_manager.set_model_field(solver_obj.fields.elev_2d)
 
 # Define the scaling for the cost function so that J ~ O(1)
-J_scalar = domain_constant(solver_obj.dt / options.simulation_end_time, mesh2d)
+# TODO: is this right, or is it dJ/dm that needs to be ~ O(1)?
+J_scalar = sta_manager.cost_function_scaling
 
 # Create inversion manager and add controls
 inv_manager = inversion_tools.InversionManager(

--- a/examples/tohoku_inversion/inverse_problem.py
+++ b/examples/tohoku_inversion/inverse_problem.py
@@ -73,6 +73,10 @@ end_times = [dat["end"] for dat in stations.values()]
 sta_manager = inversion_tools.StationObservationManager(
     mesh2d, output_directory=options.output_directory
 )
+# Define the scaling for the cost function so that J ~ O(1)
+# TODO: is this right, or is it dJ/dm that needs to be ~ O(1)?
+cost_function_scaling = domain_constant(10000000 * solver_obj.dt / options.simulation_end_time, mesh2d)
+sta_manager.cost_function_scaling = cost_function_scaling
 sta_manager.load_observation_data(
     observation_data_dir,
     station_names,
@@ -82,8 +86,7 @@ sta_manager.load_observation_data(
 )
 sta_manager.set_model_field(solver_obj.fields.elev_2d)
 
-# Define the scaling for the cost function so that J ~ O(1)
-J_scalar = Constant(solver_obj.dt / options.simulation_end_time)
+J_scalar = sta_manager.cost_function_scaling
 
 # Create inversion manager and add controls
 no_exports = os.getenv("THETIS_REGRESSION_TEST") is not None

--- a/examples/tohoku_inversion/inverse_problem.py
+++ b/examples/tohoku_inversion/inverse_problem.py
@@ -73,8 +73,8 @@ end_times = [dat["end"] for dat in stations.values()]
 sta_manager = inversion_tools.StationObservationManager(
     mesh2d, output_directory=options.output_directory
 )
-# Define the scaling for the cost function so that J ~ O(1)
-# TODO: is this right, or is it dJ/dm that needs to be ~ O(1)?
+# Define the scaling for the cost function so that dJ/dm ~ O(1)
+# TODO: Update scaling to depend on number of DOFs in the problem
 cost_function_scaling = domain_constant(10000000 * solver_obj.dt / options.simulation_end_time, mesh2d)
 sta_manager.cost_function_scaling = cost_function_scaling
 sta_manager.load_observation_data(

--- a/test_adjoint/examples/test_examples.py
+++ b/test_adjoint/examples/test_examples.py
@@ -34,8 +34,6 @@ def example_file(request):
 
 def test_examples(example_file, tmpdir, monkeypatch):
     assert os.path.isfile(example_file), 'File not found {:}'.format(example_file)
-    if 'examples/channel_inversion/inverse_problem.py' in example_file:
-        pytest.xfail("Known issue with Firedrake and mixed function spaces. See Firedrake issue #3368.")
     # copy mesh files
     source = os.path.dirname(example_file)
     for f in glob.glob(os.path.join(source, '*.msh')):


### PR DESCRIPTION
Updates scaling in the channel and Tohoku inversion examples and add the channel inversion back into testing.

- Previously the scaling has no effect because [`construct_evaluator`](https://github.com/thetisproject/thetis/blob/master/thetis/inversion_tools.py#L468) of the `StationManager` in `inversion_tools.py` has already been called and thus `cost_function_scaling_0d` does not get updated, even if `cost_function_scaling` does.
- The scaling itself needs to be higher than previously and seems to be related to the magnitude of dJ/dm rather than J

Cannot be merged until Firedrake PR [#3932](https://github.com/firedrakeproject/firedrake/pull/3932) is merged.