### PR TITLE
Add detector locations in DetectorsCallback

### DIFF
--- a/thetis/callback.py
+++ b/thetis/callback.py
@@ -524,6 +524,11 @@ class DetectorsCallback(DiagnosticCallback):
         else:
             assert ndetectors == len(detector_names), "Different number of detector locations and names"
             self.detector_names = detector_names
+        for i, det_name in enumerate(self.detector_names):
+            self.var_attrs[det_name] = {
+                'x': detector_locations[i][0],
+                'y': detector_locations[i][1]
+            }
         self._variable_names = self.detector_names
         self.detector_locations = detector_locations
         self.field_names = field_names


### PR DESCRIPTION
Detector locations seem to be missing from the DetectorsCallback but present in e.g. TimeSeriesCallback2D. I've added them as variable attributes to avoid any ambiguity in the case where the keys of the hdf5 file default to 'detectors0N'. 