### PR TITLE
pip install firedrake support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,31 +18,56 @@ jobs:
     runs-on: self-hosted
     # The docker container to use.
     container:
-      image: firedrakeproject/firedrake-vanilla:latest
+      # UNDO ME
+      # image: firedrakeproject/firedrake-vanilla-default:latest
+      image: firedrakeproject/firedrake-vanilla-default:pip
     steps:
-      - uses: actions/checkout@v2
-      - name: Cleanup
-        if: ${{ always() }}
+      - name: Pre-cleanup
         run: |
-          cd ..
-          rm -rf build
+          : # Wipe everything away in the current directory
+          find . -delete
+
+      - uses: actions/checkout@v4
+        with:
+          path: thetis-repo
+
       - name: Install Thetis
+        id: install
         run: |
-          . /home/firedrake/firedrake/bin/activate
-          python -m pip install -r requirements.txt
-          python -m pip install -e .
-      - name: Test Thetis
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          python $(which firedrake-clean)
-          python -m pytest --durations=0 --durations-min=60.0 -n 12 -v test
-      - name: Test Thetis adjoint
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          python $(which firedrake-clean)
-          python -m pytest --durations=0 -n 12 -v test_adjoint
+          : # Pass '--system-site-packages' so Firedrake can be found
+          python3 -m venv --system-site-packages venv-thetis
+          . venv-thetis/bin/activate
+          pip install ./thetis-repo
+          pip list
+
       - name: Lint
-        if: ${{ always() }}
         run: |
-          . /home/firedrake/firedrake/bin/activate
-          make lint
+          . venv-thetis/bin/activate
+          pip install flake8
+          make -C thetis-repo lint
+
+      - name: Test Thetis
+        # Run even if the step above failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          firedrake-clean
+          . venv-thetis/bin/activate
+          : # Run the serial tests
+          : # Use pytest-xdist here so we can have a single collated output (not possible
+          : # for parallel tests)
+          firedrake-run-split-tests 1 1 -n 12 --verbose --durations=0 --durations-min=60.0 thetis-repo/test
+          : # Run the parallel tests
+          firedrake-run-split-tests 2 6 --verbose --durations=0 --durations-min=60.0 thetis-repo/test
+
+      - name: Test Thetis adjoint
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          firedrake-clean
+          . venv-thetis/bin/activate
+          firedrake-run-split-tests 1 1 -n 12 --verbose --durations=0 thetis-repo/test_adjoint
+
+      - name: Post-cleanup
+        if: always()
+        run: |
+          find . -delete
+          firedrake-clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,18 +63,18 @@ jobs:
         run: |
           . venv-thetis/bin/activate
           : # Run the serial tests
-          : # Use pytest-xdist here so we can have a single collated output (not possible
-          : # for parallel tests)
-          firedrake-run-split-tests 1 1 -n 12 --verbose --durations=0 --durations-min=60.0 thetis-repo/test
-          : # Run the parallel tests
-          firedrake-run-split-tests 2 6 --verbose --durations=0 --durations-min=60.0 thetis-repo/test
+          python -m pytest -n 12 --verbose --durations=0 --durations-min=60.0 \
+            -m "parallel[1] or not parallel" thetis-repo/test
+          : # Run the parallel tests (note that xdist is not valid in parallel)
+          mpiexec -n 2 python -m pytest --verbose --durations=0 --durations-min=60.0 \
+            -m parallel[2] thetis-repo/test
 
       - name: Test Thetis adjoint
         if: success() || steps.install.conclusion == 'success'
         run: |
           firedrake-clean
           . venv-thetis/bin/activate
-          firedrake-run-split-tests 1 1 -n 12 --verbose --durations=0 thetis-repo/test_adjoint
+          python -m pytest -n 12 --verbose --durations=0 thetis-repo/test_adjoint
 
       - name: Post-cleanup
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,10 @@ jobs:
   build:
     name: "Build Thetis"
     # The type of runner that the job will run on
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux]
     # The docker container to use.
     container:
