### PR TITLE
Fix gradient in `test_anisotropic`

### DIFF
--- a/test/swe2d/test_anisotropic.py
+++ b/test/swe2d/test_anisotropic.py
@@ -157,9 +157,8 @@ def run(solve_adjoint=False, taylor_test=False, mesh=None, **model_options):
     # quantity of interest: power output
     q_2d = solver_obj.fields.solution_2d
     uv_2d, elev_2d = split(q_2d)
-    # C_D = 0.5 * C_T * A * farm_options.turbine_density  # FIXME
-    C_D = Function(P1_2d)
-    C_D.interpolate(0.5 * C_T * A * farm_options.turbine_density)
+    C_D = Function(solver_obj.function_spaces.P1DG_2d)
+    C_D.project(0.5 * C_T * A * farm_options.turbine_density)
     J = C_D * dot(uv_2d, uv_2d) ** 1.5 * dx
 
     if taylor_test:


### PR DESCRIPTION
While #381 re-enables the turbines in `test_anisotropic`, I found there's still something not right because when I use a similar setup for PDE-constrained optimisation (https://github.com/mesh-adaptation/opt_adapt/pull/38), the optimisation progress is non-monotonic and the control turbine area occasionally goes to zero.

I added a Taylor test and found that the gradient of the QoI wasn't being computed correctly with the existing setup. I tracked the problem down to the turbine_density expression, which includes several terms. By projecting this expression into $\mathbb{P}1_{DG}$ space, the Taylor test passed.