### PR TITLE
Update exports to include timestep information

### DIFF
--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -252,9 +252,9 @@ class HDF5Exporter(ExporterBase):
 
                 try:
                     initial_time_iso = f.get_attr("/", "initial_time_iso")
-                    metadata['initial_time'] = datetime.datetime.fromisoformat(initial_time_iso)
+                    metadata['initial_time_iso'] = datetime.datetime.fromisoformat(initial_time_iso)
                 except (KeyError, AttributeError):
-                    metadata['initial_time'] = None
+                    metadata['initial_time_iso'] = None
 
         return metadata
 

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -5,6 +5,7 @@ from .utility import *
 from firedrake.output.vtk_output import is_cg, VTKFile
 from collections import OrderedDict
 import itertools
+import datetime
 
 
 def is_2d(fs):
@@ -185,13 +186,24 @@ class HDF5Exporter(ExporterBase):
             with CheckpointFile(filename, 'w') as f:
                 mesh = function.function_space().mesh()
                 f.save_mesh(mesh)
-                f.save_function(function)
+
+                # include timestepping info if requested
+                ts_info = {}
                 if self.include_time:
                     if time is None:
                         raise ValueError("time must be provided when include_time=True")
-                    f.file.attrs['time'] = time
+                    ts_info['time'] = float(time)
                     if self.initial_time is not None:
-                        f.file.attrs['initial_time'] = self.initial_time
+                        f.set_attr(
+                            "/",
+                            "initial_time_iso",
+                            self.initial_time.isoformat()
+                        )
+
+                # store function with timestepping info
+                idx = 0 if ts_info else None
+                f.save_function(function, idx=float(idx), timestepping_info=ts_info)
+
         self.next_export_ix = iexport + 1
 
     @PETSc.Log.EventDecorator("thetis.HDF5Exporter.export")
@@ -230,11 +242,17 @@ class HDF5Exporter(ExporterBase):
                     raise IOError('When loading fields from hdf5 checkpoint files, you should also read the mesh from checkpoint. See the documentation for `read_mesh_from_checkpoint()`')
                 g = f.load_function(mesh, function.name())
                 function.assign(g)
-                # Try to recover metadata
-                if 'time' in f.file.attrs:
-                    metadata['time'] = float(f.file.attrs['time'])
-                if 'initial_time' in f.file.attrs:
-                    metadata['initial_time'] = f.file.attrs['initial_time']
+
+                # Recover timestepping info (numeric float time)
+                ts_history = f.get_timestepping_history(mesh, function.name())
+                metadata['time'] = ts_history.get('time', [None])[0]
+
+                try:
+                    initial_time_iso = f.get_attr("/", "initial_time_iso")
+                    metadata['initial_time'] = datetime.datetime.fromisoformat(initial_time_iso)
+                except (KeyError, AttributeError):
+                    metadata['initial_time'] = None
+
         return metadata
 
 

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -8,7 +8,7 @@ import itertools
 
 
 def is_2d(fs):
-    """Tests wether a function space is 2D or 3D"""
+    """Tests whether a function space is 2D or 3D"""
     return fs.mesh().geometric_dimension() == 2
 
 
@@ -134,7 +134,8 @@ class HDF5Exporter(ExporterBase):
     """
     @PETSc.Log.EventDecorator("thetis.HDF5Exporter.__init__")
     def __init__(self, function_space, outputdir, filename_prefix,
-                 next_export_ix=0, legacy_mode=False, verbose=False):
+                 next_export_ix=0, legacy_mode=False, verbose=False,
+                 include_time=False, initial_time=None):
         """
         Create exporter object for given function.
 
@@ -151,6 +152,8 @@ class HDF5Exporter(ExporterBase):
                                            next_export_ix, verbose)
         self.function_space = function_space
         self.dumb_checkpoint = legacy_mode