-      # UNDO ME
-      # image: firedrakeproject/firedrake-vanilla-default:latest
-      image: firedrakeproject/firedrake-vanilla-default:pip
+      image: firedrakeproject/firedrake-vanilla-default:latest
     env:
       # Make sure that tests with >2 processes are not silently skipped
       PYTEST_MPI_MAX_NPROCS: 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,27 @@ jobs:
       # UNDO ME
       # image: firedrakeproject/firedrake-vanilla-default:latest
       image: firedrakeproject/firedrake-vanilla-default:pip
+    env:
+      # Make sure that tests with >2 processes are not silently skipped
+      PYTEST_MPI_MAX_NPROCS: 2
     steps:
+      - name: Fix HOME
+        # For unknown reasons GitHub actions overwrite HOME to /github/home
+        # which will break everything unless fixed
+        # (https://github.com/actions/runner/issues/863)
+        run: echo "HOME=/home/firedrake" >> "$GITHUB_ENV"
+
       - name: Pre-cleanup
         run: |
           : # Wipe everything away in the current directory
           find . -delete
+          firedrake-clean
 
       - uses: actions/checkout@v4
         with:
+          # Download Thetis into a subdirectory not called 'thetis' to make sure
+          # that the package installs correctly. Otherwise 'import thetis' may
+          # work even if the installation failed because it is a subdirectory.
           path: thetis-repo
 
       - name: Install Thetis
@@ -50,7 +63,6 @@ jobs:
         # Run even if the step above failed
         if: success() || steps.install.conclusion == 'success'
         run: |
-          firedrake-clean
           . venv-thetis/bin/activate
           : # Run the serial tests
           : # Use pytest-xdist here so we can have a single collated output (not possible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "scipy",
   "traitlets",
   "uptide",
+  "vtk",
 ]
 authors = [
   {name = "Tuomas Karna", email = "tuomas.karna@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "thetis"
+version = "0.0.1"
+dependencies = [
+  "netCDF4",
+  "pylit",
+  "pyproj",
+  "pytz",
+  "scipy",
+  "traitlets",
+  "uptide",
+]
+authors = [
+  {name = "Tuomas Karna", email = "tuomas.karna@gmail.com" },
+]
+description = "Finite element ocean model"
+readme = "readme.md"
+license = {file = "LICENSE"}
+classifiers = [
+  "Programming Language :: Python",
+]
+
+[project.urls]
+Homepage = "https://thetisproject.org"
+Repository = "https://github.com/thetisproject/thetis.git"
+
+[tool.setuptools]
+packages = ["thetis", "test", "examples"]

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,4 @@
 from distutils.core import setup
 from glob import glob
 
-import versioneer
-
-cmdclass = versioneer.get_cmdclass()
-
-setup(name='thetis',
-      cmdclass=cmdclass,
-      version=versioneer.get_version(),
-      description='Finite element ocean model',
-      author='Tuomas Karna',
-      author_email='tuomas.karna@gmail.com',
-      url='https://github.com/thetisproject/thetis',
-      packages=['thetis', 'test', 'examples'],
-      scripts=glob('scripts/*'),
-     )
+setup(scripts=glob('scripts/*'))

--- a/test/examples/test_notebooks.py
+++ b/test/examples/test_notebooks.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 import os
 import subprocess
 import glob
@@ -21,5 +22,4 @@ def ipynb_file(request):
 
 def test_notebook_runs(ipynb_file, tmpdir, monkeypatch):
     monkeypatch.chdir(tmpdir)
-    pytest = os.path.join(os.environ.get("VIRTUAL_ENV"), "bin", "pytest")
-    subprocess.check_call([pytest, "--nbval-lax", ipynb_file])
+    subprocess.check_call([sys.executable, "-m", "pytest", "--nbval-lax", ipynb_file])


### PR DESCRIPTION
Hi, I have had a go at getting `pip install Firedrake` (https://github.com/firedrakeproject/firedrake/pull/4011) support added to your CI (and also made you a `pyproject.toml`).

The website will also need updating.

Note that I haven't yet figured out how to get versioneer working properly. If you feel strongly about keeping it then some extra hacking around is needed. I have simply removed references to it in the build process and set the version to 0.0.1 for now.