### PR TITLE
Re-enable turbines in `test_anisotropic`

### DIFF
--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -138,10 +138,15 @@ def run(solve_adjoint=False, mesh=None, **model_options):
                                  'Hessian2d',
                                  preproc_func=hessian_calculator)
 
-    # apply initial guess of inflow velocity, solve and return number of nonlinear solver iterations
+    # Apply initial guess of inflow velocity and solve
     solver_obj.assign_initial_conditions(uv=inflow_velocity)
     solver_obj.iterate()
+
     if not solve_adjoint:
+        # Check that turbines have been picked up
+        assert not np.allclose(solver_obj.fields.uv_2d.dat.data[0], 0.5, atol=1e-3)
+
+        # Return number of nonlinear solver iterations
         return solver_obj.timestepper.solver.snes.getIterationNumber()
 
     # quantity of interest: power output

--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -146,6 +146,10 @@ def run(solve_adjoint=False, mesh=None, **model_options):
         # Check that turbines have been picked up
         assert not np.allclose(solver_obj.fields.uv_2d.dat.data[0], 0.5, atol=1e-3)
 
+        # Check the turbine density has been set up correctly
+        total_turbine_density = assemble(solver_obj.tidal_farms[0].turbine_density * dx)
+        assert np.isclose(total_turbine_density, 2, atol=0.01), f"Expected 2, but got {total_turbine_density}"
+
         # Return number of nonlinear solver iterations
         return solver_obj.timestepper.solver.snes.getIterationNumber()
 


### PR DESCRIPTION
Closes #379.

Thanks to @cpjordan for explaining how to update this example to use the more up-to-date turbine implementation. (Equations need to be created after turbine farm.)

I also added a check to avoid this happening again.