### PR TITLE
Remove deprecated usage of .vector()

### DIFF
--- a/test/operations/test_operations_2d-3d.py
+++ b/test/operations/test_operations_2d-3d.py
@@ -1,5 +1,6 @@
 import pytest
 from firedrake import *
+from mpi4py import MPI
 import thetis.utility as utility
 import thetis.utility3d as utility3d
 import numpy
@@ -185,7 +186,8 @@ def test_copy_2d_field_to_3d_vec(uv_2d, uv_3d):
 
 
 def test_minimum_angle(mesh2d):
-    min_angle = utility.get_minimum_angles_2d(mesh2d).vector().gather().min()
+    min_angle_local = utility.get_minimum_angles_2d(mesh2d).dat.data_ro.min()
+    min_angle = mesh2d.comm.allreduce(min_angle_local, op=MPI.MIN)
     assert numpy.allclose(min_angle, pi/4)
 
 

--- a/test_adjoint/test_swe_adjoint.py
+++ b/test_adjoint/test_swe_adjoint.py
@@ -119,7 +119,7 @@ def test_gradient_from_adjoint(setup):
     c = Function(solver_obj.options.quadratic_drag_coefficient)
     dc = Function(c)
     from numpy.random import rand
-    c.vector()[:] = rand(*c.dat.shape)
-    dc.vector()[:] = rand(*dc.dat.shape)
+    c.dat.data_wo[...] = rand(*c.dat.shape)
+    dc.dat.data_wo[...] = rand(*dc.dat.shape)
     minconv = taylor_test(Jhat, c, dc)
     assert minconv > 1.90


### PR DESCRIPTION
See https://github.com/firedrakeproject/firedrake/pull/4499