+        self.include_time = include_time
+        self.initial_time = initial_time
 
     def gen_filename(self, iexport):
         """
@@ -163,7 +166,7 @@ class HDF5Exporter(ExporterBase):
             filename += '.h5'
         return os.path.join(self.outputdir, filename)
 
-    def export_as_index(self, iexport, function):
+    def export_as_index(self, iexport, function, time=None):
         """
         Export function to disk using the specified export index number
 
@@ -183,10 +186,16 @@ class HDF5Exporter(ExporterBase):
                 mesh = function.function_space().mesh()
                 f.save_mesh(mesh)
                 f.save_function(function)
+                if self.include_time:
+                    if time is None:
+                        raise ValueError("time must be provided when include_time=True")
+                    f.file.attrs['time'] = time
+                    if self.initial_time is not None:
+                        f.file.attrs['initial_time'] = self.initial_time
         self.next_export_ix = iexport + 1
 
     @PETSc.Log.EventDecorator("thetis.HDF5Exporter.export")
-    def export(self, function):
+    def export(self, function, time=None):
         """
         Export function to disk.
 
@@ -194,12 +203,13 @@ class HDF5Exporter(ExporterBase):
 
         :arg function: :class:`Function` to export
         """
-        self.export_as_index(self.next_export_ix, function)
+        self.export_as_index(self.next_export_ix, function, time=time)
 
     @PETSc.Log.EventDecorator("thetis.HDF5Exporter.load")
     def load(self, iexport, function):
         """
-        Loads nodal values from disk and assigns to the given function
+        Loads nodal values from disk and assigns to the given function.
+        Returns a dict of metadata (time, initial_time) if available.
 
         :arg int iexport: export index >= 0
         :arg function: target :class:`Function`
@@ -209,6 +219,7 @@ class HDF5Exporter(ExporterBase):
         filename = self.gen_filename(iexport)
         if self.verbose:
             print_output('loading {:} state from {:}'.format(function.name(), filename))
+        metadata = {}
         if self.dumb_checkpoint:
             with DumbCheckpoint(filename, mode=FILE_READ, comm=function.comm) as f:
                 f.load(function)
@@ -219,6 +230,12 @@ class HDF5Exporter(ExporterBase):
                     raise IOError('When loading fields from hdf5 checkpoint files, you should also read the mesh from checkpoint. See the documentation for `read_mesh_from_checkpoint()`')
                 g = f.load_function(mesh, function.name())
                 function.assign(g)
+                # Try to recover metadata
+                if 'time' in f.file.attrs:
+                    metadata['time'] = float(f.file.attrs['time'])
+                if 'initial_time' in f.file.attrs:
+                    metadata['initial_time'] = f.file.attrs['initial_time']
+        return metadata
 
 
 class ExportManager(object):
@@ -237,10 +254,12 @@ class ExportManager(object):
         e.export()
 
     """
+
     def __init__(self, outputdir, fields_to_export, functions, field_metadata,
                  export_type='vtk', next_export_ix=0, verbose=False,
                  legacy_mode=False,
-                 preproc_funcs={}):
+                 preproc_funcs={},
+                 include_time=False, initial_time=None):
         """
         :arg string outputdir: directory where files are stored
         :arg fields_to_export: list of fields to export
@@ -261,6 +280,8 @@ class ExportManager(object):
         self.field_metadata = field_metadata
         self.verbose = verbose
         self.preproc_callbacks = preproc_funcs
+        self.include_time = include_time
+        self.initial_time = initial_time
         # for each field create an exporter
         self.exporters = OrderedDict()
         for key in fields_to_export:
@@ -289,7 +310,7 @@ class ExportManager(object):
         :kwarg string shortname: override shortname defined in field_metadata
         :kwarg string filename: override filename defined in field_metadata
         :kwarg bool legacy_mode: use legacy `DumbCheckpoint` hdf5 format
-        :kwarg preproc_func: optional funtion that will be called prior to
+        :kwarg preproc_func: optional function that will be called prior to
             exporting. E.g. for computing diagnostic fields.
         """
         if outputdir is None:
