### PR TITLE
Adding ensemble support in forward runs and inversion

### DIFF
--- a/examples/headland_inversion/Makefile
+++ b/examples/headland_inversion/Makefile
@@ -1,15 +1,38 @@
-all: invert plot
+all: forward plot_obs invert plot
 
-CASE        ?= Uniform # Regions IndependentPointsScheme GradientReg HessianReg
-STATIONS    = stationA stationB stationC stationD stationE stationF stationG
-PARALLEL    = 1
+CASE              	?= GradientReg # Regions IndependentPointsScheme GradientReg HessianReg
+STATIONS          	= stationA stationB stationC stationD stationE stationF stationG
+ENSEMBLE          	?= false
+RANKS_PER_MEMBER  	?= 2
+N_MEMBERS         	?= 7
+PARALLEL          	?= $(shell expr $(N_MEMBERS) \* $(RANKS_PER_MEMBER))
+
+ifeq ($(ENSEMBLE),true)
+PARALLEL          	?= $(shell expr $(N_MEMBERS) \* $(RANKS_PER_MEMBER))
+MPIEXEC				= mpiexec --use-hwthread-cpus -np $(PARALLEL)
+RUN_MODE_FORWARD 	= --ensemble --ranks-per-member $(RANKS_PER_MEMBER)
+RUN_MODE_INVERT  	= --ensemble --ranks-per-member $(RANKS_PER_MEMBER)
+RUN_MODE_PLOT	  	= --ensemble
+else
+PARALLEL          	?= 4
+MPIEXEC          	= mpiexec --use-hwthread-cpus -np $(PARALLEL)
+RUN_MODE_FORWARD 	=
+RUN_MODE_INVERT  	=
+RUN_MODE_PLOT	  	=
+endif
+
+forward:
+	$(MPIEXEC) python forward_run.py $(RUN_MODE_FORWARD)
+
+plot_obs:
+	python plot_observed_elev.py $(RUN_MODE_PLOT)
 
 invert:
-	mpiexec --use-hwthread-cpus -np $(PARALLEL) python inverse_problem.py --case $(CASE) --no-consistency-test --no-taylor-test
+	$(MPIEXEC) python inverse_problem.py $(RUN_MODE_INVERT) --case $(CASE) --no-consistency-test --no-taylor-test
 
 plot:
 	for station in $(STATIONS); do \
-		python3 plot_velocity_progress.py -s $$station --case $(CASE); \
+		python3 plot_velocity_progress.py -s $$station --case $(CASE) $(RUN_MODE_PLOT); \
 	done; \
 
 clean:

--- a/examples/headland_inversion/README.md
+++ b/examples/headland_inversion/README.md
@@ -21,6 +21,61 @@ may be a simple split between areas of the domain or may be based on seabed part
 associated with a set of points. Between points, the value of the friction parameter is interpolated - see 
 [Lu and Zhang, 2006](https://doi.org/10.1016/j.csr.2006.06.007), for example.
 
+## Quick start
+
+This example can now be run in two modes:
+
+- **Regular run**: one forward solve and one inversion using all available stations together.
+- **Ensemble run**: one station per ensemble member, with a forcing phase offset applied to each member. The inversion
+  then combines all members into a single optimisation problem.
+
+Typical regular workflow:
+
+```sh
+source ~/firedrake/bin/activate
+make forward ENSEMBLE=false
+make plot_obs ENSEMBLE=false
+make invert CASE=GradientReg ENSEMBLE=false
+make plot CASE=GradientReg ENSEMBLE=false
+```
+
+Typical ensemble workflow:
+
+```sh
+source ~/firedrake/bin/activate
+make forward ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
+make plot_obs ENSEMBLE=true
+make invert CASE=GradientReg ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
+make plot CASE=GradientReg ENSEMBLE=true
+```
+
+or, to run using the default `Makefile` variable values, simply:
+
+```sh
+make
+```
+
+## Makefile options
+
+The example is driven through the local `Makefile`.
+
+Important variables are:
+
+- `CASE`: inversion parametrisation to use. One of
+  `Uniform`, `Regions`, `IndependentPointsScheme`, `GradientReg`, `HessianReg`.
+- `ENSEMBLE`: `true` or `false`.
+- `RANKS_PER_MEMBER`: MPI ranks per ensemble member in ensemble mode.
+- `N_MEMBERS`: number of ensemble members. At present this should match the number of configured stations, i.e. `7`.
+- `PARALLEL`: total number of MPI ranks used by `mpiexec`.
+
+In ensemble mode the intended layout is:
+
+```text
+PARALLEL = N_MEMBERS * RANKS_PER_MEMBER
+```
+
+In regular mode, `PARALLEL` is simply the total number of MPI ranks used for a single simulation.
+
 ## Forward run
 
 The synthetic data is stored in the time series `.hdf5` files for each station. The forward run is provided so that the
@@ -35,10 +90,34 @@ The idealised headland is 20km long and 6km wide, with a coastline depth of 3m a
 and right boundaries are forced by a sinusoidal elevation function, emulating a single tidal signal. A viscosity sponge 
 is used at the left hand boundary to provide some model stability.
 
+Run the forward model in regular mode with:
+
+In regular mode, all station time series are written into:
+
+```text
+outputs/outputs_forward/
+```
+
+In ensemble mode, one station is written per member into:
+
+```text
+outputs/outputs_forward/member_<k>/
+```
+
+with a forcing time offset of `800 * ensemble_rank` seconds. The current station/member mapping is:
+
+- member 0 -> stationA
+- member 1 -> stationB
+- member 2 -> stationC
+- member 3 -> stationD
+- member 4 -> stationE
+- member 5 -> stationF
+- member 6 -> stationG
+
+
 ## Inversion run
 
-The inversion problem is currently run from a `Makefile`. User arguments are specified here i.e. mapping to use, number
-of threads, and then the Makefile runs the scripts with the inputs provided.
+The inversion problem is run from the `Makefile`. The same `CASE` values can be used in both regular and ensemble modes.
 
 The solver object is set up using `construct_solver` and then initial values for each field (in this case we only 
 optimise for bed friction) are specified. The station manager, `StationObservationManager`, is then instantiated, which 
@@ -71,11 +150,24 @@ functional. These are the minimum and maximum values of bed friction allowed.
 
 The remainder of the script performs file saving and preparation for visualisation in ParaView.
 
+In regular mode, inversion outputs are written into:
+
+```text
+outputs/outputs_inverse/<case_dir>/
+```
+
+In ensemble mode, they are written into:
+
+```text
+outputs/outputs_inverse/<case_dir>/member_<k>/
+```
+
 ### Gradient/Hessian regularisation
 
 ```sh
 source ~/firedrake/bin/activate
-make invert CASE=GradientReg
+make invert CASE=GradientReg ENSEMBLE=false
+make invert CASE=GradientReg ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
 ```
 
 In these cases, the friction values can vary freely within the lower and upper limits defined by the control bounds. 
@@ -95,7 +187,8 @@ and `HessianRecoverer2D`, for calculating this loss can be found in `thetis.diag
 
 ```sh
 source ~/firedrake/bin/activate
-make invert CASE=Uniform
+make invert CASE=Uniform ENSEMBLE=false
+make invert CASE=Uniform ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
 ```
 
 For a uniform bed friction, there are some differences which are enforced by changing the case entry, as explained 
@@ -117,7 +210,8 @@ exporting.
 
 ```sh
 source ~/firedrake/bin/activate
-make invert CASE=Regions
+make invert CASE=Regions ENSEMBLE=false
+make invert CASE=Regions ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
 ```
 
 For region-based bed friction, we need to create a mapping that relates the Manning values to the regions of the mesh. 
@@ -138,7 +232,8 @@ forward, inverse and plotting scripts in order.
 
 ```sh
 source ~/firedrake/bin/activate
-make invert CASE=IndependentPointsScheme
+make invert CASE=IndependentPointsScheme ENSEMBLE=false
+make invert CASE=IndependentPointsScheme ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
 ```
 
 The independent point scheme approach works in the same way as the region-based approach, where we have a mapping 
@@ -155,25 +250,80 @@ would not be true RBF/quadratic/cubic interpolation.
 
 ```sh
 source ~/firedrake/bin/activate
-make plot CASE=GradientReg
-make plot CASE=Uniform
-make plot CASE=Regions
-make plot CASE=IndependentPointsScheme
+make plot_obs ENSEMBLE=false
+make plot_obs ENSEMBLE=true
+make plot CASE=GradientReg ENSEMBLE=false
+make plot CASE=GradientReg ENSEMBLE=true
 ```
 
-To plot the progress, we can use the Makefile to run `plot_velocity_progress.py`. This plots the velocity over time at 
-each of the station locations for each iteration of the optimisation, relative to the ground truth from the forward run.
+`plot_observed_elev.py` scans the selected forward-output directory layout and displays the observed elevation time
+series.
+
+`plot_velocity_progress.py` compares inversion progress against the forward data and saves PNG files named like:
+
+```text
+optimization_progress_<CASE>_<station>_ts.png
+```
 
 ## Running in parallel
 
-The default settings run these scripts in serial, however we can leverage parallel processing to accelerate the 
-simulations by partioning the mesh. To do so, simply provide the number of processors you would like to use after the 
-PARALLEL option, e.g.:
+The scripts can be run in parallel in both regular and ensemble modes.
+
+In regular mode, `PARALLEL` is the total MPI rank count for a single simulation, e.g.:
 
 ```sh
 source ~/firedrake/bin/activate
-make invert CASE=IndependentPointsScheme PARALLEL=4
+make invert CASE=IndependentPointsScheme ENSEMBLE=false PARALLEL=4
+```
+
+In ensemble mode, the intended rank layout is:
+
+```text
+PARALLEL = N_MEMBERS * RANKS_PER_MEMBER
+```
+
+for example:
+
+```sh
+source ~/firedrake/bin/activate
+make invert CASE=IndependentPointsScheme ENSEMBLE=true N_MEMBERS=7 RANKS_PER_MEMBER=2
 ```
 
 Note that if you try to use too many threads, the communication time between processes will dominate the runtime and 
 actually slow things down!
+
+## Running as ensemble
+
+`EnsembleReducedFunctional` can be leveraged to combine multiple inversions into a single optimisation problem. This is
+useful for cases where we have multiple sets of observations that do not coincide in time, but we want to use them all 
+to inform the same control field. 
+
+In this case, the forward model is run with the forcing offset by 800 s in each subsequent ensemble with one station 
+being logged in each case. Observations are therefore taken across different time windows. 
+Each ensemble member in the inversion corresponds to a respective observation window from the forward run.
+
+The recommended way to run the ensemble workflow is through the `Makefile`:
+
+```sh
+make forward ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
+make invert CASE=IndependentPointsScheme ENSEMBLE=true RANKS_PER_MEMBER=2 N_MEMBERS=7
+make plot_obs ENSEMBLE=true
+make plot CASE=IndependentPointsScheme ENSEMBLE=true
+```
+
+The number of cores must correspond to the number of ensemble members times the number of threads allocated to each 
+member (specified by parameter M in forward_run.py). 
+In this case 7 ensemble members are set up for seven stations, with each member splitting its mesh across 2 threads.
+
+If you prefer to run the scripts directly, the equivalent commands are, e.g.:
+
+```sh
+mpiexec -n 14 python forward_run.py --ensemble --ranks-per-member 2
+mpiexec -n 14 python inverse_problem.py --ensemble --ranks-per-member 2 --case IndependentPointsScheme --no-taylor-test
+python plot_observed_elev.py --ensemble
+python plot_velocity_progress.py -s stationA --case IndependentPointsScheme --ensemble
+```
+
+For additional examples of Ensemble usage in firedrake, see
+https://www.firedrakeproject.org/ensemble_parallelism.html
+https://www.firedrakeproject.org/demos/full_waveform_inversion.py.html

--- a/examples/headland_inversion/forward_run.py
+++ b/examples/headland_inversion/forward_run.py
@@ -6,6 +6,7 @@ from model_config import construct_solver
 from shapely.geometry import Point
 from mpi4py import MPI
 import argparse
+import numpy as np
 
 # ---------------------------------------- Step 1: set up mesh and ground truth ----------------------------------------
 parser = argparse.ArgumentParser(
@@ -57,8 +58,8 @@ elev_init_2d = solver_obj.fields.elev_2d
 
 coordinates = mesh2d.coordinates.dat.data[:]
 x, y = coordinates[:, 0], coordinates[:, 1]
-lx = mesh2d.comm.allreduce(numpy.max(x), MPI.MAX)
-ly = mesh2d.comm.allreduce(numpy.max(y), MPI.MAX)
+lx = mesh2d.comm.allreduce(np.max(x), MPI.MAX)
+ly = mesh2d.comm.allreduce(np.max(y), MPI.MAX)
 
 # Create a FunctionSpace on the mesh (corresponds to Manning)
 V = get_functionspace(mesh2d, 'CG', 1)

--- a/examples/headland_inversion/forward_run.py
+++ b/examples/headland_inversion/forward_run.py
@@ -5,16 +5,49 @@ import geopandas as gpd
 from model_config import construct_solver
 from shapely.geometry import Point
 from mpi4py import MPI
+import argparse
 
 # ---------------------------------------- Step 1: set up mesh and ground truth ----------------------------------------
+parser = argparse.ArgumentParser(
+    description='Run the headland forward model in standard or ensemble mode.',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument('--ensemble', action='store_true',
+                    help='Enable ensemble mode with one station/time offset per ensemble member')
+parser.add_argument('--ranks-per-member', type=int, default=2,
+                    help='Number of MPI ranks per ensemble member when --ensemble is used')
+args = parser.parse_args()
 
+ensemble = None
+comm = COMM_WORLD
+ensemble_rank = 0
+ensemble_size = 1
+distribution_parameters = None
 pwd = os.path.abspath(os.path.dirname(__file__))
 output_dir_forward = os.path.join(pwd, 'outputs', 'outputs_forward')
+time_offset = 0.
+station_index = None
+
+if args.ensemble:
+    ensemble = Ensemble(MPI.COMM_WORLD, args.ranks_per_member)
+    comm = ensemble.comm
+    ensemble_rank = ensemble.ensemble_rank
+    ensemble_size = ensemble.ensemble_size
+    distribution_parameters = {'partitioner_type': 'simple'}
+    output_dir_forward = os.path.join(pwd, 'outputs', 'outputs_forward', f'member_{ensemble_rank}')
+    # Each member set up to start its run at a slightly different point along the sinusoidal forcing.
+    time_offset = ensemble_rank * 800.0
+    # Each member then stores observations at its assigned station.
+    station_index = ensemble_rank
 
 solver_obj, update_forcings = construct_solver(
     output_directory=output_dir_forward,
     store_station_time_series=True,
     no_exports=False,
+    comm=comm,
+    distribution_parameters=distribution_parameters,
+    time_offset=time_offset,
+    station_index=station_index,
 )
 
 mesh2d = solver_obj.mesh2d
@@ -24,8 +57,8 @@ elev_init_2d = solver_obj.fields.elev_2d
 
 coordinates = mesh2d.coordinates.dat.data[:]
 x, y = coordinates[:, 0], coordinates[:, 1]
-lx = mesh2d.comm.allreduce(np.max(x), MPI.MAX)
-ly = mesh2d.comm.allreduce(np.max(y), MPI.MAX)
+lx = mesh2d.comm.allreduce(numpy.max(x), MPI.MAX)
+ly = mesh2d.comm.allreduce(numpy.max(y), MPI.MAX)
 
 # Create a FunctionSpace on the mesh (corresponds to Manning)
 V = get_functionspace(mesh2d, 'CG', 1)
@@ -66,10 +99,10 @@ for i, (region_id, group) in enumerate(polygons_by_id):
     mask_values.append(values)
     m_true.append(domain_constant(manning_value, mesh2d))
 
-overlap_counts = np.zeros(len(x))
+overlap_counts = numpy.zeros(len(x))
 
 for values in mask_values:
-    overlap_counts += np.array(values)
+    overlap_counts += numpy.array(values)
 
 for values in mask_values:
     for i in range(len(values)):
@@ -84,8 +117,12 @@ for m_, mask_ in zip(m_true, masks):
     manning_2d += m_ * mask_
 
 # Overwrite the default initial manning value
-VTKFile(os.path.join(output_dir_forward, 'manning_init.pvd')).write(manning_2d)
+VTKFile(os.path.join(output_dir_forward, 'manning_init.pvd'), comm=comm).write(manning_2d)
 
+if comm.rank == 0 and args.ensemble:
+    print(f'Ensemble member {ensemble_rank + 1}/{ensemble_size}: '
+          f'time offset = {time_offset}; '
+          f'detector station index = {station_index}')
 print_output('Exporting to ' + solver_obj.options.output_directory)
 
 print_output('Solving the forward problem...')

--- a/examples/headland_inversion/inverse_problem.py
+++ b/examples/headland_inversion/inverse_problem.py
@@ -27,6 +27,10 @@ parser.add_argument('--no-consistency-test', action='store_true',
                     help='Skip consistency test')
 parser.add_argument('--no-taylor-test', action='store_true',
                     help='Skip Taylor test')
+parser.add_argument('--ensemble', action='store_true',
+                    help='Enable ensemble mode with one station/time offset per ensemble member')
+parser.add_argument('--ranks-per-member', type=int, default=2,
+                    help='Number of MPI ranks per ensemble member when --ensemble is used')
 args = parser.parse_args()
 do_consistency_test = not args.no_consistency_test
 do_taylor_test = not args.no_taylor_test
@@ -44,6 +48,25 @@ selected_case = args.case[0]
 pwd = os.path.abspath(os.path.dirname(__file__))
 output_dir_forward = os.path.join(pwd, 'outputs', 'outputs_forward')
 output_dir_invert = os.path.join(pwd, 'outputs', 'outputs_inverse', case_to_output_dir[selected_case])
+ensemble = None
+comm = COMM_WORLD
+distribution_parameters = None
+time_offset = 0.0
+station_index = None
+ensemble_rank = 0
+ensemble_size = 1
+
+if args.ensemble:
+    ensemble = Ensemble(MPI.COMM_WORLD, args.ranks_per_member)
+    comm = ensemble.comm
+    ensemble_rank = ensemble.ensemble_rank
+    ensemble_size = ensemble.ensemble_size
+    distribution_parameters = {'partitioner_type': 'simple'}
+    time_offset = ensemble_rank * 800.0
+    station_index = ensemble_rank
+    output_dir_forward = os.path.join(pwd, 'outputs', 'outputs_forward', f'member_{ensemble_rank}')
+    output_dir_invert = os.path.join(pwd, 'outputs', 'outputs_inverse', case_to_output_dir[selected_case],
+                                     f'member_{ensemble_rank}')
 
 continue_annotation()
 
@@ -58,6 +81,10 @@ solver_obj, update_forcings = construct_solver(
     output_directory=output_dir_invert,
     store_station_time_series=False,
     no_exports=True,
+    comm=comm,
+    distribution_parameters=distribution_parameters,
+    time_offset=time_offset,
+    station_index=station_index,
 )
 options = solver_obj.options
 mesh2d = solver_obj.mesh2d
@@ -156,6 +183,15 @@ stations = [
 elev_stations = ['stationF', 'stationG']
 vel_stations = ['stationA', 'stationB', 'stationC', 'stationD', 'stationE']
 
+if args.ensemble:
+    if not 0 <= ensemble_rank < len(stations):
+        raise ValueError(f'ensemble_rank {ensemble_rank} out of range for {len(stations)} stations')
+    selected_stations = [stations[ensemble_rank]]
+    if comm.rank == 0:
+        print(f'Ensemble member {ensemble_rank + 1}/{ensemble_size}: time offset = {time_offset}')
+else:
+    selected_stations = stations
+
 # Apply cost function scaling so that dJ/dm ~ O(1)
 if selected_case in ('GradientReg', 'HessianReg'):
     cfs_scalar = 1e2 * solver_obj.dt / options.simulation_end_time
@@ -172,7 +208,7 @@ cfs_scalar_elev = cfs_scalar
 variable = 'uv'
 vel_sta_mgr = inversion_tools.StationObservationManager(mesh2d, output_directory=options.output_directory)
 vel_names, vel_coords, vel_times, vel_u, vel_v = [], [], [], [], []
-for name, (sta_x, sta_y) in [(s, (x, y)) for s, (x, y) in stations if s in vel_stations]:
+for name, (sta_x, sta_y) in [(s, (x, y)) for s, (x, y) in selected_stations if s in vel_stations]:
     file = os.path.join(output_dir_forward, f'diagnostic_timeseries_{name}.hdf5')
     with h5py.File(file) as h5file:
         t = h5file['time'][:].flatten()
@@ -182,19 +218,22 @@ for name, (sta_x, sta_y) in [(s, (x, y)) for s, (x, y) in stations if s in vel_s
         vel_times.append(t)
         vel_u.append(var[:, 1])
         vel_v.append(var[:, 2])
-vel_coords_x, vel_coords_y = numpy.array(vel_coords).T
-vel_sta_mgr.register_observation_data(vel_names, variable, vel_times, vel_coords_x, vel_coords_y,
-                                      data=(vel_u, vel_v), start_times=None, end_times=None)
-# must be assigned before constructing evaluator
-vel_sta_mgr.cost_function_scaling = domain_constant(cfs_scalar_vel, mesh2d)
-vel_sta_mgr.construct_evaluator()
-vel_sta_mgr.set_model_field(solver_obj.fields.uv_2d)
+if vel_names:
+    vel_coords_x, vel_coords_y = numpy.array(vel_coords).T
+    vel_sta_mgr.register_observation_data(vel_names, variable, vel_times, vel_coords_x, vel_coords_y,
+                                          data=(vel_u, vel_v), start_times=None, end_times=None)
+    # must be assigned before constructing evaluator
+    vel_sta_mgr.cost_function_scaling = domain_constant(cfs_scalar_vel, mesh2d)
+    vel_sta_mgr.construct_evaluator()
+    vel_sta_mgr.set_model_field(solver_obj.fields.uv_2d)
+else:
+    vel_sta_mgr = None
 
 # --- Elevation station manager ---
 variable = 'elev'
 elev_sta_mgr = inversion_tools.StationObservationManager(mesh2d, output_directory=options.output_directory)
 elev_names, elev_coords, elev_times, elev_data = [], [], [], []
-for name, (sta_x, sta_y) in [(s, (x, y)) for s, (x, y) in stations if s in elev_stations]:
+for name, (sta_x, sta_y) in [(s, (x, y)) for s, (x, y) in selected_stations if s in elev_stations]:
     file = os.path.join(output_dir_forward, f'diagnostic_timeseries_{name}.hdf5')
     with h5py.File(file) as h5file:
         t = h5file['time'][:].flatten()
@@ -203,18 +242,26 @@ for name, (sta_x, sta_y) in [(s, (x, y)) for s, (x, y) in stations if s in elev_
         elev_coords.append((sta_x, sta_y))
         elev_times.append(t)
         elev_data.append(var[:, 0])
-elev_coords_x, elev_coords_y = numpy.array(elev_coords).T
-elev_sta_mgr.register_observation_data(elev_names, variable, elev_times, elev_coords_x, elev_coords_y,
-                                       data=elev_data, start_times=None, end_times=None)
-elev_sta_mgr.cost_function_scaling = domain_constant(cfs_scalar_elev, mesh2d)
-elev_sta_mgr.construct_evaluator()
-elev_sta_mgr.set_model_field(solver_obj.fields.elev_2d)
+if elev_names:
+    elev_coords_x, elev_coords_y = numpy.array(elev_coords).T
+    elev_sta_mgr.register_observation_data(elev_names, variable, elev_times, elev_coords_x, elev_coords_y,
+                                           data=elev_data, start_times=None, end_times=None)
+    elev_sta_mgr.cost_function_scaling = domain_constant(cfs_scalar_elev, mesh2d)
+    elev_sta_mgr.construct_evaluator()
+    elev_sta_mgr.set_model_field(solver_obj.fields.elev_2d)
+else:
+    elev_sta_mgr = None
+
+manager_dict = {}
+if vel_sta_mgr is not None:
+    manager_dict['velocity'] = vel_sta_mgr
+if elev_sta_mgr is not None:
+    manager_dict['elevation'] = elev_sta_mgr
+if not manager_dict:
+    raise RuntimeError('No observation managers configured for the selected run mode')
 
 # --- Combine into a multi-station manager ---
-sta_manager = inversion_tools.MultiStationObservationManager({
-    'velocity': vel_sta_mgr,
-    'elevation': elev_sta_mgr
-})
+sta_manager = inversion_tools.MultiStationObservationManager(manager_dict)
 
 print_output('Multi-Station Manager set-up complete.')
 
@@ -237,7 +284,7 @@ control_bounds = numpy.array(control_bounds_list).T
 # Create inversion manager and add controls
 inv_manager = inversion_tools.InversionManager(
     sta_manager, output_dir=options.output_directory, no_exports=False, penalty_parameters=gamma_penalty_list,
-    test_consistency=do_consistency_test, test_gradient=do_taylor_test)
+    test_consistency=do_consistency_test, test_gradient=do_taylor_test, ensemble=ensemble)
 
 print_output('Inversion Manager instantiated.')
 
@@ -255,8 +302,8 @@ else:
     manning_2d.assign(0.04)
     inv_manager.add_control(manning_2d)
 
-if not no_exports:
-    VTKFile(os.path.join(output_dir_invert, 'manning_init.pvd')).write(manning_2d)
+if not no_exports and ensemble_rank == 0:
+    VTKFile(os.path.join(output_dir_invert, 'manning_init.pvd'), comm=comm).write(manning_2d)
 
 # Extract the regularized cost function
 if selected_case == 'GradientReg':
@@ -278,7 +325,6 @@ opt_verbose = -1  # scipy diagnostics -1, 0, 1, 99, 100, 101
 opt_options = {
     'maxiter': 10,  # NOTE increase to run iteration longer
     'ftol': 1e-5,
-    'disp': opt_verbose if mesh2d.comm.rank == 0 else -1,
 }
 if os.getenv('THETIS_REGRESSION_TEST') is not None:
     opt_options['maxiter'] = 1
@@ -294,7 +340,7 @@ for oc, cc in zip(control_opt_list, inv_manager.control_coeff_list):
         manning_2d = Function(P1_2d, name='Manning coefficient')
         manning_2d.assign(domain_constant(inv_manager.m_list[-1], mesh2d))
         if not no_exports:
-            VTKFile(os.path.join(options.output_directory, 'manning_optimised.pvd')).write(manning_2d)
+            VTKFile(os.path.join(options.output_directory, 'manning_optimised.pvd'), comm=comm).write(manning_2d)
     elif selected_case == 'Regions' or selected_case == 'IndependentPointsScheme':
         P1_2d = get_functionspace(mesh2d, 'CG', 1)
         manning_2d = Function(P1_2d, name='manning2d')
@@ -302,13 +348,13 @@ for oc, cc in zip(control_opt_list, inv_manager.control_coeff_list):
         for m_, mask_ in zip(inv_manager.m_list, masks):
             manning_2d += m_ * mask_
         if not no_exports:
-            VTKFile(os.path.join(options.output_directory, 'manning_optimised.pvd')).write(manning_2d)
+            VTKFile(os.path.join(options.output_directory, 'manning_optimised.pvd'), comm=comm).write(manning_2d)
     else:
         name = cc.name()
         oc.rename(name)
         print_function_value_range(oc, prefix='Optimal')
         if not no_exports:
-            VTKFile(os.path.join(options.output_directory, f'{name}_optimised.pvd')).write(oc)
+            VTKFile(os.path.join(options.output_directory, f'{name}_optimised.pvd'), comm=comm).write(oc)
 
 if selected_case == 'Regions' or selected_case == 'IndependentPointsScheme':
     print_output("Optimised vector m:\n" + str(

--- a/examples/headland_inversion/model_config.py
+++ b/examples/headland_inversion/model_config.py
@@ -64,18 +64,28 @@ def generate_bathymetry(mesh, H, output_directory, exporting=True):
         solve(F == 0, u, bcs, solver_parameters=solver_parameters)
 
     if exporting:
-        VTKFile(output_directory + "/dist.pvd").write(u)
+        VTKFile(output_directory + "/dist.pvd", comm=mesh.comm).write(u)
 
     bathymetry = Function(V, name="bathymetry")
     bathymetry.project(conditional(ge(u, L), H, (H - 5) * (u / L) + 5.))
     if exporting:
-        VTKFile(output_directory + '/bathymetry.pvd').write(bathymetry)
+        VTKFile(output_directory + '/bathymetry.pvd', comm=mesh.comm).write(bathymetry)
 
     return bathymetry
 
 
 def construct_solver(store_station_time_series=True, **model_options):
-    mesh2d = Mesh('headland.msh')
+    comm = model_options.pop('comm', COMM_WORLD)
+    distribution_parameters = model_options.pop('distribution_parameters', None)
+    # Ensuring that mesh elements are split between MPI processes evenly across ensemble members
+    mesh_kwargs = {}
+    if distribution_parameters is not None:
+        mesh_kwargs = dict(mesh_kwargs)
+        mesh_kwargs['distribution_parameters'] = distribution_parameters
+    mesh2d = Mesh('headland.msh', comm=comm, **mesh_kwargs)
+
+    time_offset = model_options.pop('time_offset', 0.0)
+    station_index = model_options.pop('station_index', None)
     pwd = os.path.abspath(os.path.dirname(__file__))
     output_directory = model_options.get('output_directory', f'{pwd}/outputs_forward')
     exporting = not model_options.get('no_exports', False)
@@ -108,12 +118,12 @@ def construct_solver(store_station_time_series=True, **model_options):
     manning_2d.interpolate(
         conditional(x < 11e3, manning_high, manning_low))
     if exporting:
-        VTKFile(output_directory + '/manning_init.pvd').write(manning_2d)
+        VTKFile(output_directory + '/manning_init.pvd', comm=mesh2d.comm).write(manning_2d)
 
     # viscosity
     h_viscosity = Function(P1_2d).interpolate(conditional(le(x, 1e3), 0.1*(1e3 - x), 1.0))
     if exporting:
-        VTKFile(output_directory + '/h_viscosity.pvd').write(h_viscosity)
+        VTKFile(output_directory + '/h_viscosity.pvd', comm=mesh2d.comm).write(h_viscosity)
 
     # create solver
     solver_obj = solver2d.FlowSolver2d(mesh2d, bathymetry_2d)
@@ -155,7 +165,14 @@ def construct_solver(store_station_time_series=True, **model_options):
             ('stationF', (lx/4, ly/4)),
             ('stationG', (lx/4, 3*ly/4)),
         ]
-        for name, (sta_x, sta_y) in stations:
+        # Divide up stations across the ensemble members
+        if station_index is None:
+            selected_stations = stations
+        else:
+            if not 0 <= station_index < len(stations):
+                raise ValueError(f"station_index {station_index} out of range for {len(stations)} stations")
+            selected_stations = [stations[station_index]]
+        for name, (sta_x, sta_y) in selected_stations:
             cb = DetectorsCallback(solver_obj, [(sta_x, sta_y)], ['elev_2d', 'uv_2d'], name='timeseries_'+name,
                                    detector_names=[name], append_to_log=False)
             solver_obj.add_callback(cb)
@@ -178,9 +195,12 @@ def construct_solver(store_station_time_series=True, **model_options):
     omega = 2 * pi / tidal_period
 
     def update_forcings(t):
-        print_output("Updating tidal elevation at t = {}".format(t))
-        tidal_elev.project(tidal_amplitude * sin(omega * t + omega / pow(g * H, 0.5) * x))
+        # Add in the offset associated with each ensemble member
+        t_model = t + time_offset
+        print_output("Updating tidal elevation at t = {} (offset time = {})".format(t, t_model))
+        tidal_elev.project(tidal_amplitude * sin(omega * t_model + omega / pow(g * H, 0.5) * x))
 
+    update_forcings(0.0)
     # set initial condition for elevation, piecewise linear function
     solver_obj.assign_initial_conditions(uv=as_vector((1e-7, 0.0)), elev=tidal_elev)
 

--- a/examples/headland_inversion/plot_observed_elev.py
+++ b/examples/headland_inversion/plot_observed_elev.py
@@ -1,0 +1,99 @@
+"""Plot stored detector elevation time series from Thetis detector HDF5 files.
+
+By default, scans the selected forward output directories and plots all
+`diagnostic_timeseries_*.hdf5` files it finds.
+
+Usage:
+    python plot_detector_elev.py
+    python plot_detector_elev.py --ensemble
+"""
+
+from __future__ import annotations
+from pathlib import Path
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
+import argparse
+
+parser = argparse.ArgumentParser(
+    description='Run the headland forward model in standard or ensemble mode.',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument('--ensemble', action='store_true',
+                    help='Enable ensemble mode with one station/time offset per ensemble member')
+args = parser.parse_args()
+
+plt.rc('font', size=14)
+
+if args.ensemble:
+    DEFAULT_OUTPUT_GLOB = "outputs/outputs_forward/member_*/diagnostic_timeseries_*.hdf5"
+else:
+    DEFAULT_OUTPUT_GLOB = "outputs/outputs_forward/diagnostic_timeseries_*.hdf5"
+
+
+def find_hdf5_files(base_dir: Path) -> list[Path]:
+    return sorted(base_dir.glob(DEFAULT_OUTPUT_GLOB))
+
+
+def extract_time_and_elevation(h5_path: Path) -> tuple[np.ndarray, np.ndarray]:
+    with h5py.File(h5_path, "r") as h5file:
+        if "time" in h5file:
+            time = np.asarray(h5file["time"], dtype=float)
+            station_keys = [key for key in h5file.keys() if key != "time"]
+            if not station_keys:
+                raise RuntimeError(f"No station datasets found in {h5_path}")
+            station_data = np.asarray(h5file[station_keys[0]], dtype=float)
+            if station_data.ndim != 2 or station_data.shape[1] < 1:
+                raise RuntimeError(f"Unexpected station dataset shape in {h5_path}: {station_data.shape}")
+            elev = station_data[:, 0]
+            return time, elev
+
+        dataset = None
+
+        def visitor(_, obj):
+            nonlocal dataset
+            if dataset is None and isinstance(obj, h5py.Dataset) and obj.ndim >= 2:
+                names = list(obj.dtype.names or [])
+                if "time" in names and "elev_2d" in names:
+                    dataset = obj[()]
+
+        h5file.visititems(visitor)
+
+        if dataset is None:
+            raise RuntimeError(f"Could not find detector time/elevation data in {h5_path}")
+
+        time = np.asarray(dataset["time"], dtype=float)
+        elev = np.asarray(dataset["elev_2d"], dtype=float)
+        return time, elev
+
+
+def station_label(h5_path: Path) -> str:
+    stem = h5_path.stem
+    prefix = "diagnostic_timeseries_"
+    if stem.startswith(prefix):
+        return stem[len(prefix):]
+    return stem
+
+
+def main() -> None:
+    script_dir = Path(__file__).resolve().parent
+    files = find_hdf5_files(script_dir)
+
+    if not files:
+        raise SystemExit("No detector HDF5 files found")
+
+    plt.figure(figsize=(8, 6))
+    for h5_path in files:
+        time, elev = extract_time_and_elevation(h5_path)
+        plt.plot(time, elev, label=station_label(h5_path))
+
+    plt.xlabel("Time (s)")
+    plt.ylabel("Elevation (m)")
+    plt.grid(True)
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/headland_inversion/plot_velocity_progress.py
+++ b/examples/headland_inversion/plot_velocity_progress.py
@@ -20,8 +20,10 @@ parser.add_argument(
     choices=['Uniform', 'Regions', 'IndependentPointsScheme', 'GradientReg', 'HessianReg'],
     default=['IndependentPointsScheme'],
 )
+parser.add_argument('--ensemble', action='store_true',
+                    help='Enable ensemble mode with one station/time offset per ensemble member')
 args = parser.parse_args()
-station_names = sorted(args.station)
+station_names = sorted(str(s) for s in args.station)
 station_str = '-'.join(station_names)
 
 case_to_output_dir = {
@@ -36,10 +38,42 @@ selected_case = args.case[0]
 output_dir_forward = os.path.join('outputs', 'outputs_forward')
 output_dir_invert = os.path.join('outputs', 'outputs_inverse', case_to_output_dir[selected_case])
 
+station_to_member = {
+    'stationA': 0,
+    'stationB': 1,
+    'stationC': 2,
+    'stationD': 3,
+    'stationE': 4,
+    'stationF': 5,
+    'stationG': 6,
+}
+
+
+def resolve_forward_file(station_name):
+    member = station_to_member[station_name]
+    if args.ensemble:
+        member_file = os.path.join(output_dir_forward, f'member_{member}', f'diagnostic_timeseries_{station_name}.hdf5')
+    else:
+        member_file = os.path.join(output_dir_forward, f'diagnostic_timeseries_{station_name}.hdf5')
+    return member_file
+
+
+def resolve_progress_file(station_name, variable_suffix):
+    member = station_to_member[station_name]
+    if args.ensemble:
+        member_file = os.path.join(output_dir_invert, f'member_{member}', f'diagnostic_timeseries_progress_{station_name}_{variable_suffix}.hdf5')
+    else:
+        member_file = os.path.join(output_dir_invert, f'diagnostic_timeseries_progress_{station_name}_{variable_suffix}.hdf5')
+    return member_file
+
+
 # --- Loop through stations ---
 for sta in station_names:
     init = False
-    f = os.path.join(output_dir_forward, f'diagnostic_timeseries_{sta}.hdf5')
+    iter_times = None
+    elev_iter_vals, u_iter_vals, v_iter_vals = None, None, None
+    niter = 0
+    f = resolve_forward_file(sta)
 
     if not os.path.exists(f):
         print(f"Skipping {sta}: forward file not found.")
@@ -68,12 +102,8 @@ for sta in station_names:
             raise ValueError(f"Unrecognized data format for {sta}: shape {var.shape}")
 
     # --- Try to load inverse progress files ---
-    elev_iter_vals, u_iter_vals, v_iter_vals = None, None, None
-    iter_times = None
-    niter = 0
-
-    elev_file = os.path.join(output_dir_invert, f'diagnostic_timeseries_progress_{sta}_elev.hdf5')
-    uv_file = os.path.join(output_dir_invert, f'diagnostic_timeseries_progress_{sta}_uv.hdf5')
+    elev_file = resolve_progress_file(sta, 'elev')
+    uv_file = resolve_progress_file(sta, 'uv')
 
     if os.path.exists(elev_file):
         with h5py.File(elev_file, 'r') as h5file:
@@ -106,9 +136,11 @@ for sta in station_names:
     # --- Plot elevation ---
     if plot_elev:
         init = True
+        assert elev_iter_vals is not None
+        elev_series = elev_iter_vals
         a = ax[panel_idx]
         a.plot(time, elev_vals, 'k:', lw=1.3, label='observation', zorder=3)
-        for j, eta in enumerate(elev_iter_vals):
+        for j, eta in enumerate(elev_series):
             a.plot(iter_times, eta, lw=0.5, label=f'iteration {j}')
         a.set_ylabel('Elevation (m)')
         a.set_title(f'{sta} (elevation)', size='small')
@@ -118,15 +150,18 @@ for sta in station_names:
 
     # --- Plot velocity ---
     if plot_uv:
+        assert u_iter_vals is not None and v_iter_vals is not None
+        u_series = u_iter_vals
+        v_series = v_iter_vals
         a_u = ax[panel_idx]
         a_v = ax[panel_idx + 1]
 
         a_u.plot(time, u_vals, 'k:', lw=1.3, label='observation', zorder=3)
         a_v.plot(time, v_vals, 'k:', lw=1.3, label='observation', zorder=3)
 
-        for j, u in enumerate(u_iter_vals):
+        for j, u in enumerate(u_series):
             a_u.plot(iter_times, u, lw=0.5, label=f'iteration {j}' if not init else None)
-        for j, v in enumerate(v_iter_vals):
+        for j, v in enumerate(v_series):
             a_v.plot(iter_times, v, lw=0.5)
 
         a_u.set_ylabel('u (m/s)')

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -39,15 +39,16 @@ class ExporterBase(object):
     """
     Base class for exporter objects.
     """
-    def __init__(self, filename, outputdir, next_export_ix=0, verbose=False):
+    def __init__(self, filename, outputdir, next_export_ix=0, verbose=False, comm=COMM_WORLD):
         """
         :arg string filename: output file name (without directory)
         :arg string outputdir: directory where file is stored
         :kwarg int next_export_ix: set the index for next output
         :kwarg bool verbose: print debug info to stdout
+        :kwarg comm: communicator used to create the output directory
         """
         self.filename = filename
-        self.outputdir = create_directory(outputdir)
+        self.outputdir = create_directory(outputdir, comm=comm)
         self.verbose = verbose
         # keeps track of export numbers
         self.next_export_ix = next_export_ix
@@ -68,19 +69,8 @@ class VTKExporter(ExporterBase):
     @PETSc.Log.EventDecorator("thetis.VTKExporter.__init__")
     def __init__(self, fs_visu, func_name, outputdir, filename,
                  next_export_ix=0, project_output=False, verbose=False):
-        """
-        :arg fs_visu: function space where input function will be cast
-            before exporting
-        :arg func_name: name of the function
-        :arg outputdir: output directory
-        :arg filename: name of the pvd file
-        :kwarg int next_export_ix: index for next export (default 0)
-        :kwarg bool project_output: project function to output space instead of
-            interpolating
-        :kwarg bool verbose: print debug info to stdout
-        """
-        super(VTKExporter, self).__init__(filename, outputdir, next_export_ix,
-                                          verbose)
+        self.comm = fs_visu.mesh().comm
+        ExporterBase.__init__(self, filename, outputdir, next_export_ix, verbose, comm=self.comm)
         self.fs_visu = fs_visu
         self.func_name = func_name
         self.project_output = project_output
@@ -90,7 +80,7 @@ class VTKExporter(ExporterBase):
         if (len(filename) < len(suffix)+1 or filename[:len(suffix)] != suffix):
             self.filename += suffix
         path = os.path.join(path, self.filename)
-        self.outfile = VTKFile(path)
+        self.outfile = VTKFile(path, comm=self.comm)
         self.cast_operators = {}
 
     def set_next_export_ix(self, next_export_ix):
@@ -128,20 +118,8 @@ class HDF5Exporter(ExporterBase):
     def __init__(self, function_space, outputdir, filename_prefix,
                  next_export_ix=0, legacy_mode=False, verbose=False,
                  include_time=False, initial_time=None):
-        """
-        Create exporter object for given function.
-
-        :arg function_space: space where the exported functions belong
-        :type function_space: :class:`FunctionSpace`
-        :arg string outputdir: directory where outputs will be stored
-        :arg string filename_prefix: prefix of output filename. Filename is
-            prefix_nnnnn.h5 where nnnnn is the export number.
-        :kwarg int next_export_ix: index for next export (default 0)
-        :kwarg bool legacy_mode: use legacy DumbCheckpoint format
-        :kwarg bool verbose: print debug info to stdout
-        """
-        super(HDF5Exporter, self).__init__(filename_prefix, outputdir,
-                                           next_export_ix, verbose)
+        mesh_comm = function_space.mesh().comm
+        ExporterBase.__init__(self, filename_prefix, outputdir, next_export_ix, verbose, comm=mesh_comm)
         self.function_space = function_space
         self.dumb_checkpoint = legacy_mode
         self.include_time = include_time
@@ -174,7 +152,7 @@ class HDF5Exporter(ExporterBase):
             with DumbCheckpoint(filename, mode=FILE_CREATE, comm=function.comm) as f:
                 f.store(function)
         else:
-            with CheckpointFile(filename, 'w') as f:
+            with CheckpointFile(filename, 'w', comm=function.function_space().mesh().comm) as f:
                 mesh = function.function_space().mesh()
                 f.save_mesh(mesh)
 
@@ -381,6 +359,9 @@ class ExportManager(object):
 
         :arg bathymetry_2d: 2D bathymetry :class:`Function`
         """
-        bathfile = VTKFile(os.path.join(self.outputdir, 'init_bathymetry_2d/init_bathymetry_2d.pvd'))
+        bathfile = VTKFile(
+            os.path.join(self.outputdir, 'init_bathymetry_2d/init_bathymetry_2d.pvd'),
+            comm=bathymetry_2d.function_space().mesh().comm,
+        )
 
         bathfile.write(bathymetry_2d)

--- a/thetis/exporter.py
+++ b/thetis/exporter.py
@@ -69,8 +69,19 @@ class VTKExporter(ExporterBase):
     @PETSc.Log.EventDecorator("thetis.VTKExporter.__init__")
     def __init__(self, fs_visu, func_name, outputdir, filename,
                  next_export_ix=0, project_output=False, verbose=False):
-        self.comm = fs_visu.mesh().comm
-        ExporterBase.__init__(self, filename, outputdir, next_export_ix, verbose, comm=self.comm)
+        """
+        :arg fs_visu: function space where input function will be cast
+            before exporting
+        :arg func_name: name of the function
+        :arg outputdir: output directory
+        :arg filename: name of the pvd file
+        :kwarg int next_export_ix: index for next export (default 0)
+        :kwarg bool project_output: project function to output space instead of
+            interpolating
+        :kwarg bool verbose: print debug info to stdout
+        """
+        super(VTKExporter, self).__init__(filename, outputdir, next_export_ix,
+                                          verbose)
         self.fs_visu = fs_visu
         self.func_name = func_name
         self.project_output = project_output
@@ -80,7 +91,7 @@ class VTKExporter(ExporterBase):
         if (len(filename) < len(suffix)+1 or filename[:len(suffix)] != suffix):
             self.filename += suffix
         path = os.path.join(path, self.filename)
-        self.outfile = VTKFile(path, comm=self.comm)
+        self.outfile = VTKFile(path, comm=fs_visu.comm)
         self.cast_operators = {}
 
     def set_next_export_ix(self, next_export_ix):
@@ -118,8 +129,20 @@ class HDF5Exporter(ExporterBase):
     def __init__(self, function_space, outputdir, filename_prefix,
                  next_export_ix=0, legacy_mode=False, verbose=False,
                  include_time=False, initial_time=None):
-        mesh_comm = function_space.mesh().comm
-        ExporterBase.__init__(self, filename_prefix, outputdir, next_export_ix, verbose, comm=mesh_comm)
+        """
+        Create exporter object for given function.
+
+        :arg function_space: space where the exported functions belong
+        :type function_space: :class:`FunctionSpace`
+        :arg string outputdir: directory where outputs will be stored
+        :arg string filename_prefix: prefix of output filename. Filename is
+            prefix_nnnnn.h5 where nnnnn is the export number.
+        :kwarg int next_export_ix: index for next export (default 0)
+        :kwarg bool legacy_mode: use legacy DumbCheckpoint format
+        :kwarg bool verbose: print debug info to stdout
+        """
+        super(HDF5Exporter, self).__init__(filename_prefix, outputdir,
+                                           next_export_ix, verbose)
         self.function_space = function_space
         self.dumb_checkpoint = legacy_mode
         self.include_time = include_time
@@ -152,7 +175,7 @@ class HDF5Exporter(ExporterBase):
             with DumbCheckpoint(filename, mode=FILE_CREATE, comm=function.comm) as f:
                 f.store(function)
         else:
-            with CheckpointFile(filename, 'w', comm=function.function_space().mesh().comm) as f:
+            with CheckpointFile(filename, 'w', comm=function.comm) as f:
                 mesh = function.function_space().mesh()
                 f.save_mesh(mesh)
 
@@ -360,8 +383,6 @@ class ExportManager(object):
         :arg bathymetry_2d: 2D bathymetry :class:`Function`
         """
         bathfile = VTKFile(
-            os.path.join(self.outputdir, 'init_bathymetry_2d/init_bathymetry_2d.pvd'),
-            comm=bathymetry_2d.function_space().mesh().comm,
-        )
+            os.path.join(self.outputdir, 'init_bathymetry_2d/init_bathymetry_2d.pvd'), comm=bathymetry_2d.comm)
 
         bathfile.write(bathymetry_2d)

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -612,7 +612,6 @@ class InversionManager(FrozenHasTraits):
         """
         print_output("Running consistency test")
         J = self.reduced_functional(self.control_coeff_list)
-        self._update_objective_from_evaluation(J)
         if not numpy.isclose(J, self.J):
             raise ValueError(f"Consistency test failed (expected {self.J}, got {J})")
         print_output("Consistency test passed!")
@@ -628,10 +627,7 @@ class InversionManager(FrozenHasTraits):
         for f in self.control_coeff_list:
             dc = f.copy(deepcopy=True)
             func_list.append(dc)
-        if self.ensemble:
-            minconv = taylor_test(self.reduced_functional.local_reduced_functional, self.control_coeff_list, func_list)
-        else:
-            minconv = taylor_test(self.reduced_functional, self.control_coeff_list, func_list)
+        minconv = taylor_test(self.reduced_functional, self.control_coeff_list, func_list)
         if minconv < 1.9:
             raise ValueError("Taylor test failed")  # NOTE: Pyadjoint already prints the testing
         print_output("Taylor test passed!")

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -91,10 +91,10 @@ class ControlManager:
         # Initialize exporters if needed
         if not no_exports:
             fs = self.projection_space if not self.is_field else self.controls[0].function_space()
-            self.vtk_file = fd.VTKFile(f"{output_dir}/control_progress_{index:02d}.pvd", comm=fs.mesh().comm)
+            self.vtk_file = fd.VTKFile(f"{output_dir}/control_progress_{index:02d}.pvd", comm=fs.comm)
             prefix = f"control_{index:02d}"
             self.hdf5_exporter = HDF5Exporter(fs, output_dir + "/hdf5", prefix)
-            self.gradient_vtk_file = fd.VTKFile(f"{output_dir}/gradient_progress_{index:02d}.pvd", comm=fs.mesh().comm)
+            self.gradient_vtk_file = fd.VTKFile(f"{output_dir}/gradient_progress_{index:02d}.pvd", comm=fs.comm)
 
     def project_control(self, updated_controls):
         """Project masked combination or domain_constant to CG1 field for export."""
@@ -171,7 +171,7 @@ class InversionManager(FrozenHasTraits):
             which the :class:`ReducedFunctional` can recompute values
         :kwarg test_gradient: toggle testing the correctness with
             which the :class:`ReducedFunctional` can recompute gradients
-        :kwarg ensemble: an ensemble object
+        :kwarg ensemble: an :class: 'Ensemble' object to enable ensemble parallelism
         """
         assert isinstance(sta_manager, StationObservationManagerBase)
         self.sta_manager = sta_manager
@@ -209,7 +209,7 @@ class InversionManager(FrozenHasTraits):
         if not self.no_exports:
             if self.real:
                 raise ValueError("Exports are not supported in Real mode.")
-            comm = self.control_coeff_list[0].function_space().mesh().comm
+            comm = self.control_coeff_list[0].comm
             create_directory(self.output_dir, comm=comm)
             create_directory(self.output_dir + '/hdf5', comm=comm)
         self.initialized = True
@@ -598,6 +598,8 @@ class InversionManager(FrozenHasTraits):
             self.sta_manager.dump_time_series()
         objective = self.reduced_functional
         if self.ensemble is not None:
+            # as EnsembleReducedFunctional is a custom object implemented in firedrake/adjoint instead of being native
+            # to pyadjoint, it must be converted to the ReducedFunctionalNumPy pyadjoint object
             objective = ReducedFunctionalNumPy(self.reduced_functional)
         try:
             return minimize(

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -296,7 +296,7 @@ class InversionManager(FrozenHasTraits):
         """Update objective bookkeeping consistently in serial and ensemble modes."""
         self.J_reg = self._reduce_scalar(self.J_reg_local)
         self.J_misfit = self._reduce_scalar(self.J_misfit_local)
-        self.J = float(j) if j is not None else self.J_reg + self.J_misfit
+        self.J = self._reduce_scalar(self.J_local)
 
     def start_clock(self):
         self.tic = time_mod.perf_counter()
@@ -528,11 +528,10 @@ class InversionManager(FrozenHasTraits):
         Create a Pyadjoint :class:`ReducedFunctional` for the optimization.
         """
         if self.Jhat is None:
-            rf_cls = EnsembleReducedFunctional if self.ensemble is not None else ReducedFunctional
-            rf_args = [self.J, self.control_list]
             if self.ensemble is not None:
-                rf_args.append(self.ensemble)
-            self.Jhat = rf_cls(*rf_args, **self.rf_kwargs)
+                self.Jhat = EnsembleReducedFunctional(self.J, self.control_list, self.ensemble, **self.rf_kwargs)
+            else:
+                self.Jhat = ReducedFunctional(self.J, self.control_list, **self.rf_kwargs)
         return self.Jhat
 
     @property
@@ -584,7 +583,7 @@ class InversionManager(FrozenHasTraits):
         self.start_clock()
         J = self.reduced_functional(self.control_coeff_list)
         self._update_objective_from_evaluation(J)
-        self.set_initial_state(self.J if self.ensemble is not None else J,
+        self.set_initial_state(self.J,
                                self.reduced_functional.derivative(apply_riesz=True), self.control_coeff_list)
         if self.is_export_root:
             self.sta_manager.collect_time_series(self.i)

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -14,6 +14,7 @@ import h5py
 from scipy.interpolate import interp1d
 import time as time_mod
 from pyadjoint.optimization.optimization import SciPyConvergenceError
+from pyadjoint.reduced_functional_numpy import ReducedFunctionalNumPy
 import os
 from mpi4py import MPI
 
@@ -90,10 +91,10 @@ class ControlManager:
         # Initialize exporters if needed
         if not no_exports:
             fs = self.projection_space if not self.is_field else self.controls[0].function_space()
-            self.vtk_file = fd.VTKFile(f"{output_dir}/control_progress_{index:02d}.pvd")
+            self.vtk_file = fd.VTKFile(f"{output_dir}/control_progress_{index:02d}.pvd", comm=fs.mesh().comm)
             prefix = f"control_{index:02d}"
             self.hdf5_exporter = HDF5Exporter(fs, output_dir + "/hdf5", prefix)
-            self.gradient_vtk_file = fd.VTKFile(f"{output_dir}/gradient_progress_{index:02d}.pvd")
+            self.gradient_vtk_file = fd.VTKFile(f"{output_dir}/gradient_progress_{index:02d}.pvd", comm=fs.mesh().comm)
 
     def project_control(self, updated_controls):
         """Project masked combination or domain_constant to CG1 field for export."""
@@ -158,7 +159,7 @@ class InversionManager(FrozenHasTraits):
 
     @unfrozen
     def __init__(self, sta_manager, output_dir='outputs', no_exports=False, real=False,
-                 penalty_parameters=[], test_consistency=True, test_gradient=True):
+                 penalty_parameters=[], test_consistency=True, test_gradient=True, ensemble=None):
         """
         :arg sta_manager: the :class:`StationObservationManagerBase` instance
         :kwarg output_dir: model output directory
@@ -170,6 +171,7 @@ class InversionManager(FrozenHasTraits):
             which the :class:`ReducedFunctional` can recompute values
         :kwarg test_gradient: toggle testing the correctness with
             which the :class:`ReducedFunctional` can recompute gradients
+        :kwarg ensemble: an ensemble object
         """
         assert isinstance(sta_manager, StationObservationManagerBase)
         self.sta_manager = sta_manager
@@ -180,6 +182,7 @@ class InversionManager(FrozenHasTraits):
         self.penalty_parameters = penalty_parameters
         self.test_consistency = test_consistency
         self.test_gradient = test_gradient
+        self.ensemble = ensemble
         self._controls_wrapped = []
         self.control_managers = []
         self.initialized = False
@@ -187,6 +190,9 @@ class InversionManager(FrozenHasTraits):
         self.J = 0  # cost function value (float)
         self.J_reg = 0  # regularization term value (float)
         self.J_misfit = 0  # misfit term value (float)
+        self.J_local = 0  # local cost function value before ensemble reduction
+        self.J_reg_local = 0  # local regularization term value before ensemble reduction
+        self.J_misfit_local = 0  # local misfit term value before ensemble reduction
         self.dJdm_list = None  # cost function gradient (Function)
         self.m_list = None  # control (Function)
         self.Jhat = None
@@ -203,8 +209,9 @@ class InversionManager(FrozenHasTraits):
         if not self.no_exports:
             if self.real:
                 raise ValueError("Exports are not supported in Real mode.")
-            create_directory(self.output_dir)
-            create_directory(self.output_dir + '/hdf5')
+            comm = self.control_coeff_list[0].function_space().mesh().comm
+            create_directory(self.output_dir, comm=comm)
+            create_directory(self.output_dir + '/hdf5', comm=comm)
         self.initialized = True
 
     def add_control(self, controls, mappings=None):
@@ -279,6 +286,18 @@ class InversionManager(FrozenHasTraits):
         self.dJdm_list = djdm_list
         self.m_list = m_list
 
+    def _reduce_scalar(self, value):
+        """Reduce a scalar over the ensemble communicator if present."""
+        if self.ensemble is None:
+            return float(value)
+        return self.ensemble.ensemble_comm.allreduce(float(value), op=MPI.SUM)
+
+    def _update_objective_from_evaluation(self, j):
+        """Update objective bookkeeping consistently in serial and ensemble modes."""
+        self.J_reg = self._reduce_scalar(self.J_reg_local)
+        self.J_misfit = self._reduce_scalar(self.J_misfit_local)
+        self.J = float(j) if j is not None else self.J_reg + self.J_misfit
+
     def start_clock(self):
         self.tic = time_mod.perf_counter()
 
@@ -317,7 +336,7 @@ class InversionManager(FrozenHasTraits):
         self.J_misfit_progress.append(self.J_misfit)
         self.dJdm_progress.append(djdm)
         comm = self.dJdm_list[0].comm
-        if comm.rank == 0 and not self.no_exports:
+        if comm.rank == 0 and self.is_export_root:
             if self.real:
                 numpy.save(f'{self.output_dir}/m_progress', self.m_progress)
             numpy.save(f'{self.output_dir}/J_progress', self.J_progress)
@@ -332,7 +351,7 @@ class InversionManager(FrozenHasTraits):
                      f'J={self.J:.3e}, dJdm={djdm}, '
                      f'grad_ev={self.nb_grad_evals}, duration {elapsed}')
 
-        if not self.no_exports:
+        if self.is_export_root:
             ref_index = 0
             for cm in self.control_managers:
                 num_controls = len(cm.mappings) if cm.mappings is not None else 1
@@ -354,18 +373,20 @@ class InversionManager(FrozenHasTraits):
 
         def functional_eval_cb(j, m):
             """Called after functional evaluation"""
-            self.J = float(j)
+            self.J_local = float(j)
             # collect additional data we want before it is discarded if we have garbage collection
             tape = get_working_tape()
             reg_blocks = tape.get_blocks(tag="reg_eval")
-            self.J_reg = sum([b.get_outputs()[0].saved_output for b in reg_blocks])
+            self.J_reg_local = sum([b.get_outputs()[0].saved_output for b in reg_blocks])
             misfit_blocks = tape.get_blocks(tag="misfit_eval")
-            self.J_misfit = sum([b.get_outputs()[0].saved_output for b in misfit_blocks])
+            self.J_misfit_local = sum([b.get_outputs()[0].saved_output for b in misfit_blocks])
+            self._update_objective_from_evaluation(j)
             self.sta_manager.collect_time_series(self.i)
             return j
 
         def gradient_eval_cb(j, djdm, m):
             """Called after gradient evaluation"""
+            self._update_objective_from_evaluation(j)
             self.set_control_state(self.J, djdm, m)  # must be self.J as j is reset by garbage collection
             self.nb_grad_evals += 1
             return djdm
@@ -507,8 +528,28 @@ class InversionManager(FrozenHasTraits):
         Create a Pyadjoint :class:`ReducedFunctional` for the optimization.
         """
         if self.Jhat is None:
-            self.Jhat = ReducedFunctional(self.J, self.control_list, **self.rf_kwargs)
+            rf_cls = EnsembleReducedFunctional if self.ensemble is not None else ReducedFunctional
+            rf_args = [self.J, self.control_list]
+            if self.ensemble is not None:
+                rf_args.append(self.ensemble)
+            self.Jhat = rf_cls(*rf_args, **self.rf_kwargs)
         return self.Jhat
+
+    @property
+    def is_export_root(self):
+        """Return True on the rank responsible for shared optimization exports."""
+        if self.no_exports:
+            return False
+        if self.ensemble is None:
+            return True
+        return self.ensemble.ensemble_rank == 0
+
+    @property
+    def is_station_export_root(self):
+        """Return True on ranks that should write station time-series outputs."""
+        if self.no_exports:
+            return False
+        return True
 
     def stop_annotating(self):
         """
@@ -532,7 +573,7 @@ class InversionManager(FrozenHasTraits):
 
         def optimization_callback(m):
             self.update_progress()
-            if not self.no_exports:
+            if self.is_station_export_root:
                 self.sta_manager.dump_time_series()
 
         return optimization_callback
@@ -548,14 +589,19 @@ class InversionManager(FrozenHasTraits):
         print_output(f'Running {opt_method} optimization')
         self.reset_counters()
         self.start_clock()
-        J = float(self.reduced_functional(self.control_coeff_list))
-        self.set_initial_state(J, self.reduced_functional.derivative(apply_riesz=True), self.control_coeff_list)
-        if not self.no_exports:
+        J = self.reduced_functional(self.control_coeff_list)
+        self._update_objective_from_evaluation(J)
+        self.set_initial_state(self.J if self.ensemble is not None else J,
+                               self.reduced_functional.derivative(apply_riesz=True), self.control_coeff_list)
+        if self.is_export_root:
             self.sta_manager.collect_time_series(self.i)
             self.sta_manager.dump_time_series()
+        objective = self.reduced_functional
+        if self.ensemble is not None:
+            objective = ReducedFunctionalNumPy(self.reduced_functional)
         try:
             return minimize(
-                self.reduced_functional, method=opt_method, bounds=bounds,
+                objective, method=opt_method, bounds=bounds,
                 callback=self.get_optimization_callback(), options=opt_options)
         except SciPyConvergenceError as e:
             if "TOTAL NO. OF ITERATIONS REACHED LIMIT" in str(e):
@@ -572,6 +618,7 @@ class InversionManager(FrozenHasTraits):
         """
         print_output("Running consistency test")
         J = self.reduced_functional(self.control_coeff_list)
+        self._update_objective_from_evaluation(J)
         if not numpy.isclose(J, self.J):
             raise ValueError(f"Consistency test failed (expected {self.J}, got {J})")
         print_output("Consistency test passed!")
@@ -587,7 +634,10 @@ class InversionManager(FrozenHasTraits):
         for f in self.control_coeff_list:
             dc = f.copy(deepcopy=True)
             func_list.append(dc)
-        minconv = taylor_test(self.reduced_functional, self.control_coeff_list, func_list)
+        if self.ensemble:
+            minconv = taylor_test(self.reduced_functional.local_reduced_functional, self.control_coeff_list, func_list)
+        else:
+            minconv = taylor_test(self.reduced_functional, self.control_coeff_list, func_list)
         if minconv < 1.9:
             raise ValueError("Taylor test failed")  # NOTE: Pyadjoint already prints the testing
         print_output("Taylor test passed!")
@@ -958,7 +1008,7 @@ class StationObservationManager(StationObservationManagerBase):
             "the functional post-evaluation callback)."
         )
 
-        create_directory(self.output_directory)
+        create_directory(self.output_directory, comm=self.mesh.comm)
 
         var = self.variable
 

--- a/thetis/inversion_tools.py
+++ b/thetis/inversion_tools.py
@@ -544,13 +544,6 @@ class InversionManager(FrozenHasTraits):
             return True
         return self.ensemble.ensemble_rank == 0
 
-    @property
-    def is_station_export_root(self):
-        """Return True on ranks that should write station time-series outputs."""
-        if self.no_exports:
-            return False
-        return True
-
     def stop_annotating(self):
         """
         Stop recording operations for the adjoint solver.
@@ -573,7 +566,7 @@ class InversionManager(FrozenHasTraits):
 
         def optimization_callback(m):
             self.update_progress()
-            if self.is_station_export_root:
+            if not self.no_exports:
                 self.sta_manager.dump_time_series()
 
         return optimization_callback


### PR DESCRIPTION
This PR adds ensemble support to Thetis for both forward simulations and adjoint-based optimisation. At the library level, `thetis/exporter.py` now supports HDF5 and VTK exporting in ensembles, and `thetis/inversion_tools.py` now supports ensemble-aware reduced functionals. The `headland_inversion` example has been updated to demonstrate ensemble usage in both forward runs and inversion.

#### Changes
- Added `comm=` arguments to I/O-related functions creating output directories or writing files
- Made `thetis/inversion_tools.py` ensemble-aware and added support for `EnsembleReducedFunctional` to handle cost function evaluation across multiple ensemble members
- Added ensemble functionality to `forward_run.py` and `inverse_problem.py` in the `headland_inversion` example
- Updated related plotting scripts and `README` in `headland_inversion` to accommodate ensemble workflow and document usage

#### Why work with ensembles?
- Ensemble forward runs allow for running Thetis models with multiple permutations of input parameters in parallel, improving efficiency when problem no longer benefits from spatial parallelism
- Ensemble-based adjoint optimisation allows for optimising an input field across a number of Thetis model instances that may have different input parameters otherwise. E.g., fitting a Manning field to minimise model discrepancies across multiple observation windows