### PR TITLE
Update PR branch specification

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,6 @@ jobs:
   test:
     uses: ./.github/workflows/core.yml
     with:
-      branch: ${{ github.head_ref }}
+      branch: ${{ github.event.pull_request.head.sha }}
       image: ${{ github.base_ref == 'release' && 'firedrakeproject/firedrake-vanilla-default:latest' || 'firedrakeproject/firedrake-vanilla-default:dev-main' }}
     secrets: inherit


### PR DESCRIPTION
The workflow now checks out the PR using `github.event.pull_request.head.sha`, ensuring that CI always tests the exact commit under review, regardless of whether the PR comes from a fork or the main repository.

This change does not affect push builds and does not alter CI semantics given the existing requirement that PR branches are kept up to date with main or release.

You could also use `github.ref` instead I think (see [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context)):
`github.head_ref`:  "test the branch as it exists in the base repository, which is wrong for forks, and does not test a merge"
`head.sha`: “test what the contributor actually pushed”
`github.ref`: “test what would happen if we merged this PR right now”

Fixes #439.