@@ -316,14 +337,16 @@ class ExportManager(object):
                 self.exporters[fieldname] = HDF5Exporter(native_space,
                                                          outputdir, filename,
                                                          legacy_mode=legacy_mode,
-                                                         next_export_ix=next_export_ix)
+                                                         next_export_ix=next_export_ix,
+                                                         include_time=self.include_time,
+                                                         initial_time=self.initial_time)
 
     def set_next_export_ix(self, next_export_ix):
         """Set export index to all child exporters"""
         for k in self.exporters:
             self.exporters[k].set_next_export_ix(next_export_ix)
 
-    def export(self):
+    def export(self, time=None):
         """
         Export all designated functions to disk
 
@@ -339,7 +362,10 @@ class ExportManager(object):
                     sys.stdout.flush()
                 if key in self.preproc_callbacks:
                     self.preproc_callbacks[key]()
-                self.exporters[key].export(field)
+                if isinstance(self.exporters[key], HDF5Exporter):
+                    self.exporters[key].export(field, time=time)
+                else:
+                    self.exporters[key].export(field)
         if self.verbose and COMM_WORLD.rank == 0:
             sys.stdout.write('\n')
             sys.stdout.flush()

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -240,7 +240,10 @@ class HDF5Exporter(ExporterBase):
                 mesh = function.function_space().mesh()
                 if not hasattr(mesh, 'sfXC'):
                     raise IOError('When loading fields from hdf5 checkpoint files, you should also read the mesh from checkpoint. See the documentation for `read_mesh_from_checkpoint()`')
-                g = f.load_function(mesh, function.name())
+                try:
+                    g = f.load_function(mesh, function.name(), idx=0)
+                except:
+                    g = f.load_function(mesh, function.name())
                 function.assign(g)
 
                 # Recover timestepping info (numeric float time)

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -242,7 +242,7 @@ class HDF5Exporter(ExporterBase):
                     raise IOError('When loading fields from hdf5 checkpoint files, you should also read the mesh from checkpoint. See the documentation for `read_mesh_from_checkpoint()`')
                 try:
                     g = f.load_function(mesh, function.name(), idx=0)
-                except:
+                except AssertionError:
                     g = f.load_function(mesh, function.name())
                 function.assign(g)
 

--- a/thetis/solver2d.py
+++ b/thetis/solver2d.py
@@ -902,8 +902,13 @@ class FlowSolver2d(FrozenClass):
         self.simulation_time = t
 
         # if initial_time stored in file, update options
-        if 'initial_time_iso' in metadata:
-            self.options.simulation_initial_date = datetime.datetime.fromisoformat(metadata['initial_time_iso'])
+        if 'initial_time_iso' in metadata and metadata['initial_time_iso'] is not None:
+            initial_time = metadata['initial_time_iso']
+            if isinstance(initial_time, str):
+                self.options.simulation_initial_date = datetime.datetime.fromisoformat(initial_time)
+            else:
+                # already a datetime object
+                self.options.simulation_initial_date = initial_time
 
         # for next export
         self.export_initial_state = outputdir != self.options.output_directory


### PR DESCRIPTION
Addresses #416. Automatically adds timestep information to h5 exports when using `FlowSolver2d.options.fields_to_export_hdf5 = ['uv_2d', 'elev_2d']`. 

However, I have used:
`f.save_function(function, idx=float(idx), timestepping_info=ts_info)`

but timestepping_info is really designed for a single file with multiple timesteps. I would propose that we either:
- commit to a single h5 file output with timestepping information
- use `f.set_attr()` instead of saving function with timestepping_info, so that we do not have to pass `idx=0` every time we load it

@stephankramer thoughts on how we approach this sensibly? Because I think one of the above would be better. Once we come to a decision I can update `solver.py` and convert to a full PR.