### PR TITLE
Avoid subspace warning

### DIFF
--- a/thetis/assembledschur.py
+++ b/thetis/assembledschur.py
@@ -29,7 +29,7 @@ class AssembledSchurPC(PCBase):
 
         test, trial = a.arguments()
         W = test.function_space()
-        V, Q = W.subfunctions
+        V, Q = W.subspaces
         v = TestFunction(V)
         u = TrialFunction(V)
         mass = dot(v, u)*dx

--- a/thetis/shallowwater_eq.py
+++ b/thetis/shallowwater_eq.py
@@ -906,7 +906,7 @@ class ShallowWaterEquations(BaseShallowWaterEquation):
         super(ShallowWaterEquations, self).__init__(function_space, depth, options)
 
         u_test, eta_test = TestFunctions(function_space)
-        u_space, eta_space = function_space.subfunctions
+        u_space, eta_space = function_space.subspaces
 
         self.add_momentum_terms(u_test, u_space, eta_space, depth, options, tidal_farms=tidal_farms)
 
@@ -945,7 +945,7 @@ class ModeSplit2DEquations(BaseShallowWaterEquation):
         super(ModeSplit2DEquations, self).__init__(function_space, depth, options)
 
         u_test, eta_test = TestFunctions(function_space)
-        u_space, eta_space = function_space.subfunctions
+        u_space, eta_space = function_space.subspaces
 
         self.add_momentum_terms(u_test, u_space, eta_space, depth, options)
 


### PR DESCRIPTION
Avoids deprecation warning about using the `subfunctions` property of a `FunctionSpace`.