### PR TITLE
Add projected area option for turbines

### DIFF
--- a/thetis/options.py
+++ b/thetis/options.py
@@ -462,8 +462,8 @@ class TidalTurbineOptions(FrozenHasTraits):
     name = 'Tidal turbine options'
     diameter = PositiveFloat(
         18., help='Turbine diameter').tag(config=True)
-    swept_diameter = PositiveFloat(
-        None, allow_none=True, help='Projected diameter of the turbine '
+    projected_diameter = PositiveFloat(
+        None, allow_none=True, help='Extent over which turbine drag is applied'
                                     '(defaults to diameter if not provided)').tag(config=True)
     C_support = NonNegativeFloat(
         0., help='Thrust coefficient for support structure').tag(config=True)

--- a/thetis/options.py
+++ b/thetis/options.py
@@ -462,6 +462,9 @@ class TidalTurbineOptions(FrozenHasTraits):
     name = 'Tidal turbine options'
     diameter = PositiveFloat(
         18., help='Turbine diameter').tag(config=True)
+    swept_diameter = PositiveFloat(
+        None, allow_none=True, help='Projected diameter of the turbine '
+                                    '(defaults to diameter if not provided)').tag(config=True)
     C_support = NonNegativeFloat(
         0., help='Thrust coefficient for support structure').tag(config=True)
     A_support = NonNegativeFloat(


### PR DESCRIPTION
- Concentrates the thrust into a smaller (or larger) area, allowing a narrower or wider wake for the same applied thrust
- Swept diameter defaults to normal diameter
- No changes to the examples

Based on [previous feature of OpenTidalFarm](https://github.com/OpenTidalFarm/OpenTidalFarm/blob/master/opentidalfarm/turbines/thrust_turbine.py).