### PR TITLE
Add scheduler to tidalfarm.py

### DIFF
--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -22,27 +22,17 @@ the forward model and automatically derives the adjoint.
 from thetis import *
 from firedrake.adjoint import *
 from checkpoint_schedules import SingleMemoryStorageSchedule
-import logging
 op2.init(log_level=INFO)
 
 # start annotating all Firedrake opterations in the forward model
 continue_annotation()
 
 tape = get_working_tape()
-output_logger.handlers = []
-output_logger.propagate = False
 tape.enable_checkpointing(
     SingleMemoryStorageSchedule(),
     gc_timestep_frequency=56,  # every 56 time steps we will do garbage collection
     gc_generation=2
 )
-# TODO: this is a logging workaround - update when Firedrake #4753 is addressed
-if COMM_WORLD.rank == 0:
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter('%(message)s'))
-    output_logger.addHandler(handler)
-else:
-    output_logger.addHandler(logging.NullHandler())
 
 # setup the Thetis solver obj as usual:
 mesh2d = Mesh('headland.msh')

--- a/examples/tidalfarm/tidalfarm.py
+++ b/examples/tidalfarm/tidalfarm.py
@@ -21,10 +21,28 @@ the forward model and automatically derives the adjoint.
 
 from thetis import *
 from firedrake.adjoint import *
+from checkpoint_schedules import SingleMemoryStorageSchedule
+import logging
 op2.init(log_level=INFO)
 
 # start annotating all Firedrake opterations in the forward model
 continue_annotation()
+
+tape = get_working_tape()
+output_logger.handlers = []
+output_logger.propagate = False
+tape.enable_checkpointing(
+    SingleMemoryStorageSchedule(),
+    gc_timestep_frequency=56,  # every 56 time steps we will do garbage collection
+    gc_generation=2
+)
+# TODO: this is a logging workaround - update when Firedrake #4753 is addressed
+if COMM_WORLD.rank == 0:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    output_logger.addHandler(handler)
+else:
+    output_logger.addHandler(logging.NullHandler())
 
 # setup the Thetis solver obj as usual:
 mesh2d = Mesh('headland.msh')
@@ -131,7 +149,9 @@ solver_obj.add_callback(cb, 'timestep')
 
 # run as normal (this run will be annotated by firedrake adjoint)
 solver_obj.assign_initial_conditions(uv=as_vector((1e-7, 0.0)), elev=tidal_elev)
-solver_obj.iterate(update_forcings=update_forcings)
+num_steps = int(numpy.ceil(solver_obj.options.simulation_end_time / solver_obj.dt))
+adj_timestepper = tape.timestepper(iter(range(num_steps)))
+solver_obj.iterate(update_forcings=update_forcings, adj_timestepper=adj_timestepper)
 
 
 # compute maximum turbine density (based on a minimum of 1.5D between
@@ -164,11 +184,19 @@ c = Control(turbine_density)
 #            farm if multiple are defined)
 callback_list = optimisation.OptimisationCallbackList([
     optimisation.ControlsExportOptimisationCallback(solver_obj),
-    optimisation.DerivativesExportOptimisationCallback(solver_obj),
     optimisation.UserExportOptimisationCallback(solver_obj, (farm_density,)),
     optimisation.FunctionalOptimisationCallback(solver_obj),
     turbines.TurbineOptimisationCallback(solver_obj, cb),
 ])
+derivative_callback_list = optimisation.OptimisationCallbackList([
+    optimisation.DerivativesExportOptimisationCallback(solver_obj),
+])
+
+
+def update_control(value):
+    turbine_density.assign(value)
+    projector.project()
+
 
 # anything that follows, is no longer annotated:
 pause_annotation()
@@ -176,7 +204,13 @@ pause_annotation()
 # this reduces the functional J(u, td) to a function purely of the control td:
 # rf(td) = J(u(td), td) where the velocities u(td) of the entire simulation
 # are computed by replaying the forward model for any provided turbine density td
-rf = ReducedFunctional(scaled_functional, c, derivative_cb_post=callback_list)
+rf = ReducedFunctional(
+    scaled_functional,
+    c,
+    eval_cb_pre=update_control,
+    eval_cb_post=callback_list,
+    derivative_cb_post=derivative_callback_list,
+)
 
 
 if test_gradient:


### PR DESCRIPTION
This PR adds checkpointing for adjoint optimisation in [examples/tidalfarm/tidalfarm.py](https://github.com/thetisproject/thetis/blob/main/examples/tidalfarm/tidalfarm.py).

The Taylor test is made to pass by syncing the live control `Function` before each `ReducedFunctional` replay, but the optimisation diagnostics need to be updated to fix the inversion.

All optimisation callbacks were being run as `derivative_cb_post`. With checkpointing, this is too late for diagnostics that depend on replayed forward values. By the time the adjoint derivative callback runs, checkpointing may already have discarded some saved forward values, so the callback can see `None` or stale zero values.
The fix separates the callbacks by when their data is valid:

```
rf = ReducedFunctional(
    scaled_functional,
    c,
    eval_cb_pre=update_control,
    eval_cb_post=callback_list,
    derivative_cb_post=derivative_callback_list,
)
```

where `update_control` syncs the live control before each replay:

```
def update_control(value):
    turbine_density.assign(value)
    projector.project()
```

`eval_cb_post` now handles functional/turbine/control diagnostics immediately after the forward replay. `derivative_cb_post` now only exports the adjoint derivative.

**For future reference**
Without checkpointing, pyadjoint keeps enough forward state in memory that the adjoint can run directly backwards through the recorded tape.
With checkpointing, pyadjoint deliberately does not keep all forward states. Instead, it stores selected restart states, discards other intermediate values, and later recomputes parts of the forward model when the adjoint needs them. This saves memory, but it means the timing of callbacks matters: some replayed forward values are only reliably available immediately after the replay, not after the later adjoint cleanup.
There is also a control-state subtlety. `ReducedFunctional` updates pyadjoint’s checkpointed value of the control, but the live Firedrake `Function` can still contain the old value. In checkpointed replay, some operations can fall back to that live `Function`. So we explicitly assign the trial control into the live `turbine_density` before each replay.