### PR TITLE
Fix weekly release test badge (release)

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           firedrake-clean
           . venv-thetis/bin/activate
-          python -m pytest -n 12 --verbose --durations=0 thetis-repo/test_adjoint
+          python -m pytest -n 8 --verbose --durations=0 thetis-repo/test_adjoint
 
       - name: Post-cleanup
         if: always()

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   weekly-release:
     name: Weekly release test
-    uses: ./.github/workflows/core.yml
+    uses: thetisproject/thetis/.github/workflows/core.yml@release
     with:
       branch: release
       image: firedrakeproject/firedrake-vanilla-default:latest


### PR DESCRIPTION
At the moment the weekly release test correctly tests on release, but the GitHub actions badge says main. I think this will fix it. I'll just revert if not but I can't test this locally obviously! I think I need to update both branches for this to work but would become consistent anyway.