### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           : # Pass '--system-site-packages' so Firedrake can be found
           python3 -m venv --system-site-packages venv-thetis
           . venv-thetis/bin/activate
-          pip install ./thetis-repo
+          pip install ./thetis-repo[dev]
           pip list
 
       - name: Lint
@@ -63,7 +63,8 @@ jobs:
         run: |
           . venv-thetis/bin/activate
           : # Run the serial tests
-          python -m pytest -n 12 --verbose --durations=0 --durations-min=60.0 \
+          export COVERAGE_FILE=".coverage.serial"
+          python -m pytest --cov=thetis -n 12 --verbose --durations=0 --durations-min=60.0 \
           -m "parallel[1] or not parallel" thetis-repo/test
 
       - name: Test Thetis (parallel)
@@ -71,7 +72,8 @@ jobs:
         run: |
           . venv-thetis/bin/activate
           : # Run the parallel tests (note that xdist is not valid in parallel)
-          mpiexec -n 2 python -m pytest --verbose --durations=0 --durations-min=60.0 \
+          mpiexec -n 2 bash -c 'export COVERAGE_FILE=".coverage.mpi.${OMPI_COMM_WORLD_RANK}"; \
+          python -m pytest --cov=thetis --verbose --durations=0 --durations-min=60.0 \
           -m parallel[2] thetis-repo/test'
 
       - name: Test Thetis adjoint
@@ -79,7 +81,23 @@ jobs:
         run: |
           firedrake-clean
           . venv-thetis/bin/activate
-          python -m pytest -n 12 --verbose --durations=0 thetis-repo/test_adjoint
+          export COVERAGE_FILE=".coverage.adjoint"
+          python -m pytest --cov=thetis -n 12 --verbose --durations=0 thetis-repo/test_adjoint
+          ls -alh .coverage*
+
+      - name: Combine coverage
+        run: |
+          . venv-thetis/bin/activate
+          export COVERAGE_FILE=".coverage"
+          coverage combine
+          coverage xml
+          coverage report
+
+      - name: Upload coverage to Codecov (dry run)
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          dry_run: true  # fail_ci_if_error: true
 
       - name: Post-cleanup
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,7 @@ docs = [
   "sphinxcontrib-youtube",
   "vtk",  # needed to resolve API
 ]
+
+dev = [
+  "pytest-cov",
+]

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/thetisproject/thetis/actions/workflows/build.yml/badge.svg)](https://github.com/thetisproject/thetis/actions/workflows/build.yml)
 ![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)
+[![Coverage Status](https://codecov.io/gh/thetisproject/thetis/branch/master/graph/badge.svg?token=YOUR_TOKEN_HERE)](https://codecov.io/gh/thetisproject/thetis)
 
 **Thetis** is an open-source, finite element framework for simulating **coastal and estuarine flows** with advanced numerics, high flexibility, and easy extensibility.
 


### PR DESCRIPTION
Adds code coverage to Thetis testing. Will rebase the branch once #403 is merged. 

Currently have the code coverage configured with `dry_run` which simulates the coverage upload, without actually uploading it. This needs to be amended if this is a welcome addition so that the code coverage is uploaded. This will need the repo to be connected on https://about.codecov.io/.

Also needs a couple more checks. The latest [check](https://github.com/thetisproject/thetis/actions/runs/16117475269/job/45474636168#step:8:669) suggests that an inversion example runs yet we [report no coverage](https://github.com/thetisproject/thetis/actions/runs/16117475269/job/45474636168#step:8:1601).