### PR TITLE
Update DeferredExportManager assertion [release]

### DIFF
--- a/thetis/optimisation.py
+++ b/thetis/optimisation.py
@@ -137,7 +137,7 @@ class DeferredExportManager(object):
                 self.functions = [Function(function.function_space(), name=name) for function, name in zip(functions, suggested_names)]
             self.export_manager = UserExportManager(self.solver_obj_or_outputdir, self.functions, **self.kwargs)
         for function, function_arg in zip(self.functions, functions):
-            assert function.function_space() is function_arg.function_space()
+            assert function.function_space() == function_arg.function_space()
             function.assign(function_arg)
         self.export_manager.export()
 


### PR DESCRIPTION
We have an assertion in optimisation exporting so that the function space for our controls or derivatives etc. remain the same:

`assert function.function_space() is function_arg.function_space()`

which checks object identity. This assertion fails in `examples/tidalfarm.py` when running the optimisation even though the function spaces are "equal". This infers that they are different Python objects. I therefore propose to switching to:

`assert function.function_space() == function_arg.function_space()`

Fixes #435.

